### PR TITLE
fix(ci): tokenless Codecov upload

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,11 +69,9 @@ jobs:
         run: cd cmd/kruda && go test -tags kruda_stdjson ./...
 
       - name: Upload coverage to Codecov
-        # Upload only once per Go version (Linux) to avoid duplicates
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == 'stable'
         uses: codecov/codecov-action@v5
         with:
           files: coverage.out
           flags: unittests
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Fast by default, type-safe by design.
 [![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go)](https://go.dev)
 [![Go Reference](https://pkg.go.dev/badge/github.com/go-kruda/kruda.svg)](https://pkg.go.dev/github.com/go-kruda/kruda)
 [![CI](https://github.com/go-kruda/kruda/actions/workflows/test.yml/badge.svg)](https://github.com/go-kruda/kruda/actions/workflows/test.yml)
-[![Coverage](https://codecov.io/gh/go-kruda/kruda/branch/main/graph/badge.svg)](https://codecov.io/gh/go-kruda/kruda)
+[![codecov](https://codecov.io/gh/go-kruda/kruda/graph/badge.svg?token=9HIGH8L2Q7)](https://codecov.io/gh/go-kruda/kruda)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 ## Why Kruda?


### PR DESCRIPTION
## Summary
- Remove `CODECOV_TOKEN` from upload (Codecov org no longer requires it)
- Upload only once from `Go stable` instead of both versions to avoid duplicates

## Test plan
- [ ] Check Codecov shows coverage after merge