### PR TITLE
fix(ci): upgrade codecov-action to v5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,10 +71,9 @@ jobs:
       - name: Upload coverage to Codecov
         # Upload only once per Go version (Linux) to avoid duplicates
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: coverage.out
           flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- Upgrade codecov-action v4 → v5
- Pass token via `with.token` instead of env var (v5 requirement)
- CODECOV_TOKEN secret already configured