### PR TITLE
ci: skip docs-only benchmark runs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,11 +8,21 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths-ignore:
-      - "**/*.md"
+    paths:
+      - "**/*.go"
+      - "**/go.mod"
+      - "**/go.sum"
+      - ".github/workflows/benchmark.yml"
+      - "bench/**"
+      - "scripts/**"
   pull_request:
-    paths-ignore:
-      - "**/*.md"
+    paths:
+      - "**/*.go"
+      - "**/go.mod"
+      - "**/go.sum"
+      - ".github/workflows/benchmark.yml"
+      - "bench/**"
+      - "scripts/**"
 
 permissions:
   deployments: write


### PR DESCRIPTION
## Summary
- run the Benchmark workflow only for Go, module, benchmark, script, or benchmark workflow changes
- avoid spending benchmark runner time on docs-only PRs
- keep manual workflow_dispatch available

## Verification
- git diff --check
- inspected main branch protection: required checks are Test (Go 1.25.8, ubuntu-latest) and Test (Go stable, ubuntu-latest), not Benchmark

No runtime code changes. No release tag.