### PR TITLE
docs: align release and wing guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ kruda/
 ├── wing_*.go          # Wing transport (epoll on Linux / kqueue on macOS) — flattened into core since v1.2.0
 ├── middleware/        # Built-in middleware (Logger, Recovery, CORS, etc.)
 ├── transport/         # Transport adapter interfaces (nethttp, fasthttp)
-│   └── wing/          # Deprecation alias — re-exports Wing symbols from core (will be removed in v2.0.0)
+│   └── wing/          # Compatibility shim for the old Wing import path
 ├── contrib/           # Optional modules (JWT, WebSocket, RateLimit, …)
 ├── json/              # JSON engine abstraction
 ├── examples/          # Example applications
@@ -71,8 +71,8 @@ cd contrib/ratelimit && go test ./...
 
 **Cross-module dev tip:** contrib `go.mod` files require the latest tagged
 core (e.g. `kruda v1.2.0`). When you change core and want a contrib package
-to see those changes locally — before the next core tag exists on the proxy
-— set up a Go workspace:
+or the legacy Wing compatibility shim to see those changes locally — before
+the next core tag exists on the proxy — set up a Go workspace:
 
 ```bash
 go work init . transport/wing contrib/cache contrib/compress contrib/etag \

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Fast by default, type-safe by design.
 - Typed handlers `C[T]` — body + param + query parsed into one struct, validated at compile time
 - Auto CRUD — implement `ResourceService[T]`, get 5 REST endpoints
 - Built-in DI — optional, no codegen, type-safe generics
-- Pluggable transport — Wing in core (Linux, epoll+eventfd; legacy `transport/wing` import path still works as a deprecated alias), fasthttp, or net/http
+- Pluggable transport — Wing in core (Linux, epoll+eventfd), fasthttp, or net/http
 - Single-tag releases — one `vX.Y.Z` covers core and contrib (no more sub-module coordination)
 - Minimal deps — Sonic JSON (opt-out via `kruda_stdjson`), pluggable transport
 - AI-friendly — typed API + 22 examples = AI generates correct code on first try
@@ -227,7 +227,7 @@ go install golang.org/x/vuln/cmd/govulncheck@latest
 govulncheck ./...
 ```
 
-The `transport/wing` directory is now a thin deprecation alias module — its surface is just type re-exports from core, so scanning the root is sufficient.
+The legacy `transport/wing` import path is a compatibility shim. Its surface is type re-exports from core, so scanning the root covers Wing's runtime implementation.
 
 Kruda core has minimal external dependencies (Sonic JSON, fasthttp). Use `kruda_stdjson` build tag to switch to stdlib JSON. Upgrade to the latest Go patch release for security fixes.
 

--- a/doc.go
+++ b/doc.go
@@ -42,9 +42,10 @@
 // (via [WithTLS] / [WithHTTP3]) auto-falls back to net/http on every
 // platform.
 //
-// Wing is built into core since v1.2.0; the legacy
-// import "github.com/go-kruda/kruda/transport/wing" still works as a
-// deprecated re-export and will be removed in v2.0.0.
+// Wing is built into core since v1.2.0. New code should import
+// github.com/go-kruda/kruda directly and use the kruda.Wing option/helpers.
+// The legacy github.com/go-kruda/kruda/transport/wing import path remains a
+// compatibility shim for older v1.x consumers.
 //
 // # Wing dispatch tuning (advanced)
 //

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -8,14 +8,18 @@ Kruda follows a **single-tag release model** since v1.2.0. One tag, one release.
 
 Every release must go through the same guardrail:
 
-1. Create a release or hotfix branch.
+1. Create a descriptive release or hotfix branch.
 2. Open a pull request.
 3. Wait for the PR test and benchmark checks to pass.
 4. Merge the PR.
 5. Wait for `main` to finish green `Tests` and `Benchmark` runs for the merge commit.
-6. Tag that green `main` commit.
+6. Tag that green `main` commit only when the change justifies a new version.
 
 The release workflow refuses to publish if the tag is not on `origin/main` or if no successful `Tests` and `Benchmark` workflow runs exist for the tagged commit.
+
+Docs-only, CI-only, and maintainer-process changes can merge without a new tag.
+Cut a version when users receive a framework fix, security fix, compatibility
+fix, or feature that is worth asking them to upgrade for.
 
 ## Pre-release checklist
 
@@ -29,7 +33,7 @@ Before opening the release PR, run `./scripts/pre-release.sh` for local release 
 - [ ] PR benchmark check has no same-runner `benchstat` regression above 10% on the hot path
 - [ ] CHANGELOG.md has a section for the new version with date
 - [ ] No `replace` directives left in `transport/wing/go.mod` or any `contrib/*/go.mod`
-- [ ] Every contrib package's `go.mod` requires the new core version (not the previous one)
+- [ ] Every released submodule's `go.mod` requires the intended core version
 - [ ] Public API surface diff reviewed — additions OK, removals require a major bump
 
 ## Tagging


### PR DESCRIPTION
## Summary
- clarify that Wing is implemented in core while the legacy import path is compatibility-only
- remove the hard-coded v2 removal promise from public contributor/package docs
- document that docs-only, CI-only, and maintainer-process changes do not require a new tag

## Verification
- /usr/bin/env GOCACHE=/private/tmp/kruda-go-build-cache go test -tags kruda_stdjson ./...

No runtime code changes. No release tag.