### PR TITLE
security: preserve headers on fast responses

### DIFF
--- a/ctx_fasthttp_test.go
+++ b/ctx_fasthttp_test.go
@@ -796,6 +796,20 @@ func TestTryFastHTTPText_NoCtx(t *testing.T) {
 	}
 }
 
+func TestTryFastHTTPText_PendingHeadersFallback(t *testing.T) {
+	app := New()
+	c, _ := newFastHTTPCtx(app)
+	c.AddHeader("Vary", "Origin")
+
+	ok := c.tryFastHTTPText("hello")
+	if ok {
+		t.Fatal("expected false when headers still need generic flush")
+	}
+	if c.responded {
+		t.Fatal("responded should remain false")
+	}
+}
+
 // --- tryFastHTTPJSON ---
 
 func TestTryFastHTTPJSON(t *testing.T) {
@@ -822,6 +836,20 @@ func TestTryFastHTTPJSON_NoCtx(t *testing.T) {
 	ok := c.tryFastHTTPJSON([]byte("{}"))
 	if ok {
 		t.Fatal("expected false")
+	}
+}
+
+func TestTryFastHTTPJSON_PendingCookieFallback(t *testing.T) {
+	app := New()
+	c, _ := newFastHTTPCtx(app)
+	c.SetCookie(&Cookie{Name: "sid", Value: "abc"})
+
+	ok := c.tryFastHTTPJSON([]byte("{}"))
+	if ok {
+		t.Fatal("expected false when cookies still need generic flush")
+	}
+	if c.responded {
+		t.Fatal("responded should remain false")
 	}
 }
 

--- a/ctx_response.go
+++ b/ctx_response.go
@@ -66,7 +66,7 @@ func (c *Ctx) JSON(v any) error {
 
 	// Wing fast path: Marshal → SetJSON directly, skip pooled buffer.
 	if jr, ok := c.writer.(transport.JSONResponder); ok {
-		if len(c.cookies) == 0 && len(c.respHeaders) == 0 {
+		if c.canBypassHeaderWrite(true) {
 			data, err := c.app.config.JSONEncoder(v)
 			if err != nil {
 				return err
@@ -124,9 +124,11 @@ func (c *Ctx) jsonSend(data []byte) error {
 	}
 	// Fast path for Wing transport — bypass header interface entirely
 	if jr, ok := c.writer.(transport.JSONResponder); ok {
-		c.responded = true
-		jr.SetJSON(c.status, data)
-		return nil
+		if c.canBypassHeaderWrite(true) {
+			c.responded = true
+			jr.SetJSON(c.status, data)
+			return nil
+		}
 	}
 	// Fast path for net/http embedded adapter — bypass transport interface
 	if w := &c.embeddedResp; w.w != nil {
@@ -163,9 +165,11 @@ func (c *Ctx) Text(s string) error {
 	}
 	// Fast path for transports with pre-built static response support (e.g., Wing)
 	if sr, ok := c.writer.(transport.StaticTextResponder); ok {
-		c.responded = true
-		sr.SetStaticText(c.status, "text/plain; charset=utf-8", s)
-		return nil
+		if c.canBypassHeaderWrite(true) {
+			c.responded = true
+			sr.SetStaticText(c.status, "text/plain; charset=utf-8", s)
+			return nil
+		}
 	}
 	// Fast path for net/http embedded adapter - bypass transport interface
 	if w := &c.embeddedResp; w.w != nil {
@@ -183,6 +187,13 @@ func (c *Ctx) Text(s string) error {
 	}
 	c.contentType = "text/plain; charset=utf-8"
 	return c.sendBytes([]byte(s))
+}
+
+func (c *Ctx) canBypassHeaderWrite(includeSecurityHeaders bool) bool {
+	if c.cacheControl != "" || c.location != "" || len(c.respHeaders) != 0 || len(c.cookies) != 0 {
+		return false
+	}
+	return !includeSecurityHeaders || c.app == nil || len(c.app.secHeaders) == 0
 }
 
 // HTML sends an HTML response (raw string, no template).

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -6,7 +6,7 @@ For vulnerability reporting, see [SECURITY.md](https://github.com/go-kruda/kruda
 
 ## Security Headers
 
-When enabled via `WithSecureHeaders()`, every response includes these headers:
+When enabled via `WithSecureHeaders()`, normal handler responses include these headers:
 
 | Header | Default Value | Purpose |
 |--------|--------------|---------|
@@ -15,7 +15,9 @@ When enabled via `WithSecureHeaders()`, every response includes these headers:
 | `X-XSS-Protection` | `0` | Disabled per modern best practice (CSP preferred) |
 | `Referrer-Policy` | `strict-origin-when-cross-origin` | Controls referrer information |
 
-The `Server: Kruda` header is sent by default (no version number is leaked).
+Kruda does not emit a `Server` header by default, so framework identity and version details are not exposed by normal responses.
+
+Prebuilt Wing static responses are written directly for maximum throughput and bypass middleware/header injection. Prefer normal handlers when a response needs CORS, cookies, or `WithSecureHeaders()`.
 
 ```go
 // Explicitly enable security headers

--- a/docs/guide/transport.md
+++ b/docs/guide/transport.md
@@ -8,7 +8,7 @@ Kruda ships with three transports. The default is **Wing** on Linux, **fasthttp*
 |---------------|-----------|-----|
 | Maximum throughput (plaintext, JSON, DB) | **Wing** (default on Linux) | epoll+eventfd, zero-copy, no goroutine-per-conn |
 | SSE (Server-Sent Events) | **net/http** | SSE requires `http.Flusher` streaming |
-| Session cookies / Set-Cookie headers | **net/http** | Wing's fast path skips custom headers |
+| Session cookies / Set-Cookie headers | **Wing** or **net/http** | Wing keeps headers by falling back from its zero-copy fast path when needed |
 | HTTP/2, TLS termination | **net/http** | Wing is HTTP/1.1 only |
 | WebSocket | **net/http** | WebSocket upgrade needs full HTTP semantics |
 | Battle-tested HTTP/1.1 (chunked, expect-100) | **fasthttp** | Mature, widely deployed |
@@ -47,7 +47,7 @@ KRUDA_TRANSPORT=fasthttp ./myapp   # force fasthttp
 
 Wing is optimized for raw throughput. It intentionally skips some HTTP features:
 
-- **No `Set-Cookie` in JSON fast path** — Wing's JSON response builder bypasses custom headers for speed. Use `kruda.NetHTTP()` if your routes need cookies.
+- **Prebuilt static responses bypass middleware** — route-level prebuilt responses are written directly. Use normal handlers when a response needs CORS, cookies, or `WithSecureHeaders()`.
 - **No `http.Flusher`** — SSE streaming requires flushing, which Wing doesn't support.
 - **No HTTP/2** — Wing speaks HTTP/1.1 only. Use `kruda.NetHTTP()` with TLS for HTTP/2.
 - **No chunked transfer encoding** — Wing pre-computes Content-Length.

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -405,6 +405,23 @@ func TestCORS_AllowCredentialsPanicOnWildcard(t *testing.T) {
 	})
 }
 
+func TestCORS_InvalidOriginPanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for invalid origin")
+		}
+		msg, ok := r.(string)
+		if !ok || !strings.Contains(msg, "invalid origin") {
+			t.Fatalf("expected panic about invalid origin, got %v", r)
+		}
+	}()
+
+	CORS(CORSConfig{
+		AllowOrigins: []string{"https://"},
+	})
+}
+
 func TestCORS_SpecificOrigin(t *testing.T) {
 	handler := func(c *kruda.Ctx) error {
 		return c.JSON(kruda.Map{"ok": true})
@@ -432,6 +449,9 @@ func TestCORS_SpecificOrigin(t *testing.T) {
 
 	if resp2.headers.Get("Access-Control-Allow-Origin") != "" {
 		t.Fatalf("expected no Allow-Origin for non-matching origin, got %q", resp2.headers.Get("Access-Control-Allow-Origin"))
+	}
+	if resp2.headers.Get("Vary") != "Origin" {
+		t.Fatalf("expected Vary=Origin for non-matching origin, got %q", resp2.headers.Get("Vary"))
 	}
 }
 
@@ -797,6 +817,68 @@ func TestCORS_PreflightCustomHeaders(t *testing.T) {
 	headers := resp.headers.Get("Access-Control-Allow-Headers")
 	if !strings.Contains(headers, "X-Custom-Auth") {
 		t.Errorf("expected X-Custom-Auth in allowed headers, got %q", headers)
+	}
+}
+
+func TestCORS_PreflightDisallowedOriginFallsThroughWithoutCORSHeaders(t *testing.T) {
+	handler := func(c *kruda.Ctx) error {
+		return c.JSON(kruda.Map{"ok": true})
+	}
+
+	app := kruda.New()
+	app.Use(CORS(CORSConfig{
+		AllowOrigins: []string{"https://allowed.example"},
+	}))
+	app.Options("/test", handler)
+
+	req := optionsReq(map[string]string{
+		"Origin":                        "https://evil.example",
+		"Access-Control-Request-Method": "POST",
+	})
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 200 {
+		t.Fatalf("expected fallthrough handler status 200, got %d", resp.statusCode)
+	}
+	if resp.headers.Get("Access-Control-Allow-Origin") != "" {
+		t.Fatalf("expected no Allow-Origin for disallowed origin, got %q", resp.headers.Get("Access-Control-Allow-Origin"))
+	}
+	if resp.headers.Get("Access-Control-Allow-Methods") != "" {
+		t.Fatalf("expected no Allow-Methods for disallowed origin, got %q", resp.headers.Get("Access-Control-Allow-Methods"))
+	}
+	if resp.headers.Get("Vary") != "Origin" {
+		t.Fatalf("expected Vary=Origin for disallowed origin, got %q", resp.headers.Get("Vary"))
+	}
+}
+
+func TestCORS_PreflightCredentialsWithSpecificOrigin(t *testing.T) {
+	handler := func(c *kruda.Ctx) error {
+		return c.JSON(kruda.Map{"ok": true})
+	}
+
+	app := kruda.New()
+	app.Use(CORS(CORSConfig{
+		AllowOrigins:     []string{"https://trusted.example"},
+		AllowCredentials: true,
+	}))
+	app.Options("/test", handler)
+
+	req := optionsReq(map[string]string{
+		"Origin":                        "https://trusted.example",
+		"Access-Control-Request-Method": "POST",
+	})
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 204 {
+		t.Fatalf("expected 204, got %d", resp.statusCode)
+	}
+	if resp.headers.Get("Access-Control-Allow-Origin") != "https://trusted.example" {
+		t.Fatalf("expected trusted Allow-Origin, got %q", resp.headers.Get("Access-Control-Allow-Origin"))
+	}
+	if resp.headers.Get("Access-Control-Allow-Credentials") != "true" {
+		t.Fatalf("expected Allow-Credentials=true, got %q", resp.headers.Get("Access-Control-Allow-Credentials"))
 	}
 }
 

--- a/serve_fast.go
+++ b/serve_fast.go
@@ -310,6 +310,9 @@ func (h *fhHeaderAdapter) Add(key, value string) { h.ctx.Response.Header.Add(key
 // Returns true if successful (fasthttp context available), false otherwise.
 func (c *Ctx) tryFastHTTPText(s string) bool {
 	if c.embeddedFHResp.ctx != nil {
+		if !c.canBypassHeaderWrite(false) {
+			return false
+		}
 		c.responded = true
 		ctx := c.embeddedFHResp.ctx
 		ctx.SetStatusCode(c.status)
@@ -333,6 +336,9 @@ func (c *Ctx) tryFastHTTPJSONDirect(v any) bool {
 	if c.embeddedFHResp.ctx == nil {
 		return false
 	}
+	if !c.canBypassHeaderWrite(false) {
+		return false
+	}
 	enc := c.app.config.JSONEncoder
 	if enc == nil {
 		return false
@@ -354,6 +360,9 @@ func (c *Ctx) tryFastHTTPJSONDirect(v any) bool {
 // Returns true if successful (fasthttp context available), false otherwise.
 func (c *Ctx) tryFastHTTPJSON(data []byte) bool {
 	if c.embeddedFHResp.ctx != nil {
+		if !c.canBypassHeaderWrite(false) {
+			return false
+		}
 		c.responded = true
 		ctx := c.embeddedFHResp.ctx
 		ctx.SetStatusCode(c.status)

--- a/transport/security_header_test.go
+++ b/transport/security_header_test.go
@@ -1,0 +1,17 @@
+//go:build !race
+
+package transport
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestStaticResponseDoesNotEmitServerHeader(t *testing.T) {
+	body := "ok-" + t.Name()
+	resp := GetStaticResponseString(200, "text/plain", body)
+
+	if bytes.Contains(resp, []byte("\r\nServer:")) {
+		t.Fatal("static response should not emit Server header")
+	}
+}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -181,7 +181,7 @@ func getStaticByKey(status int, contentType, key string, body []byte) []byte {
 	b = append(b, "Date: "...)
 	dateOffset := len(b)
 	b = append(b, time.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05 GMT")...)
-	b = append(b, "\r\nServer: Kruda\r\n"...)
+	b = append(b, "\r\n"...)
 	if contentType != "" {
 		b = append(b, "Content-Type: "...)
 		b = append(b, contentType...)

--- a/wing_http.go
+++ b/wing_http.go
@@ -619,11 +619,11 @@ func wingInternMethod(b []byte) string {
 }
 
 func updateDateHdr() {
-	b := []byte("Date: " + time.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05 GMT") + "\r\nServer: Kruda\r\n")
+	b := []byte("Date: " + time.Now().UTC().Format("Mon, 02 Jan 2006 15:04:05 GMT") + "\r\n")
 	cachedDateHdr.Store(&b)
 }
 
-// dateHdr returns the cached Date+Server header chunk.
+// dateHdr returns the cached Date header chunk.
 func dateHdr() []byte {
 	return *cachedDateHdr.Load()
 }
@@ -639,7 +639,7 @@ func (r *wingResponse) buildZeroCopy() []byte {
 	}
 	b := r.buf[:0]
 
-	// JSON fast path — status + Date+Server + Content-Type:json + Content-Length + body
+	// JSON fast path — status + Date + Content-Type:json + Content-Length + body
 	if r.jsonFast {
 		if r.status > 0 && r.status < len(statusLines) && statusLines[r.status] != nil {
 			b = append(b, statusLines[r.status]...)
@@ -664,7 +664,7 @@ func (r *wingResponse) buildZeroCopy() []byte {
 		b = append(b, " Unknown\r\n"...)
 	}
 
-	// Fixed headers: Date + Server (combined in dateHdr)
+	// Fixed headers: Date.
 	b = append(b, dateHdr()...)
 
 	// Headers — check for Content-Length in the same loop.

--- a/wing_security_header_test.go
+++ b/wing_security_header_test.go
@@ -1,0 +1,60 @@
+//go:build linux || darwin
+
+package kruda
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestWingDateHeaderDoesNotEmitServerHeader(t *testing.T) {
+	if bytes.Contains(dateHdr(), []byte("\r\nServer:")) {
+		t.Fatal("wing date header chunk should not emit Server header")
+	}
+}
+
+func TestWingAppTextWithSecureHeadersDoesNotEmitServerAndKeepsSecurityHeaders(t *testing.T) {
+	app := New(Wing(), WithSecureHeaders())
+	app.Get("/text", func(c *Ctx) error { return c.Text("ok") })
+	app.Compile()
+
+	resp := serveWingResponse(t, app, "GET", "/text")
+
+	if got := resp.headers.Get("Server"); got != "" {
+		t.Fatalf("Server header should not be present, got %q", got)
+	}
+	if got := resp.headers.Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatal("expected X-Content-Type-Options=nosniff")
+	}
+	if !bytes.Contains(resp.body, []byte("ok")) {
+		t.Fatal("expected text response body")
+	}
+}
+
+func TestWingAppJSONWithSecureHeadersDoesNotEmitServerAndKeepsSecurityHeaders(t *testing.T) {
+	app := New(Wing(), WithSecureHeaders())
+	app.Get("/json", func(c *Ctx) error { return c.JSON(Map{"ok": true}) })
+	app.Compile()
+
+	resp := serveWingResponse(t, app, "GET", "/json")
+
+	if got := resp.headers.Get("Server"); got != "" {
+		t.Fatalf("Server header should not be present, got %q", got)
+	}
+	if got := resp.headers.Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatal("expected X-Content-Type-Options=nosniff")
+	}
+	if !bytes.Contains(resp.body, []byte(`"ok":true`)) {
+		t.Fatal("expected JSON response body")
+	}
+}
+
+func serveWingResponse(t *testing.T, app *App, method, path string) *wingResponse {
+	t.Helper()
+
+	resp := acquireResponse()
+	t.Cleanup(func() { releaseResponse(resp) })
+
+	app.ServeKruda(resp, &wingRequest{method: method, path: path})
+	return resp
+}


### PR DESCRIPTION
## Summary
- Preserve pending headers, cookies, and opt-in security headers by falling back from JSON/text fast paths when needed
- Remove default Server header emission from Wing and static response builders
- Expand CORS and response-header regression coverage, plus update security and transport docs

## Verification
- go test -count=1 -tags kruda_stdjson ./...
- go test -race -count=1 -tags kruda_stdjson ./...
- npm run build --prefix docs
- GOWORK=off go test -run '^$' -bench 'BenchmarkKruda_NoSecurityHeaders$' -benchmem -count=5 ./bench