### PR TITLE
Phase 7: Launch prep — examples, docs, version fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ cd transport/wing && govulncheck ./...
 
 Kruda core has minimal external dependencies (Sonic JSON, fasthttp). Use `kruda_stdjson` build tag to switch to stdlib JSON. Upgrade to the latest Go patch release for security fixes.
 
-**Minimum Go version for zero stdlib vulnerabilities:** go1.25.7+
+**Minimum Go version for zero stdlib vulnerabilities:** go1.25.8+
 
 ## Contributing
 

--- a/docs/github-discussion-welcome.md
+++ b/docs/github-discussion-welcome.md
@@ -1,0 +1,50 @@
+# 👋 Welcome to Kruda Discussions!
+
+สวัสดีครับ/ค่ะ! Welcome to the Kruda community.
+
+This is the place to ask questions, share ideas, and show off what you've built with Kruda.
+
+## Getting Started
+
+- 📖 [README](https://github.com/go-kruda/kruda#readme) — Quick Start, features, benchmarks
+- 📂 [Examples](https://github.com/go-kruda/kruda/tree/main/examples) — 21 copy-paste-able examples (hello, typed-handlers, auto-crud, middleware, DI, and more)
+- 🤝 [Contributing Guide](https://github.com/go-kruda/kruda/blob/main/CONTRIBUTING.md) — Dev setup, code style, PR process
+- 📦 [pkg.go.dev](https://pkg.go.dev/github.com/go-kruda/kruda) — API reference
+- 📋 [CHANGELOG](https://github.com/go-kruda/kruda/blob/main/CHANGELOG.md) — Release history
+
+## Discussion Categories
+
+| Category | Use for |
+|----------|---------|
+| 💬 General | Anything Kruda-related |
+| ❓ Help | Questions, troubleshooting, "how do I..." |
+| 💡 Ideas | Feature requests, API design suggestions |
+| 🙌 Show & Tell | Share your projects, benchmarks, blog posts |
+
+## Quick Install
+
+```bash
+go get github.com/go-kruda/kruda
+```
+
+```go
+package main
+
+import "github.com/go-kruda/kruda"
+
+func main() {
+    app := kruda.New()
+    app.Get("/", func(c *kruda.Ctx) error {
+        return c.Text("Hello, Kruda!")
+    })
+    app.Listen(":3000")
+}
+```
+
+## Tips
+
+- AI tools (Claude, Cursor, etc.) can convert your existing Gin/Fiber/Echo code to Kruda — just paste and ask "Convert this to Kruda"
+- Check the [concept mapping table](https://github.com/go-kruda/kruda#coming-from-another-framework) in the README if you're coming from another framework
+- All examples work with `go run .` — no extra setup needed
+
+Happy coding! 🚀

--- a/docs/guide/coming-from-stdlib.md
+++ b/docs/guide/coming-from-stdlib.md
@@ -1,0 +1,223 @@
+# Coming from stdlib (net/http)
+
+If you've been writing Go web services with `net/http` and `http.ServeMux`, Kruda will feel familiar — it builds on the same patterns but removes the boilerplate.
+
+## Quick Comparison
+
+| Concept | stdlib | Kruda |
+|---------|--------|-------|
+| Create server | `http.NewServeMux()` | `kruda.New()` |
+| Route | `mux.HandleFunc("GET /path", h)` | `app.Get("/path", h)` |
+| Handler sig | `func(w http.ResponseWriter, r *http.Request)` | `func(c *kruda.Ctx) error` |
+| JSON response | `json.NewEncoder(w).Encode(obj)` | `c.JSON(obj)` |
+| Status code | `w.WriteHeader(404)` | `c.Status(404).JSON(obj)` |
+| Path param | `r.PathValue("id")` | `c.Param("id")` |
+| Query param | `r.URL.Query().Get("q")` | `c.Query("q")` |
+| Body parse | `json.NewDecoder(r.Body).Decode(&v)` | `c.Bind(&v)` or `C[T]` |
+| Middleware | manual wrapping | `app.Use(mw)` |
+| Route group | manual prefix | `app.Group("/api")` |
+| Start | `http.ListenAndServe(":3000", mux)` | `app.Listen(":3000")` |
+
+## Hello World
+
+**stdlib:**
+```go
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"message": "hello",
+		})
+	})
+	http.ListenAndServe(":3000", mux)
+}
+```
+
+**Kruda:**
+```go
+package main
+
+import "github.com/go-kruda/kruda"
+
+func main() {
+	app := kruda.New()
+	app.Get("/", func(c *kruda.Ctx) error {
+		return c.JSON(kruda.Map{"message": "hello"})
+	})
+	app.Listen(":3000")
+}
+```
+
+No manual `Content-Type` header. No `json.NewEncoder`. Handlers return `error` instead of silently failing.
+
+## Key Differences
+
+### 1. Handler Signature
+
+stdlib handlers take two args and return nothing — errors are easy to forget:
+
+```go
+// stdlib — must remember to return after writing error
+func handler(w http.ResponseWriter, r *http.Request) {
+	user, err := findUser(r.PathValue("id"))
+	if err != nil {
+		http.Error(w, err.Error(), 500)
+		return // forget this and you write twice
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(user)
+}
+```
+
+Kruda handlers return `error` — the compiler helps you:
+
+```go
+// Kruda — error return enforces handling
+func handler(c *kruda.Ctx) error {
+	user, err := findUser(c.Param("id"))
+	if err != nil {
+		return err // centralized error handler formats the response
+	}
+	return c.JSON(user)
+}
+```
+
+### 2. JSON Body Parsing
+
+**stdlib:**
+```go
+type CreateUser struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+mux.HandleFunc("POST /users", func(w http.ResponseWriter, r *http.Request) {
+	var input CreateUser
+	if err := json.NewDecoder(r.Body).Decode(&input); err != nil {
+		http.Error(w, "invalid JSON", 400)
+		return
+	}
+	// manual validation...
+	if input.Name == "" {
+		http.Error(w, "name required", 422)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(201)
+	json.NewEncoder(w).Encode(createUser(input))
+})
+```
+
+**Kruda:**
+```go
+type CreateUser struct {
+	Name  string `json:"name" validate:"required"`
+	Email string `json:"email" validate:"required,email"`
+}
+
+app.Post("/users", func(c *kruda.Ctx) error {
+	var input CreateUser
+	if err := c.Bind(&input); err != nil {
+		return err // auto 422 with structured validation errors
+	}
+	return c.Status(201).JSON(createUser(input))
+})
+// Or use typed handlers for compile-time safety:
+// kruda.Post[CreateUser, User](app, "/users", handler)
+```
+
+No manual `json.NewDecoder`. No manual validation. Validation errors return structured 422 automatically.
+
+### 3. Middleware
+
+stdlib requires manual function wrapping:
+
+```go
+// stdlib — nested wrapping, hard to read
+func logging(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		next.ServeHTTP(w, r)
+		log.Printf("%s %s %v", r.Method, r.URL.Path, time.Since(start))
+	})
+}
+
+func cors(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		next.ServeHTTP(w, r)
+	})
+}
+
+http.ListenAndServe(":3000", logging(cors(mux)))
+```
+
+Kruda has a built-in middleware chain:
+
+```go
+import "github.com/go-kruda/kruda/middleware"
+
+app.Use(middleware.Logger())
+app.Use(middleware.CORS())
+app.Use(middleware.Recovery())
+app.Use(middleware.RequestID())
+```
+
+### 4. Route Groups
+
+stdlib has no built-in grouping — you manage prefixes manually:
+
+```go
+// stdlib — manual prefix management
+mux.HandleFunc("GET /api/v1/users", listUsers)
+mux.HandleFunc("POST /api/v1/users", createUser)
+mux.HandleFunc("GET /api/v1/users/{id}", getUser)
+// auth middleware? wrap each handler individually or the whole mux
+```
+
+Kruda supports groups with scoped middleware:
+
+```go
+app.Group("/api/v1").
+	Guard(authMiddleware).
+	Get("/users", listUsers).
+	Post("/users", createUser).
+	Get("/users/:id", getUser).
+	Done()
+```
+
+### 5. Pluggable Transport
+
+stdlib is locked to `net/http`. Kruda auto-selects the fastest transport for your platform:
+
+```go
+// Wing (default on Linux) — epoll+eventfd, 846K req/s
+app := kruda.New()
+
+// net/http — same engine as stdlib, with Kruda's ergonomics
+app := kruda.New(kruda.NetHTTP())
+
+// fasthttp — broad compatibility
+app := kruda.New(kruda.FastHTTP())
+```
+
+You can use `kruda.NetHTTP()` to keep the exact same transport as stdlib while gaining Kruda's API.
+
+## What You Gain
+
+- **846K req/s** — Wing transport (epoll+eventfd) by default on Linux
+- **Error-returning handlers** — no more silent failures or forgotten `return`
+- **Type-safe handlers** — `C[T]` with auto-bind, auto-validate, auto-OpenAPI
+- **Built-in middleware** — Logger, CORS, Recovery, RequestID, RateLimit
+- **Route groups** — with scoped middleware via `Guard()`
+- **Auto CRUD** — `kruda.Resource[Product, string](app, "/products", service)` generates full REST
+- **Built-in DI** — optional dependency injection without codegen
+- **Same transport option** — `kruda.NetHTTP()` uses `net/http` under the hood if you prefer

--- a/examples/ratelimit/README.md
+++ b/examples/ratelimit/README.md
@@ -5,7 +5,8 @@ Global and per-route rate limiting using `contrib/ratelimit` with skip functions
 ## Run
 
 ```bash
-go run ./examples/ratelimit/
+cd examples/ratelimit
+go run .
 ```
 
 ## Test

--- a/examples/ratelimit/go.mod
+++ b/examples/ratelimit/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/go-kruda/kruda/transport/wing v0.0.0-00010101000000-000000000000 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect

--- a/examples/session/README.md
+++ b/examples/session/README.md
@@ -5,7 +5,8 @@ Cookie-based session management using `contrib/session` with an in-memory store.
 ## Run
 
 ```bash
-go run ./examples/session/
+cd examples/session
+go run .
 ```
 
 ## Test

--- a/examples/websocket/README.md
+++ b/examples/websocket/README.md
@@ -5,7 +5,8 @@ Real-time echo server using `contrib/ws` with message size limits and an HTML te
 ## Run
 
 ```bash
-go run ./examples/websocket/
+cd examples/websocket
+go run .
 ```
 
 ## Test

--- a/examples/websocket/go.mod
+++ b/examples/websocket/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/bytedance/sonic v1.15.0 // indirect
 	github.com/bytedance/sonic/loader v0.5.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/go-kruda/kruda/transport/wing v0.0.0-00010101000000-000000000000 // indirect
 	github.com/klauspost/compress v1.18.2 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect


### PR DESCRIPTION
## Summary
- Fix govulncheck minimum version: go1.25.7+ → go1.25.8+ (match go.mod)
- Fix example run commands (ratelimit, session, websocket)
- Add `docs/guide/coming-from-stdlib.md` migration guide
- Add GitHub Discussions welcome post draft

## Pre-v1.0.0 checklist
- [x] CI passes
- [x] All examples verified
- [x] README updated
- [x] CHANGELOG ready