### PR TITLE
fix: update sub-module deps to v1.0.3

### DIFF
--- a/contrib/cache/go.mod
+++ b/contrib/cache/go.mod
@@ -7,7 +7,7 @@ replace (
 	github.com/go-kruda/kruda/transport/wing => ../../transport/wing
 )
 
-require github.com/go-kruda/kruda v0.0.0
+require github.com/go-kruda/kruda v1.0.3
 
 require (
 	github.com/andybalholm/brotli v1.2.0 // indirect

--- a/contrib/compress/go.mod
+++ b/contrib/compress/go.mod
@@ -7,7 +7,7 @@ replace (
 	github.com/go-kruda/kruda/transport/wing => ../../transport/wing
 )
 
-require github.com/go-kruda/kruda v0.0.0
+require github.com/go-kruda/kruda v1.0.3
 
 require (
 	github.com/andybalholm/brotli v1.2.0 // indirect

--- a/contrib/etag/go.mod
+++ b/contrib/etag/go.mod
@@ -7,7 +7,7 @@ replace (
 	github.com/go-kruda/kruda/transport/wing => ../../transport/wing
 )
 
-require github.com/go-kruda/kruda v0.0.0
+require github.com/go-kruda/kruda v1.0.3
 
 require (
 	github.com/andybalholm/brotli v1.2.0 // indirect

--- a/contrib/jwt/go.mod
+++ b/contrib/jwt/go.mod
@@ -7,7 +7,7 @@ replace (
 	github.com/go-kruda/kruda/transport/wing => ../../transport/wing
 )
 
-require github.com/go-kruda/kruda v0.0.0
+require github.com/go-kruda/kruda v1.0.3
 
 require (
 	github.com/andybalholm/brotli v1.2.0 // indirect

--- a/contrib/otel/go.mod
+++ b/contrib/otel/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	github.com/go-kruda/kruda v0.0.0
+	github.com/go-kruda/kruda v1.0.3
 	go.opentelemetry.io/otel v1.41.0
 	go.opentelemetry.io/otel/sdk v1.41.0
 	go.opentelemetry.io/otel/trace v1.41.0

--- a/contrib/prometheus/go.mod
+++ b/contrib/prometheus/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	github.com/go-kruda/kruda v0.0.0
+	github.com/go-kruda/kruda v1.0.3
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.1
 )

--- a/contrib/ratelimit/go.mod
+++ b/contrib/ratelimit/go.mod
@@ -7,7 +7,7 @@ replace (
 	github.com/go-kruda/kruda/transport/wing => ../../transport/wing
 )
 
-require github.com/go-kruda/kruda v0.0.0
+require github.com/go-kruda/kruda v1.0.3
 
 require (
 	github.com/andybalholm/brotli v1.2.0 // indirect

--- a/contrib/session/go.mod
+++ b/contrib/session/go.mod
@@ -7,7 +7,7 @@ replace (
 	github.com/go-kruda/kruda/transport/wing => ../../transport/wing
 )
 
-require github.com/go-kruda/kruda v0.0.0
+require github.com/go-kruda/kruda v1.0.3
 
 require (
 	github.com/andybalholm/brotli v1.2.0 // indirect

--- a/contrib/swagger/go.mod
+++ b/contrib/swagger/go.mod
@@ -7,7 +7,7 @@ replace (
 	github.com/go-kruda/kruda/transport/wing => ../../transport/wing
 )
 
-require github.com/go-kruda/kruda v0.0.0
+require github.com/go-kruda/kruda v1.0.3
 
 require (
 	github.com/andybalholm/brotli v1.2.0 // indirect

--- a/contrib/ws/go.mod
+++ b/contrib/ws/go.mod
@@ -7,7 +7,7 @@ replace (
 	github.com/go-kruda/kruda/transport/wing => ../../transport/wing
 )
 
-require github.com/go-kruda/kruda v0.0.0
+require github.com/go-kruda/kruda v1.0.3
 
 require (
 	github.com/andybalholm/brotli v1.2.0 // indirect

--- a/scripts/pre-release-check.sh
+++ b/scripts/pre-release-check.sh
@@ -143,6 +143,24 @@ for file in "${FILES_TO_CHECK[@]}"; do
     fi
 done
 
+# 8b. Sub-module dependency check
+log "Checking sub-module dependencies..."
+SUBMOD_OK=true
+for modfile in contrib/*/go.mod transport/wing/go.mod; do
+    if [ -f "$modfile" ]; then
+        DEP_VER=$(grep "github.com/go-kruda/kruda v" "$modfile" | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+        if [ -n "$DEP_VER" ] && [ "$DEP_VER" != "$VERSION" ]; then
+            warn "$modfile requires kruda $DEP_VER (expected $VERSION)"
+            SUBMOD_OK=false
+        fi
+    fi
+done
+if [ "$SUBMOD_OK" = true ]; then
+    ok "All sub-modules require kruda $VERSION"
+else
+    fail "Sub-module dependencies out of sync. Run: scripts/tag-submodules.sh $VERSION"
+fi
+
 # 9. Build verification
 log "Verifying builds for target platforms..."
 PLATFORMS=("linux/amd64" "darwin/arm64" "windows/amd64")

--- a/scripts/tag-submodules.sh
+++ b/scripts/tag-submodules.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Tag Sub-Modules — Kruda Framework
+# Updates sub-module go.mod deps and creates version tags for all sub-modules.
+#
+# Usage:
+#   ./scripts/tag-submodules.sh v1.0.3
+#
+# This will:
+#   1. Update all sub-module go.mod to require kruda $VERSION
+#   2. Commit the changes
+#   3. Tag each sub-module (contrib/*/vX.Y.Z, transport/wing/vX.Y.Z)
+#   4. Push tags
+
+set -euo pipefail
+
+VERSION="${1:-}"
+if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "Usage: $0 v1.0.3"
+    exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+log() { echo -e "${CYAN}[tag-sub]${NC} $*"; }
+ok() { echo -e "${GREEN}[✓]${NC} $*"; }
+
+# Collect sub-modules
+SUBMODS=(contrib/cache contrib/compress contrib/etag contrib/jwt contrib/otel contrib/prometheus contrib/ratelimit contrib/session contrib/swagger contrib/ws transport/wing)
+
+# 1. Update go.mod files
+log "Updating sub-module go.mod to require kruda $VERSION..."
+CHANGED=false
+for mod in "${SUBMODS[@]}"; do
+    if [ -f "$mod/go.mod" ]; then
+        if grep -q "github.com/go-kruda/kruda v" "$mod/go.mod"; then
+            sed -i '' "s|github.com/go-kruda/kruda v[0-9]*\.[0-9]*\.[0-9]*|github.com/go-kruda/kruda $VERSION|g" "$mod/go.mod"
+            CHANGED=true
+        fi
+    fi
+done
+
+if [ "$CHANGED" = true ] && [ -n "$(git status --porcelain)" ]; then
+    git add contrib/*/go.mod transport/wing/go.mod
+    git commit -m "chore: sync sub-module deps to $VERSION"
+    ok "Committed go.mod updates"
+else
+    ok "All go.mod files already up to date"
+fi
+
+# 2. Tag sub-modules
+log "Creating sub-module tags..."
+TAGS=()
+for mod in "${SUBMODS[@]}"; do
+    TAG="$mod/$VERSION"
+    if git rev-parse "$TAG" >/dev/null 2>&1; then
+        log "  $TAG already exists, skipping"
+    else
+        git tag -a "$TAG" -m "$mod $VERSION"
+        TAGS+=("$TAG")
+        ok "  Tagged $TAG"
+    fi
+done
+
+# 3. Summary
+echo ""
+if [ ${#TAGS[@]} -eq 0 ]; then
+    echo -e "${GREEN}${BOLD}No new tags to push.${NC}"
+else
+    echo -e "${BOLD}Tags created:${NC}"
+    for tag in "${TAGS[@]}"; do
+        echo "  $tag"
+    done
+    echo ""
+    echo -e "${BOLD}Push all tags:${NC}"
+    echo "  git push origin ${TAGS[*]}"
+    echo ""
+    read -p "Push now? (y/N): " -n 1 -r
+    echo ""
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        git push origin "${TAGS[@]}"
+        ok "All tags pushed"
+    fi
+fi

--- a/transport/wing/go.mod
+++ b/transport/wing/go.mod
@@ -2,7 +2,7 @@ module github.com/go-kruda/kruda/transport/wing
 
 go 1.25.8
 
-require github.com/go-kruda/kruda v0.0.0
+require github.com/go-kruda/kruda v1.0.3
 
 require (
 	github.com/andybalholm/brotli v1.2.0 // indirect


### PR DESCRIPTION
All contrib/ and transport/wing go.mod files had `require go-kruda/kruda v0.0.0` — works locally because of `replace` directives, but pkg.go.dev ignores `replace` so it can't resolve the dependency.

Updated all 11 sub-modules to require `v1.0.3`. After merge, sub-modules need new version tags so pkg.go.dev indexes them properly.