### PR TITLE
docs: add session cookie security guidance

### DIFF
--- a/contrib/session/README.md
+++ b/contrib/session/README.md
@@ -31,6 +31,28 @@ app.Get("/profile", func(c *kruda.Ctx) error {
 })
 ```
 
+## Production Cookie Settings
+
+For HTTPS deployments, enable the `Secure` flag and choose a `SameSite` mode
+that matches your app's cross-site flow. Keep `CookieHTTPOnly` enabled unless
+JavaScript must read the session cookie.
+
+```go
+app.Use(session.New(session.Config{
+    CookieSecure:   true,
+    CookieHTTPOnly: true,
+    CookieSameSite: http.SameSiteLaxMode,
+}))
+```
+
+Use `http.SameSiteStrictMode` for same-site apps that do not need cross-site
+login or callback flows. If you set `http.SameSiteNoneMode`, browsers require
+`CookieSecure: true`.
+
+Call `sess.Destroy()` on logout. The delete cookie keeps the configured path,
+domain, `Secure`, `HttpOnly`, and `SameSite` attributes so browsers remove the
+same cookie that was issued.
+
 ## Config
 
 | Option | Type | Default | Description |

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -259,6 +259,18 @@ app.Use(session.New(session.Config{
 }))
 ```
 
+Production guidance:
+
+- Keep `CookieHTTPOnly` enabled so browser JavaScript cannot read session IDs.
+- Set `CookieSecure: true` on HTTPS deployments.
+- Use `http.SameSiteLaxMode` for most browser apps, or `http.SameSiteStrictMode`
+  when cross-site login and callback flows are not needed.
+- If `http.SameSiteNoneMode` is required, also set `CookieSecure: true`.
+- Use a shared persistent `Store` for multi-instance deployments; the default
+  memory store is single-process only.
+- Call `sess.Destroy()` on logout. Kruda expires the cookie using the configured
+  path, domain, `Secure`, `HttpOnly`, and `SameSite` attributes.
+
 **Custom store:** Implement the `Store` interface for Redis, database, or other backends:
 
 ```go


### PR DESCRIPTION
## Summary
- Add production guidance for session cookie Secure, HttpOnly, and SameSite settings.
- Document how logout cookie deletion preserves configured cookie attributes.
- Mirror the guidance in the security guide and contrib/session README.

## Verification
- `git diff --check`
- `npm run build --prefix docs`