### PR TITLE
fix: replace broken kruda.dev links

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,18 +131,11 @@ Wing transport uses raw `epoll` + `eventfd` on Linux — bypasses both fasthttp 
 
 ## Documentation
 
-Full documentation at [kruda.dev](https://kruda.dev):
-
-- [Getting Started](https://kruda.dev/guide/getting-started)
-- [Routing](https://kruda.dev/guide/routing)
-- [Typed Handlers](https://kruda.dev/guide/handlers)
-- [Middleware](https://kruda.dev/guide/middleware)
-- [Transport](https://kruda.dev/guide/transport) — Wing, fasthttp, net/http
-- [Performance](https://kruda.dev/guide/performance) — benchmarks & tuning
-- [Security](https://kruda.dev/guide/security) — headers, path traversal, rate limiting
-- [DI Container](https://kruda.dev/guide/di-container)
-- [Error Handling](https://kruda.dev/guide/error-handling)
-- [API Reference](https://kruda.dev/api/app)
+- [API Reference (pkg.go.dev)](https://pkg.go.dev/github.com/go-kruda/kruda)
+- [Examples](examples/) — 21 runnable examples
+- [Contributing](CONTRIBUTING.md)
+- [Security Policy](SECURITY.md)
+- [Benchmark Charts](https://go-kruda.github.io/kruda/benchmarks/)
 
 ## AI Integration
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,9 +13,7 @@ Security patches are applied to the latest minor release. Pre-1.0 releases recei
 
 **Please do NOT open a public GitHub issue for security vulnerabilities.**
 
-Instead, report vulnerabilities via email:
-
-📧 **security@kruda.dev**
+Instead, report via [GitHub Security Advisories](https://github.com/go-kruda/kruda/security/advisories/new).
 
 Include the following in your report:
 


### PR DESCRIPTION
## Summary

- Replace dead `kruda.dev` documentation links in README with working alternatives (pkg.go.dev, examples dir, GitHub Pages benchmarks)
- Replace `security@kruda.dev` email in SECURITY.md with GitHub Security Advisories link

## Test plan

- [x] All links in README point to real pages
- [x] SECURITY.md reporting link works