### PR TITLE
fix: sendBytes panic on fasthttp transport

### DIFF
--- a/context.go
+++ b/context.go
@@ -1100,6 +1100,12 @@ func (c *Ctx) sendBytes(data []byte) error {
 	}
 	c.responded = true
 	c.contentLength = len(data)
+
+	// Fast path: fasthttp — use embedded adapter directly (c.writer is nil)
+	if c.trySendBytesFastHTTP(data) {
+		return nil
+	}
+
 	c.writeHeaders()
 	c.writer.WriteHeader(c.status)
 


### PR DESCRIPTION
## What

`sendBytes` (unexported) was missing the fasthttp fast path, causing a nil pointer dereference on macOS where fasthttp is the default transport.

`c.writer` is nil on the fasthttp serve path — `ServeFast` uses `embeddedFHResp` instead. The exported `SendBytes` already had `trySendBytesFastHTTP` but the internal `sendBytes` didn't.

## Impact

Anything that goes through `sendBytes` without its own fasthttp shortcut panics on macOS:
- `HTML()`
- `Render()`
- OpenAPI spec handler (registered internally by `Listen()`)

`JSON()` and `Text()` were **not** affected — they have their own dedicated fast paths (`tryFastHTTPJSON`, `tryFastHTTPText`).

## Fix

Added the same `trySendBytesFastHTTP` check that `SendBytes` already has.

## Test

- All existing tests pass (`go test -race -tags kruda_stdjson ./...`)
- Verified OpenAPI example runs without panic on macOS (fasthttp transport)
- All endpoints return expected status codes