### PR TITLE
chore: remove remaining TFB references

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,41 +33,9 @@ jobs:
       - name: Run security scan
         run: govulncheck ./...
         
-  tfb-verify:
-    name: TFB Verification
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: stable
-          
-      - name: Build TFB Docker image
-        run: docker build -f frameworks/Go/kruda/kruda.dockerfile -t kruda-tfb frameworks/Go/kruda
-          
-      - name: Test TFB endpoints
-        run: |
-          # Start container
-          CONTAINER_ID=$(docker run -d -p 8080:8080 kruda-tfb)
-          sleep 10
-          
-          # Test endpoints
-          endpoints=("/json" "/plaintext" "/db" "/queries?n=20" "/fortunes" "/cached-queries?n=20" "/updates?n=20")
-          for endpoint in "${endpoints[@]}"; do
-            echo "Testing $endpoint..."
-            curl -f "http://localhost:8080$endpoint" || exit 1
-          done
-          
-          # Cleanup
-          docker stop "$CONTAINER_ID"
-          docker rm "$CONTAINER_ID"
-          
   release:
     name: Create Release
-    needs: [test, security, tfb-verify]
+    needs: [test, security]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/scripts/pre-release-check.sh
+++ b/scripts/pre-release-check.sh
@@ -115,16 +115,7 @@ else
     cp "$BENCH_FILE" bench_baseline.txt
 fi
 
-# 7. TFB verification
-log "Verifying TechEmpower Framework Benchmarks setup..."
-if [ -f "$SCRIPT_DIR/verify-tfb.sh" ]; then
-    "$SCRIPT_DIR/verify-tfb.sh" || fail "TFB verification failed"
-    ok "TFB verification passed"
-else
-    warn "TFB verification script not found, skipping"
-fi
-
-# 8. Documentation build
+# 7. Documentation build
 log "Building documentation..."
 if [ -d "docs" ] && [ -f "docs/package.json" ]; then
     cd docs
@@ -140,7 +131,7 @@ else
     warn "Documentation directory not found, skipping"
 fi
 
-# 9. Version consistency check
+# 8. Version consistency check
 log "Checking version consistency..."
 # Check if version is mentioned in key files
 FILES_TO_CHECK=("README.md" "CHANGELOG.md")
@@ -152,7 +143,7 @@ for file in "${FILES_TO_CHECK[@]}"; do
     fi
 done
 
-# 10. Build verification
+# 9. Build verification
 log "Verifying builds for target platforms..."
 PLATFORMS=("linux/amd64" "darwin/arm64" "windows/amd64")
 for platform in "${PLATFORMS[@]}"; do
@@ -162,7 +153,7 @@ for platform in "${PLATFORMS[@]}"; do
 done
 ok "Cross-platform builds verified"
 
-# 11. Check for TODO/FIXME comments
+# 10. Check for TODO/FIXME comments
 log "Checking for TODO/FIXME comments..."
 TODO_COUNT=$(find . -name "*.go" -not -path "./vendor/*" -not -path "./.git/*" | xargs grep -c "TODO\|FIXME" | awk -F: '{sum += $2} END {print sum+0}')
 if [ "$TODO_COUNT" -gt 0 ]; then
@@ -186,7 +177,6 @@ echo "  ✓ All tests pass"
 echo "  ✓ Linting clean"
 echo "  ✓ Security scan clean"
 echo "  ✓ Benchmark performance acceptable"
-echo "  ✓ TFB verification passed"
 echo "  ✓ Documentation builds"
 echo "  ✓ Cross-platform builds work"
 echo ""

--- a/scripts/scaling-linux.sh
+++ b/scripts/scaling-linux.sh
@@ -40,12 +40,12 @@ command -v go   >/dev/null || { fail "go not found"; exit 1; }
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
 log "Building Kruda..."
-(cd "$ROOT_DIR/frameworks/Go/kruda/src" && \
+(cd "$ROOT_DIR/bench/reproducible/kruda" && \
     go build -ldflags="-s -w" -o "$RESULTS_DIR/kruda-bench" .) 2>&1
 ok "Kruda built"
 
 log "Building Fiber..."
-(cd "$ROOT_DIR/bench/tfb/fiber" && \
+(cd "$ROOT_DIR/bench/reproducible/fiber" && \
     go build -ldflags="-s -w" -o "$RESULTS_DIR/fiber-bench" .) 2>&1
 ok "Fiber built"
 


### PR DESCRIPTION
Follow-up to #21. Removes leftover TFB references from:

- `.github/workflows/release.yml` — removed `tfb-verify` job and updated `needs`
- `scripts/pre-release-check.sh` — removed TFB verification step, renumbered
- `scripts/scaling-linux.sh` — updated build paths to `bench/reproducible/`

No impact on framework code or API.