### PR TITLE
docs: remove Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Fast by default, type-safe by design.
 [![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go)](https://go.dev)
 [![CI](https://github.com/go-kruda/kruda/actions/workflows/test.yml/badge.svg)](https://github.com/go-kruda/kruda/actions/workflows/test.yml)
 [![Coverage](https://codecov.io/gh/go-kruda/kruda/branch/main/graph/badge.svg)](https://codecov.io/gh/go-kruda/kruda)
-[![Go Report Card](https://goreportcard.com/badge/github.com/go-kruda/kruda)](https://goreportcard.com/report/github.com/go-kruda/kruda)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 ## Why Kruda?


### PR DESCRIPTION
## Summary
Remove Go Report Card badge — their Go version doesn't support Go 1.25 yet,
causing go_vet to fail and badge to show error.

Will add back when they update. Remaining badges: Go Version, CI, Coverage, License.