### PR TITLE
ci: centralize standalone module tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,30 +58,16 @@ jobs:
         # doesn't exist on the proxy until release. For PR CI we add a local
         # replace so tests can resolve kruda from the working tree. The replace
         # is ephemeral (CI runner only) — never committed.
-        run: |
-          cd transport/wing
-          go mod edit -replace=github.com/go-kruda/kruda=../..
-          go mod tidy
-          go test -v -race ./...
+        run: scripts/test-standalone-modules.sh --verbose --race transport/wing
 
       - name: Test contrib packages
         shell: bash
-        # Same ephemeral-replace dance as wing — contrib modules require the new
-        # kruda tag which doesn't exist until release.
-        run: |
-          for dir in contrib/jwt contrib/ws contrib/ratelimit contrib/session contrib/compress contrib/etag contrib/cache contrib/otel contrib/prometheus contrib/swagger; do
-            echo "::group::Testing $dir"
-            (
-              cd "$dir"
-              go mod edit -replace=github.com/go-kruda/kruda=../..
-              go mod tidy
-              go test -tags kruda_stdjson ./...
-            )
-            echo "::endgroup::"
-          done
+        # Dynamically discovers contrib modules so new modules cannot be missed
+        # by a stale hardcoded CI list.
+        run: scripts/test-standalone-modules.sh contrib
 
       - name: Test CLI
-        run: cd cmd/kruda && go test -tags kruda_stdjson ./...
+        run: scripts/test-standalone-modules.sh cmd/kruda
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.go-version == 'stable'

--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -45,51 +45,8 @@ go test -race -tags kruda_stdjson ./...
 ok "tests passed"
 
 section "standalone module tests"
-test_replaced_module() {
-  local module_dir=$1
-  local gomod_backup gosum_backup
-
-  gomod_backup=$(mktemp)
-  cp "$module_dir/go.mod" "$gomod_backup"
-  if [[ -f "$module_dir/go.sum" ]]; then
-    gosum_backup=$(mktemp)
-    cp "$module_dir/go.sum" "$gosum_backup"
-  else
-    gosum_backup=""
-  fi
-
-  (
-    set -euo pipefail
-    cd "$module_dir"
-    trap 'cp "$gomod_backup" go.mod; if [[ -n "$gosum_backup" ]]; then cp "$gosum_backup" go.sum; else rm -f go.sum; fi' EXIT
-    GOWORK=off go mod edit -replace github.com/go-kruda/kruda="$ROOT"
-    GOWORK=off go mod tidy
-    GOWORK=off go test -tags kruda_stdjson ./...
-  )
-
-  rm -f "$gomod_backup"
-  if [[ -n "$gosum_backup" ]]; then
-    rm -f "$gosum_backup"
-  fi
-}
-
-test_plain_module() {
-  local module_dir=$1
-  (cd "$module_dir" && GOWORK=off go test -tags kruda_stdjson ./...)
-}
-
-for dir in contrib/*/; do
-  if [[ -f "$dir/go.mod" ]]; then
-    test_replaced_module "${dir%/}"
-    ok "${dir%/}"
-  fi
-done
-
-test_replaced_module "transport/wing"
-ok "transport/wing"
-
-test_plain_module "cmd/kruda"
-ok "cmd/kruda"
+scripts/test-standalone-modules.sh
+ok "standalone modules"
 
 section "cross-platform builds"
 GOOS=linux go build ./...

--- a/scripts/test-standalone-modules.sh
+++ b/scripts/test-standalone-modules.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Test Kruda standalone modules with an ephemeral local replace.
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+
+race=false
+verbose=false
+modules=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --race)
+      race=true
+      shift
+      ;;
+    --verbose)
+      verbose=true
+      shift
+      ;;
+    contrib)
+      while IFS= read -r dir; do
+        modules+=("$dir")
+      done < <(find contrib -mindepth 2 -maxdepth 2 -name go.mod -print | sed 's#/go.mod$##' | sort)
+      shift
+      ;;
+    *)
+      modules+=("${1%/}")
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#modules[@]} -eq 0 ]]; then
+  while IFS= read -r dir; do
+    modules+=("$dir")
+  done < <(find contrib -mindepth 2 -maxdepth 2 -name go.mod -print | sed 's#/go.mod$##' | sort)
+  modules+=("transport/wing" "cmd/kruda")
+fi
+
+test_flags=(-tags kruda_stdjson)
+if [[ "$race" == true ]]; then
+  test_flags=(-race "${test_flags[@]}")
+fi
+if [[ "$verbose" == true ]]; then
+  test_flags=(-v "${test_flags[@]}")
+fi
+
+restore_module() {
+  local module_dir=$1
+  local gomod_backup=$2
+  local gosum_backup=$3
+
+  cp "$gomod_backup" "$module_dir/go.mod"
+  if [[ -n "$gosum_backup" ]]; then
+    cp "$gosum_backup" "$module_dir/go.sum"
+  else
+    rm -f "$module_dir/go.sum"
+  fi
+}
+
+test_replaced_module() {
+  local module_dir=$1
+  local gomod_backup gosum_backup status
+
+  gomod_backup=$(mktemp)
+  cp "$module_dir/go.mod" "$gomod_backup"
+  if [[ -f "$module_dir/go.sum" ]]; then
+    gosum_backup=$(mktemp)
+    cp "$module_dir/go.sum" "$gosum_backup"
+  else
+    gosum_backup=""
+  fi
+
+  status=0
+  (
+    cd "$module_dir"
+    GOWORK=off go mod edit -replace github.com/go-kruda/kruda="$ROOT"
+    GOWORK=off go mod tidy
+    GOWORK=off go test "${test_flags[@]}" ./...
+  ) || status=$?
+  restore_module "$module_dir" "$gomod_backup" "$gosum_backup"
+  rm -f "$gomod_backup" "$gosum_backup"
+  return "$status"
+}
+
+test_plain_module() {
+  local module_dir=$1
+  (cd "$module_dir" && GOWORK=off go test "${test_flags[@]}" ./...)
+}
+
+for module_dir in "${modules[@]}"; do
+  if [[ ! -f "$module_dir/go.mod" ]]; then
+    echo "missing go.mod: $module_dir" >&2
+    exit 1
+  fi
+
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::group::Testing $module_dir"
+  else
+    echo "==> Testing $module_dir"
+  fi
+
+  if [[ "$module_dir" == "cmd/kruda" ]]; then
+    test_plain_module "$module_dir"
+  else
+    test_replaced_module "$module_dir"
+  fi
+
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::endgroup::"
+  fi
+done


### PR DESCRIPTION
## Summary
- Add a reusable script for standalone module verification with ephemeral local replace directives.
- Use the script from CI for Wing, contrib modules, and the CLI.
- Reuse the same script from pre-release validation to avoid drift between CI and release checks.

## Verification
- `git diff --check`
- `bash -n scripts/test-standalone-modules.sh scripts/pre-release.sh`
- `scripts/test-standalone-modules.sh contrib/session cmd/kruda`
- `scripts/test-standalone-modules.sh --verbose --race transport/wing`
- `scripts/test-standalone-modules.sh`