### PR TITLE
fix: remove replace directives for downstream compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ Thumbs.db
 
 # Go
 vendor/
+go.work
+go.work.sum
 
 # AI tooling
 CLAUDE.md

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.8
 
 require (
 	github.com/bytedance/sonic v1.15.0
-	github.com/go-kruda/kruda/transport/wing v0.0.0-00010101000000-000000000000
+	github.com/go-kruda/kruda/transport/wing v1.0.3
 	github.com/valyala/fasthttp v1.69.0
 )
 
@@ -21,5 +21,3 @@ require (
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 )
-
-replace github.com/go-kruda/kruda/transport/wing => ./transport/wing

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-kruda/kruda/transport/wing v1.0.3 h1:Z0d69eVsV1VjKrAFwjr13cVXgSliw9ZeLMFTsWjy9mo=
+github.com/go-kruda/kruda/transport/wing v1.0.3/go.mod h1:ZUEn45euUJGYuOz6/ftdVozFa6WE1dpaiGPwer0c6RA=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
 github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=

--- a/scripts/tag-submodules.sh
+++ b/scripts/tag-submodules.sh
@@ -47,8 +47,15 @@ for mod in "${SUBMODS[@]}"; do
     fi
 done
 
+# Also update core go.mod to point to new transport/wing version
+log "Updating core go.mod to require transport/wing $VERSION..."
+if grep -q "github.com/go-kruda/kruda/transport/wing v" go.mod; then
+    sed -i '' "s|github.com/go-kruda/kruda/transport/wing v[0-9]*\.[0-9]*\.[0-9]*|github.com/go-kruda/kruda/transport/wing $VERSION|g" go.mod
+    CHANGED=true
+fi
+
 if [ "$CHANGED" = true ] && [ -n "$(git status --porcelain)" ]; then
-    git add contrib/*/go.mod transport/wing/go.mod
+    git add go.mod contrib/*/go.mod transport/wing/go.mod
     git commit -m "chore: sync sub-module deps to $VERSION"
     ok "Committed go.mod updates"
 else

--- a/transport/wing/go.mod
+++ b/transport/wing/go.mod
@@ -10,5 +10,3 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasthttp v1.69.0 // indirect
 )
-
-replace github.com/go-kruda/kruda => ../..

--- a/transport/wing/go.sum
+++ b/transport/wing/go.sum
@@ -1,5 +1,7 @@
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
+github.com/go-kruda/kruda v1.0.3 h1:3/QxaCGD6ZqKGWpg7qjBzZMeR+AuSiehAKP9zR8IFo8=
+github.com/go-kruda/kruda v1.0.3/go.mod h1:sc04NvBp8ehU1TJfBySq5PfP7Kprq4eOcdpVJm1KmPI=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
 github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=


### PR DESCRIPTION
## Summary
- Remove `replace` directives from `go.mod` and `transport/wing/go.mod` — use published versions instead
- Add `go.work` + `.gitignore` for local dev
- Update `tag-submodules.sh` to also sync core `go.mod` on release

## Problem
Downstream projects running `go get github.com/go-kruda/kruda` fail with:
```
transport/wing@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
```
Because `replace` directives are not inherited by downstream modules.

## Test plan
- [x] `go build -tags kruda_stdjson ./...` passes
- [x] Downstream project `go mod tidy` resolves cleanly after tagging new version