### PR TITLE
ci: opt into Node.js 24 for GitHub Actions

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,6 +14,9 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   benchmark:
     name: Benchmark Regression

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,6 +19,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   benchmark:
     name: Benchmark

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,9 @@ permissions:
   pages: write
   id-token: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 # Allow only one concurrent deployment
 concurrency:
   group: pages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ permissions:
   contents: write
   packages: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,9 @@ on:
 permissions:
   contents: read
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   test:
     name: Test (Go ${{ matrix.go-version }}, ${{ matrix.os }})


### PR DESCRIPTION
GitHub Actions deprecating Node.js 20 — forced default to 24 starts June 2nd, full removal Sept 16th.

Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` env to all 5 workflows:
- `test.yml`
- `release.yml`
- `docs.yml`
- `bench.yml`
- `benchmark.yml`

This silences the 8 deprecation warnings showing up on every CI run. Once the actions (checkout, setup-go, etc.) release Node 24 native builds, we can drop this env var.