### PR TITLE
security: preserve session cookie attributes on destroy

### DIFF
--- a/contrib/session/README.md
+++ b/contrib/session/README.md
@@ -35,10 +35,10 @@ app.Get("/profile", func(c *kruda.Ctx) error {
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| CookieName | string | "session_id" | Session cookie name |
-| MaxAge | time.Duration | 24*time.Hour | Session expiration |
+| CookieName | string | "_session" | Session cookie name |
+| MaxAge | int | 86400 | Session cookie max-age in seconds |
 | CookiePath | string | "/" | Cookie path |
 | CookieSecure | bool | false | HTTPS only cookie |
 | CookieHTTPOnly | bool | true | HTTP only cookie |
-| CookieSameSite | http.SameSite | SameSiteLax | SameSite policy |
+| CookieSameSite | http.SameSite | http.SameSiteLaxMode | SameSite policy |
 | Store | Store | MemoryStore | Session storage backend |

--- a/contrib/session/session.go
+++ b/contrib/session/session.go
@@ -227,11 +227,14 @@ func New(config ...Config) kruda.HandlerFunc {
 
 		if sess.destroy {
 			c.SetCookie(&kruda.Cookie{
-				Name:   cfg.CookieName,
-				Value:  "",
-				Path:   cfg.CookiePath,
-				Domain: cfg.CookieDomain,
-				MaxAge: -1,
+				Name:     cfg.CookieName,
+				Value:    "",
+				Path:     cfg.CookiePath,
+				Domain:   cfg.CookieDomain,
+				MaxAge:   -1,
+				Secure:   cfg.CookieSecure,
+				HTTPOnly: httpOnly,
+				SameSite: cfg.CookieSameSite,
 			})
 		}
 

--- a/contrib/session/session_test.go
+++ b/contrib/session/session_test.go
@@ -545,6 +545,63 @@ func TestSession_Destroy(t *testing.T) {
 	}
 }
 
+func TestSession_DestroyPreservesCookieAttributes(t *testing.T) {
+	store := NewMemoryStore()
+	defer store.Close()
+	cfg := Config{
+		Store:          store,
+		CookiePath:     "/app",
+		CookieDomain:   "example.com",
+		CookieSecure:   true,
+		CookieSameSite: http.SameSiteStrictMode,
+	}
+
+	var sessionID string
+	app := kruda.New()
+	app.Use(New(cfg))
+	app.Get("/test", func(c *kruda.Ctx) error {
+		sess := GetSession(c)
+		sess.Set("user", "alice")
+		sessionID = sess.ID()
+		c.SetContentType("application/json").SetBody(okBody)
+		return nil
+	})
+
+	resp := newMockResponse()
+	app.ServeKruda(resp, newReq("GET", "/test", nil))
+	if sessionID == "" {
+		t.Fatal("expected session ID")
+	}
+
+	app2 := kruda.New()
+	app2.Use(New(cfg))
+	app2.Get("/test", func(c *kruda.Ctx) error {
+		GetSession(c).Destroy()
+		c.SetContentType("application/json").SetBody(okBody)
+		return nil
+	})
+
+	resp2 := newMockResponse()
+	app2.ServeKruda(resp2, newReq("GET", "/test", map[string]string{
+		"_session": sessionID,
+	}))
+
+	setCookie := resp2.headers.Get("Set-Cookie")
+	checks := []string{
+		"Path=/app",
+		"Domain=example.com",
+		"Max-Age=0",
+		"Secure",
+		"HttpOnly",
+		"SameSite=Strict",
+	}
+	for _, want := range checks {
+		if !strings.Contains(setCookie, want) {
+			t.Fatalf("expected destroy Set-Cookie to contain %q, got %q", want, setCookie)
+		}
+	}
+}
+
 func TestSession_SkipFunction(t *testing.T) {
 	cfg := Config{
 		Skip: func(method, path string) bool {


### PR DESCRIPTION
## Summary
- Preserve configured Secure, HttpOnly, and SameSite attributes when destroying a session cookie.
- Add a regression test for the destroy Set-Cookie attributes.
- Correct session README defaults for CookieName, MaxAge, and CookieSameSite.

## Verification
- `go test -count=1 -tags kruda_stdjson ./...` from the repository root
- `GOWORK=off go test -count=1 -tags kruda_stdjson ./...` from `contrib/session`
- `git diff --check`

## Performance
- This change only affects the session destroy response path in the contrib module and does not touch Kruda request routing or transport hot paths.