### PR TITLE
fix(sse): prevent double JSON encoding and incomplete chunked response

### DIFF
--- a/context.go
+++ b/context.go
@@ -1030,7 +1030,12 @@ func (c *Ctx) SSE(fn func(*SSEStream) error) error {
 		ctx:     c.Context(),
 	}
 
-	return fn(stream)
+	err := fn(stream)
+
+	// Flush after callback returns to ensure net/http sends the terminating chunk.
+	flusher.Flush()
+
+	return err
 }
 
 // Provide stores a typed value in the request context for later retrieval via Need.

--- a/kruda_test.go
+++ b/kruda_test.go
@@ -674,7 +674,7 @@ func TestIntegration_SSE_Streaming(t *testing.T) {
 	if !strings.Contains(body, "event: greeting\n") {
 		t.Error("body should contain 'event: greeting'")
 	}
-	if !strings.Contains(body, "data: \"hello\"\n") {
+	if !strings.Contains(body, "data: hello\n") {
 		t.Errorf("body should contain data hello, got: %s", body)
 	}
 	if !strings.Contains(body, "data: 42\n") {

--- a/sse.go
+++ b/sse.go
@@ -24,16 +24,55 @@ func sanitizeSSE(s string) string {
 	return s
 }
 
-// Event sends a named event with data (JSON-encoded).
+// encodeData returns data as bytes. Strings and []byte are passed through;
+// all other types are JSON-encoded. This prevents double-encoding when
+// the caller already holds a JSON string.
+func (s *SSEStream) encodeData(data any) ([]byte, error) {
+	switch v := data.(type) {
+	case string:
+		return []byte(v), nil
+	case []byte:
+		return v, nil
+	default:
+		b, err := s.encode(data)
+		if err != nil {
+			return nil, fmt.Errorf("SSE encode error: %w", err)
+		}
+		return b, nil
+	}
+}
+
+// formatDataField formats encoded bytes as one or more "data: " lines per SSE spec.
+// Multiline data must have each line prefixed with "data: ".
+func formatDataField(b []byte) []byte {
+	s := string(b)
+	if !strings.ContainsAny(s, "\r\n") {
+		return b
+	}
+	// Normalize \r\n and lone \r to \n
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	lines := strings.Split(s, "\n")
+	var buf strings.Builder
+	for i, line := range lines {
+		if i > 0 {
+			buf.WriteString("\ndata: ")
+		}
+		buf.WriteString(line)
+	}
+	return []byte(buf.String())
+}
+
+// Event sends a named event with data (JSON-encoded unless string or []byte).
 func (s *SSEStream) Event(event string, data any) error {
 	if err := s.ctx.Err(); err != nil {
 		return err
 	}
-	b, err := s.encode(data)
+	b, err := s.encodeData(data)
 	if err != nil {
-		return fmt.Errorf("SSE encode error: %w", err)
+		return err
 	}
-	_, err = fmt.Fprintf(s.writer, "event: %s\ndata: %s\n\n", sanitizeSSE(event), b)
+	_, err = fmt.Fprintf(s.writer, "event: %s\ndata: %s\n\n", sanitizeSSE(event), formatDataField(b))
 	if err != nil {
 		return err
 	}
@@ -46,11 +85,11 @@ func (s *SSEStream) EventWithID(id, event string, data any) error {
 	if err := s.ctx.Err(); err != nil {
 		return err
 	}
-	b, err := s.encode(data)
+	b, err := s.encodeData(data)
 	if err != nil {
-		return fmt.Errorf("SSE encode error: %w", err)
+		return err
 	}
-	_, err = fmt.Fprintf(s.writer, "id: %s\nevent: %s\ndata: %s\n\n", sanitizeSSE(id), sanitizeSSE(event), b)
+	_, err = fmt.Fprintf(s.writer, "id: %s\nevent: %s\ndata: %s\n\n", sanitizeSSE(id), sanitizeSSE(event), formatDataField(b))
 	if err != nil {
 		return err
 	}
@@ -58,16 +97,16 @@ func (s *SSEStream) EventWithID(id, event string, data any) error {
 	return nil
 }
 
-// Data sends an unnamed event with data (JSON-encoded).
+// Data sends an unnamed event with data (JSON-encoded unless string or []byte).
 func (s *SSEStream) Data(data any) error {
 	if err := s.ctx.Err(); err != nil {
 		return err
 	}
-	b, err := s.encode(data)
+	b, err := s.encodeData(data)
 	if err != nil {
-		return fmt.Errorf("SSE encode error: %w", err)
+		return err
 	}
-	_, err = fmt.Fprintf(s.writer, "data: %s\n\n", b)
+	_, err = fmt.Fprintf(s.writer, "data: %s\n\n", formatDataField(b))
 	if err != nil {
 		return err
 	}

--- a/sse_integration_test.go
+++ b/sse_integration_test.go
@@ -63,8 +63,8 @@ func TestSSE_HTTPIntegration(t *testing.T) {
 	if !strings.Contains(body, "event: greeting") {
 		t.Errorf("missing 'event: greeting' in body:\n%s", body)
 	}
-	if !strings.Contains(body, `data: "hello"`) {
-		t.Errorf("missing 'data: \"hello\"' in body:\n%s", body)
+	if !strings.Contains(body, "data: hello") {
+		t.Errorf("missing 'data: hello' in body:\n%s", body)
 	}
 	if !strings.Contains(body, "data: 42") {
 		t.Errorf("missing 'data: 42' in body:\n%s", body)

--- a/sse_pbt_test.go
+++ b/sse_pbt_test.go
@@ -47,8 +47,7 @@ func TestPropertySSEEventFormatting(t *testing.T) {
 			}
 
 			got := buf.String()
-			jsonData, _ := json.Marshal(data)
-			want := fmt.Sprintf("event: %s\ndata: %s\n\n", name, jsonData)
+			want := fmt.Sprintf("event: %s\ndata: %s\n\n", name, data)
 			return got == want && flushCount == 1
 		}
 		if err := quick.Check(f, cfg); err != nil {

--- a/sse_test.go
+++ b/sse_test.go
@@ -45,7 +45,7 @@ func TestSSEStream_Event(t *testing.T) {
 	}
 
 	got := buf.String()
-	want := "event: ping\ndata: \"hello\"\n\n"
+	want := "event: ping\ndata: hello\n\n"
 	if got != want {
 		t.Errorf("Event output = %q, want %q", got, want)
 	}
@@ -70,7 +70,7 @@ func TestSSEStream_EventWithID(t *testing.T) {
 	}
 
 	got := buf.String()
-	want := "id: 42\nevent: ping\ndata: \"hello\"\n\n"
+	want := "id: 42\nevent: ping\ndata: hello\n\n"
 	if got != want {
 		t.Errorf("EventWithID output = %q, want %q", got, want)
 	}
@@ -243,7 +243,8 @@ func TestSSEStream_EncodeError(t *testing.T) {
 		ctx:     context.Background(),
 	}
 
-	err := s.Event("test", "data")
+	// Strings bypass encoder, so use a struct to trigger the bad encoder
+	err := s.Event("test", struct{ X int }{1})
 	if err == nil {
 		t.Fatal("expected encode error")
 	}
@@ -251,7 +252,7 @@ func TestSSEStream_EncodeError(t *testing.T) {
 		t.Errorf("error = %q, want to contain 'SSE encode error'", err.Error())
 	}
 
-	err = s.Data("data")
+	err = s.Data(struct{ X int }{1})
 	if err == nil {
 		t.Fatal("expected encode error for Data")
 	}
@@ -336,10 +337,10 @@ func TestCtx_SSE_MultipleEvents(t *testing.T) {
 	}
 
 	body := string(fw.body)
-	if !strings.Contains(body, "event: msg\ndata: \"one\"\n\n") {
+	if !strings.Contains(body, "event: msg\ndata: one\n\n") {
 		t.Errorf("missing Event output in body: %q", body)
 	}
-	if !strings.Contains(body, "data: \"two\"\n\n") {
+	if !strings.Contains(body, "data: two\n\n") {
 		t.Errorf("missing Data output in body: %q", body)
 	}
 	if !strings.Contains(body, ": ping\n\n") {
@@ -403,7 +404,7 @@ func TestSSEStream_MultiLineData(t *testing.T) {
 		ctx:     context.Background(),
 	}
 
-	// JSON with newlines gets serialized — the data itself is single-line JSON
+	// Multiline strings must have each line prefixed with "data: " per SSE spec
 	data := "line1\nline2\nline3"
 	err := s.Data(data)
 	if err != nil {
@@ -411,11 +412,9 @@ func TestSSEStream_MultiLineData(t *testing.T) {
 	}
 
 	got := buf.String()
-	if !strings.HasPrefix(got, "data: ") {
-		t.Errorf("expected data: prefix, got %q", got)
-	}
-	if !strings.HasSuffix(got, "\n\n") {
-		t.Errorf("expected trailing \\n\\n, got %q", got)
+	want := "data: line1\ndata: line2\ndata: line3\n\n"
+	if got != want {
+		t.Errorf("MultiLineData output = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Double JSON encoding** — `Event`/`Data`/`EventWithID` always JSON-encoded data, so passing a pre-formatted JSON string like `{"status":"connected"}` produced `"{\"status\":\"connected\"}"`. Now `string` and `[]byte` pass through; only other types are JSON-encoded.
- **Multiline data injection** — raw strings containing `\n` broke SSE framing (lines after the first were interpreted as new fields). Added `formatDataField()` that prefixes every line with `data: ` per SSE spec.
- **ERR_INCOMPLETE_CHUNKED_ENCODING** — `Ctx.SSE()` returned immediately after the callback without a final flush, so `net/http` never sent the terminating `0\r\n\r\n` chunk. Added `flusher.Flush()` after callback returns.

## Test plan
- [x] All 28 SSE tests pass (`go test -race -tags kruda_stdjson -run SSE ./...`)
- [x] Full test suite passes
- [x] Unit tests updated for new string pass-through behavior
- [x] `TestSSEStream_MultiLineData` now asserts correct multi-line `data:` format
- [x] `TestSSEStream_EncodeError` uses struct instead of string to actually trigger encoder