### PR TITLE
fix(ci): restore Codecov token for protected branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,4 +74,5 @@ jobs:
         with:
           files: coverage.out
           flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false


### PR DESCRIPTION
## Summary
- Tokenless upload fails: "Token required because branch is protected"
- Restore token (updated to global org token), keep single upload from Go stable

## Test plan
- [ ] Codecov shows coverage after merge to main