### PR TITLE
fix(ci): TFB Docker build context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,7 @@ jobs:
           go-version: stable
           
       - name: Build TFB Docker image
-        run: |
-          cd frameworks/Go/kruda
-          docker build -f Dockerfile -t kruda-tfb .
+        run: docker build -f frameworks/Go/kruda/Dockerfile -t kruda-tfb .
           
       - name: Test TFB endpoints
         run: |

--- a/frameworks/Go/kruda/Dockerfile
+++ b/frameworks/Go/kruda/Dockerfile
@@ -1,9 +1,16 @@
 FROM golang:1.26-alpine AS builder
 WORKDIR /build
 # Copy framework source (needed for replace directive)
-COPY . /kruda
+COPY go.mod go.sum /kruda/
+COPY *.go /kruda/
+COPY bench/ /kruda/bench/
+COPY cmd/ /kruda/cmd/
+COPY contrib/ /kruda/contrib/
+COPY internal/ /kruda/internal/
+COPY middleware/ /kruda/middleware/
+COPY transport/ /kruda/transport/
 # Copy TFB app source
-COPY src/ /build/
+COPY frameworks/Go/kruda/src/ /build/
 # Adjust replace directive to point to copied framework source
 RUN sed -i 's|../../../../|/kruda|g' /build/go.mod
 RUN cd /build && go mod download


### PR DESCRIPTION
## Summary
- Fix TFB verification failing because Docker build context was `frameworks/Go/kruda/` instead of repo root
- `COPY . /kruda` only got Dockerfile+src, not the framework source code
- Now builds from repo root with explicit COPY of needed directories

## Test plan
- [ ] Release workflow TFB verification step passes on next tag