### PR TITLE
fix: preserve overflow wing headers

### DIFF
--- a/wing_http.go
+++ b/wing_http.go
@@ -496,7 +496,7 @@ var respPool = sync.Pool{
 func acquireResponse() *wingResponse {
 	r := respPool.Get().(*wingResponse)
 	r.status = 200
-	r.headers.count = 0
+	r.headers.reset()
 	r.body = r.body[:0]
 	r.buf = r.buf[:0]
 	r.staticResp = nil
@@ -511,7 +511,7 @@ func releaseResponse(r *wingResponse) {
 	r.jsonFast = false
 	r.fileFd = 0
 	r.fileSize = 0
-	r.headers.count = 0
+	r.headers.reset()
 	if cap(r.buf) > 65536 {
 		r.buf = make([]byte, 0, 2048)
 	} else {
@@ -678,6 +678,15 @@ func (r *wingResponse) buildZeroCopy() []byte {
 			hasCL = true
 		}
 	}
+	for i := 0; i < len(r.headers.extra); i++ {
+		b = append(b, r.headers.extra[i].key...)
+		b = append(b, ": "...)
+		b = append(b, r.headers.extra[i].val...)
+		b = append(b, "\r\n"...)
+		if !hasCL && r.headers.extra[i].key == "Content-Length" {
+			hasCL = true
+		}
+	}
 	if !hasCL {
 		b = append(b, "Content-Length: "...)
 		b = strconv.AppendInt(b, int64(len(r.body)), 10)
@@ -715,6 +724,12 @@ func (r *wingResponse) buildHeadersOnly() []byte {
 		b = append(b, r.headers.vals[i]...)
 		b = append(b, "\r\n"...)
 	}
+	for i := 0; i < len(r.headers.extra); i++ {
+		b = append(b, r.headers.extra[i].key...)
+		b = append(b, ": "...)
+		b = append(b, r.headers.extra[i].val...)
+		b = append(b, "\r\n"...)
+	}
 	b = append(b, "Content-Length: "...)
 	b = strconv.AppendInt(b, r.fileSize, 10)
 	b = append(b, "\r\n\r\n"...)
@@ -728,7 +743,21 @@ func (r *wingResponse) buildHeadersOnly() []byte {
 type wingHeaders struct {
 	keys  [8]string
 	vals  [8]string
+	extra []wingHeader
 	count int
+}
+
+type wingHeader struct {
+	key string
+	val string
+}
+
+func (h *wingHeaders) reset() {
+	h.count = 0
+	for i := range h.extra {
+		h.extra[i] = wingHeader{}
+	}
+	h.extra = h.extra[:0]
 }
 
 func (h *wingHeaders) Set(key, value string) {
@@ -738,11 +767,19 @@ func (h *wingHeaders) Set(key, value string) {
 			return
 		}
 	}
+	for i := 0; i < len(h.extra); i++ {
+		if h.extra[i].key == key {
+			h.extra[i].val = value
+			return
+		}
+	}
 	if h.count < len(h.keys) {
 		h.keys[h.count] = key
 		h.vals[h.count] = value
 		h.count++
+		return
 	}
+	h.extra = append(h.extra, wingHeader{key: key, val: value})
 }
 
 // Add appends a new key-value pair without replacing existing keys.
@@ -752,13 +789,20 @@ func (h *wingHeaders) Add(key, value string) {
 		h.keys[h.count] = key
 		h.vals[h.count] = value
 		h.count++
+		return
 	}
+	h.extra = append(h.extra, wingHeader{key: key, val: value})
 }
 
 func (h *wingHeaders) Get(key string) string {
 	for i := 0; i < h.count; i++ {
 		if h.keys[i] == key {
 			return h.vals[i]
+		}
+	}
+	for i := 0; i < len(h.extra); i++ {
+		if h.extra[i].key == key {
+			return h.extra[i].val
 		}
 	}
 	return ""
@@ -771,6 +815,16 @@ func (h *wingHeaders) Del(key string) {
 			h.keys[i] = h.keys[h.count]
 			h.vals[i] = h.vals[h.count]
 			// Don't increment — recheck swapped element.
+		} else {
+			i++
+		}
+	}
+	for i := 0; i < len(h.extra); {
+		if h.extra[i].key == key {
+			last := len(h.extra) - 1
+			h.extra[i] = h.extra[last]
+			h.extra[last] = wingHeader{}
+			h.extra = h.extra[:last]
 		} else {
 			i++
 		}

--- a/wing_http_test.go
+++ b/wing_http_test.go
@@ -3,6 +3,7 @@
 package kruda
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"testing"
@@ -233,6 +234,26 @@ func TestResponseBuild(t *testing.T) {
 	}
 	if !strings.HasSuffix(s, "\r\n\r\nhello") {
 		t.Errorf("response doesn't end with body: %q", s[len(s)-20:])
+	}
+}
+
+func TestResponseBuildIncludesHeadersBeyondInlineCapacity(t *testing.T) {
+	resp := acquireResponse()
+	defer releaseResponse(resp)
+
+	resp.WriteHeader(204)
+	for i := 0; i < 10; i++ {
+		resp.Header().Set(fmt.Sprintf("X-Test-%02d", i), fmt.Sprintf("value-%02d", i))
+	}
+
+	data := resp.build()
+	s := string(data)
+
+	for i := 0; i < 10; i++ {
+		want := fmt.Sprintf("X-Test-%02d: value-%02d\r\n", i, i)
+		if !strings.Contains(s, want) {
+			t.Fatalf("response is missing header %q\nresponse:\n%s", want, s)
+		}
 	}
 }
 

--- a/wing_security_header_test.go
+++ b/wing_security_header_test.go
@@ -49,6 +49,45 @@ func TestWingAppJSONWithSecureHeadersDoesNotEmitServerAndKeepsSecurityHeaders(t 
 	}
 }
 
+func TestWingPreflightWithSecureHeadersKeepsAllHeaders(t *testing.T) {
+	app := New(Wing(), WithSecureHeaders())
+	app.Use(func(c *Ctx) error {
+		if c.Method() == "OPTIONS" {
+			c.AddHeader("Vary", "Origin")
+			c.SetHeader("Access-Control-Allow-Origin", "https://example.com")
+			c.SetHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			c.SetHeader("Access-Control-Allow-Headers", "Origin, Content-Type, Authorization")
+			c.SetHeader("Access-Control-Max-Age", "86400")
+			c.SetHeader("Access-Control-Allow-Credentials", "true")
+			return c.NoContent()
+		}
+		return c.Next()
+	})
+	app.Options("/resource", func(c *Ctx) error { return c.NoContent() })
+	app.Get("/resource", func(c *Ctx) error { return c.Text("ok") })
+	app.Compile()
+
+	resp := serveWingResponse(t, app, "OPTIONS", "/resource")
+
+	expected := map[string]string{
+		"Vary":                             "Origin",
+		"Access-Control-Allow-Origin":      "https://example.com",
+		"Access-Control-Allow-Methods":     "GET, POST, OPTIONS",
+		"Access-Control-Allow-Headers":     "Origin, Content-Type, Authorization",
+		"Access-Control-Max-Age":           "86400",
+		"Access-Control-Allow-Credentials": "true",
+		"X-Content-Type-Options":           "nosniff",
+		"X-Frame-Options":                  "DENY",
+		"X-Xss-Protection":                 "0",
+		"Referrer-Policy":                  "strict-origin-when-cross-origin",
+	}
+	for key, want := range expected {
+		if got := resp.headers.Get(key); got != want {
+			t.Fatalf("%s = %q, want %q\nresponse:\n%s", key, got, want, string(resp.build()))
+		}
+	}
+}
+
 func serveWingResponse(t *testing.T, app *App, method, path string) *wingResponse {
 	t.Helper()
 


### PR DESCRIPTION
## Summary
- Preserve Wing response headers beyond the 8 inline slots using a lazy overflow slice.
- Include overflow headers during normal response and sendfile header serialization.
- Add regression coverage for overflow headers and secure preflight responses.

## Root Cause
Wing response headers used a fixed 8-slot inline array. When middleware and security headers exceeded that capacity, additional headers were silently dropped.

## Performance
- The first 8 headers remain inline.
- Overflow storage is allocated only when a response exceeds the inline capacity.
- Hot-path benchmark allocation count stayed unchanged at `472 B/op` and `4 allocs/op`.
- `BenchmarkCPUResponseBuild` with `-benchtime=2s -count=5`:
  - branch: `145.2`, `143.3`, `145.0`, `149.0`, `149.1 ns/op`
  - main: `151.6`, `158.0`, `149.9`, `150.5`, `149.9 ns/op`

## Verification
- `go test -count=1 -run 'TestResponseBuildIncludesHeadersBeyondInlineCapacity|TestWingPreflightWithSecureHeadersKeepsAllHeaders'`
- `go test -count=1 -run 'TestResponseBuild|TestIOHeadersDel|TestWing'`
- `go test -count=1 -tags kruda_stdjson ./...`
- `go test -race -count=1 -tags kruda_stdjson ./...`
- `go test -run '^$' -bench 'BenchmarkCPUResponse(Build|JSON)$' -benchmem -count=10`
- `go test -run '^$' -bench 'BenchmarkCPUResponseBuild$' -benchmem -benchtime=2s -count=5`
