### PR TITLE
fix: preserve nethttp headers on fast responses

### DIFF
--- a/ctx_response.go
+++ b/ctx_response.go
@@ -132,23 +132,25 @@ func (c *Ctx) jsonSend(data []byte) error {
 	}
 	// Fast path for net/http embedded adapter — bypass transport interface
 	if w := &c.embeddedResp; w.w != nil {
-		c.responded = true
-		h := w.w.Header()
-		if w.contentTypeSlice == nil {
-			w.contentTypeSlice = make([]string, 1)
+		if c.canBypassHeaderWrite(false) {
+			c.responded = true
+			h := w.w.Header()
+			if w.contentTypeSlice == nil {
+				w.contentTypeSlice = make([]string, 1)
+			}
+			w.contentTypeSlice[0] = "application/json; charset=utf-8"
+			h["Content-Type"] = w.contentTypeSlice
+			cl := len(data)
+			if cl < len(contentLengthStrings) {
+				h["Content-Length"] = []string{contentLengthStrings[cl]}
+			} else {
+				h["Content-Length"] = []string{strconv.Itoa(cl)}
+			}
+			w.w.WriteHeader(c.status)
+			w.written = true
+			_, _ = w.w.Write(data)
+			return nil
 		}
-		w.contentTypeSlice[0] = "application/json; charset=utf-8"
-		h["Content-Type"] = w.contentTypeSlice
-		cl := len(data)
-		if cl < len(contentLengthStrings) {
-			h["Content-Length"] = []string{contentLengthStrings[cl]}
-		} else {
-			h["Content-Length"] = []string{strconv.Itoa(cl)}
-		}
-		w.w.WriteHeader(c.status)
-		w.written = true
-		_, _ = w.w.Write(data)
-		return nil
 	}
 	c.contentType = "application/json; charset=utf-8"
 	return c.sendBytes(data)
@@ -173,17 +175,19 @@ func (c *Ctx) Text(s string) error {
 	}
 	// Fast path for net/http embedded adapter - bypass transport interface
 	if w := &c.embeddedResp; w.w != nil {
-		c.responded = true
-		h := w.w.Header()
-		if w.contentTypeSlice == nil {
-			w.contentTypeSlice = make([]string, 1)
+		if c.canBypassHeaderWrite(false) {
+			c.responded = true
+			h := w.w.Header()
+			if w.contentTypeSlice == nil {
+				w.contentTypeSlice = make([]string, 1)
+			}
+			w.contentTypeSlice[0] = "text/plain; charset=utf-8"
+			h["Content-Type"] = w.contentTypeSlice
+			w.w.WriteHeader(c.status)
+			w.written = true
+			_, _ = io.WriteString(w.w, s)
+			return nil
 		}
-		w.contentTypeSlice[0] = "text/plain; charset=utf-8"
-		h["Content-Type"] = w.contentTypeSlice
-		w.w.WriteHeader(c.status)
-		w.written = true
-		_, _ = io.WriteString(w.w, s)
-		return nil
 	}
 	c.contentType = "text/plain; charset=utf-8"
 	return c.sendBytes([]byte(s))

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -100,6 +100,19 @@ go test -bench=. -benchmem -count=5 ./... > new.txt
 benchstat bench/baseline.txt new.txt
 ```
 
+### Reading Benchmark Changes
+
+Go microbenchmarks are noisy. Treat `allocs/op` and `B/op` changes on hot paths as stronger signals than a single `ns/op` movement, and compare repeated runs on the same runner whenever possible.
+
+Kruda's CI uses a 10% regression threshold for benchmark warnings. Borderline `ns/op` changes should be reviewed with `benchstat`, recent main-branch results, and the PR's code path impact before they are treated as real regressions.
+
+Maintainer checklist for performance-sensitive PRs:
+
+- Confirm the changed code runs on the measured hot path.
+- Compare against same-runner `main` results, not only an older local baseline.
+- Block releases on new allocations or bytes in hot-path benchmarks unless the change is explicitly opt-in.
+- Treat security or correctness work that adds cost only when enabled as acceptable when the default path is unchanged.
+
 ## Profile-Guided Optimization (PGO)
 
 Go 1.21+ supports PGO — the compiler uses a CPU profile of your app to make better inlining, devirtualization, and layout decisions. This gives **2-7% free performance** with zero code changes.

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -1,6 +1,6 @@
 # Security
 
-Kruda provides security hardening features that can be enabled with a single option. Use `WithSecureHeaders()` to enable all default security headers.
+Kruda keeps behavior-affecting hardening explicit so applications can choose the security/performance tradeoff they need. Use `WithSecureHeaders()` to enable default security response headers, or `WithSecurity()` to enable both security headers and app-level path traversal prevention.
 
 For vulnerability reporting, see [SECURITY.md](https://github.com/go-kruda/kruda/blob/main/SECURITY.md).
 
@@ -34,7 +34,7 @@ Kruda assumes:
 
 - The application is exposed to untrusted network traffic (the internet).
 - Request paths, headers, query parameters, and body content are attacker-controlled.
-- The framework provides layered protections. Core protections (path normalization, header injection prevention, body size limits) are always active. Security response headers are opt-in via `WithSecureHeaders()`.
+- The framework provides layered protections. Header injection prevention, body size limits, and timeouts are active by default. Security response headers are opt-in via `WithSecureHeaders()`, and app-level path traversal prevention is opt-in via `WithPathTraversal()` or `WithSecurity()`.
 
 | Threat | Severity | Status |
 |--------|----------|--------|
@@ -49,7 +49,7 @@ Kruda assumes:
 
 **Source:** `router.go` -- `cleanPath()`
 
-All request paths are normalized before route matching:
+When enabled, request paths containing `.` or percent-encoded segments are normalized before route matching:
 
 1. Decodes percent-encoded sequences (`%2e%2e%2f` -> `../`)
 2. Normalizes via `path.Clean()` to resolve `.` and `..` segments

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -31,6 +31,7 @@ Before opening the release PR, run `./scripts/pre-release.sh` for local release 
 - [ ] Wing tests pass: covered by the same `go test ./...` since v1.2.0 (flattened into core)
 - [ ] Native fuzz tests don't crash within 30s each: `go test -fuzz=FuzzRouterPattern -fuzztime=30s -run=^$ .` (and FuzzRouterMatch, FuzzBindJSON, FuzzValidateString)
 - [ ] PR benchmark check has no same-runner `benchstat` regression above 10% on the hot path
+- [ ] Any `ns/op` movement is reviewed against `B/op`, `allocs/op`, same-runner `main`, and whether the changed code is on the default hot path
 - [ ] CHANGELOG.md has a section for the new version with date
 - [ ] No `replace` directives left in `transport/wing/go.mod` or any `contrib/*/go.mod`
 - [ ] Every released submodule's `go.mod` requires the intended core version

--- a/integration_transport_test.go
+++ b/integration_transport_test.go
@@ -4,12 +4,12 @@ package kruda
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 )
@@ -39,7 +39,7 @@ func TestTransportSmoke_NetHTTP(t *testing.T) {
 		app := New(NetHTTP())
 		app.Get("/ping", func(c *Ctx) error { return c.Text("pong") })
 		app.Compile()
-		addr, shutdown := startSmokeApp(t, app)
+		addr, shutdown := startSmokeApp(t, app, "/ping")
 		defer shutdown()
 		requireSmokeGet(t, "http://"+addr+"/ping", "pong")
 	})
@@ -69,7 +69,7 @@ func TestTransportSecurityHeadersAndCookies_NetHTTP(t *testing.T) {
 
 	t.Run("Transport.Serve on TCP listener", func(t *testing.T) {
 		app := newApp()
-		addr, shutdown := startSmokeApp(t, app)
+		addr, shutdown := startSmokeApp(t, app, "/headers/json")
 		defer shutdown()
 		requireSecurityCookieGet(t, "http://"+addr+"/headers/json")
 		requireSecurityCookieGet(t, "http://"+addr+"/headers/text")
@@ -89,7 +89,7 @@ func TestTransportSmoke_FastHTTP(t *testing.T) {
 		t.Skipf("fasthttp transport not selected on this platform (got %q)", app.transportType)
 	}
 
-	addr, shutdown := startSmokeApp(t, app)
+	addr, shutdown := startSmokeApp(t, app, "/ping")
 	defer shutdown()
 	requireSmokeGet(t, "http://"+addr+"/ping", "pong")
 }
@@ -115,15 +115,15 @@ func TestTransportSmoke_Wing(t *testing.T) {
 		t.Skipf("wing transport not selected on this platform (got %q)", app.transportType)
 	}
 
-	addr, shutdown := startSmokeApp(t, app)
+	addr, shutdown := startSmokeApp(t, app, "/ping")
 	defer shutdown()
 	requireSmokeGet(t, "http://"+addr+"/ping", `"msg":"pong"`)
 }
 
 // startSmokeApp binds the App's transport to a random TCP port, starts
-// Serve in a goroutine, and waits until the port accepts connections.
+// Serve in a goroutine, and waits until the app serves an HTTP request.
 // Returns the bound addr and a shutdown closure that the caller must defer.
-func startSmokeApp(t *testing.T, app *App) (string, func()) {
+func startSmokeApp(t *testing.T, app *App, readyPath string) (string, func()) {
 	t.Helper()
 
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -132,31 +132,47 @@ func startSmokeApp(t *testing.T, app *App) (string, func()) {
 	}
 	addr := ln.Addr().String()
 
-	var wg sync.WaitGroup
-	wg.Add(1)
+	done := make(chan struct{})
 	go func() {
-		defer wg.Done()
+		defer close(done)
 		_ = app.transport.Serve(ln, app) // returns ErrServerClosed on Shutdown
 	}()
-
-	// Wait for the server to accept.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		conn, dErr := net.DialTimeout("tcp", addr, 100*time.Millisecond)
-		if dErr == nil {
-			conn.Close()
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
 
 	shutdown := func() {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		_ = app.transport.Shutdown(ctx)
-		wg.Wait()
+		select {
+		case <-done:
+		case <-ctx.Done():
+			t.Errorf("transport shutdown timed out: %v", ctx.Err())
+		}
 	}
-	return addr, shutdown
+
+	// Wait until the app can serve an actual HTTP request. A bare TCP dial can
+	// succeed before an async transport has registered its read loop.
+	client := &http.Client{Timeout: 250 * time.Millisecond}
+	readyURL := "http://" + addr + readyPath
+	var lastErr error
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, getErr := client.Get(readyURL)
+		if getErr == nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return addr, shutdown
+			}
+			lastErr = fmt.Errorf("status %d", resp.StatusCode)
+		} else {
+			lastErr = getErr
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	shutdown()
+	t.Fatalf("server did not become ready at %s: %v", readyURL, lastErr)
+	return "", func() {}
 }
 
 // requireSmokeGet performs a GET against url and fails the test unless the

--- a/integration_transport_test.go
+++ b/integration_transport_test.go
@@ -45,6 +45,37 @@ func TestTransportSmoke_NetHTTP(t *testing.T) {
 	})
 }
 
+func TestTransportSecurityHeadersAndCookies_NetHTTP(t *testing.T) {
+	newApp := func() *App {
+		app := New(NetHTTP(), WithSecureHeaders())
+		app.Get("/headers/json", func(c *Ctx) error {
+			c.SetCookie(&Cookie{Name: "sid", Value: "abc", Path: "/", HTTPOnly: true})
+			return c.JSON(Map{"ok": true})
+		})
+		app.Get("/headers/text", func(c *Ctx) error {
+			c.SetCookie(&Cookie{Name: "sid", Value: "abc", Path: "/", HTTPOnly: true})
+			return c.Text("ok")
+		})
+		app.Compile()
+		return app
+	}
+
+	t.Run("ServeHTTP via httptest", func(t *testing.T) {
+		srv := httptest.NewServer(newApp())
+		defer srv.Close()
+		requireSecurityCookieGet(t, srv.URL+"/headers/json")
+		requireSecurityCookieGet(t, srv.URL+"/headers/text")
+	})
+
+	t.Run("Transport.Serve on TCP listener", func(t *testing.T) {
+		app := newApp()
+		addr, shutdown := startSmokeApp(t, app)
+		defer shutdown()
+		requireSecurityCookieGet(t, "http://"+addr+"/headers/json")
+		requireSecurityCookieGet(t, "http://"+addr+"/headers/text")
+	})
+}
+
 // TestTransportSmoke_FastHTTP verifies the fasthttp transport can serve a
 // basic request through the App's normal route registration path. The
 // fasthttp transport requires a real TCP listener (no httptest equivalent),
@@ -144,5 +175,30 @@ func requireSmokeGet(t *testing.T, url, want string) {
 	body, _ := io.ReadAll(resp.Body)
 	if !strings.Contains(string(body), want) {
 		t.Errorf("GET %s body=%q want contains %q", url, body, want)
+	}
+}
+
+func requireSecurityCookieGet(t *testing.T, url string) {
+	t.Helper()
+	client := &http.Client{Timeout: 2 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("GET %s status=%d want=200", url, resp.StatusCode)
+	}
+	if got := resp.Header.Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("GET %s X-Content-Type-Options=%q", url, got)
+	}
+	if got := resp.Header.Get("X-Frame-Options"); got != "DENY" {
+		t.Fatalf("GET %s X-Frame-Options=%q", url, got)
+	}
+	if got := resp.Header.Get("Set-Cookie"); !strings.Contains(got, "sid=abc") || !strings.Contains(got, "HttpOnly") {
+		t.Fatalf("GET %s Set-Cookie=%q", url, got)
+	}
+	if got := resp.Header.Get("Server"); got != "" {
+		t.Fatalf("GET %s Server header should not be set, got %q", url, got)
 	}
 }

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -336,6 +336,51 @@ func TestCORS_PreflightRequest(t *testing.T) {
 	}
 }
 
+func TestCORS_PreflightWithSecureHeadersPreservesBothHeaderSets(t *testing.T) {
+	app := kruda.New(kruda.WithSecureHeaders())
+	app.Use(CORS(CORSConfig{
+		AllowOrigins:     []string{"https://app.example.com"},
+		AllowMethods:     []string{"GET", "POST", "OPTIONS"},
+		AllowHeaders:     []string{"Origin", "Content-Type", "Authorization"},
+		AllowCredentials: true,
+		MaxAge:           3600,
+	}))
+	app.Options("/test", func(c *kruda.Ctx) error { return c.NoContent() })
+	app.Compile()
+
+	req := optionsReq(map[string]string{
+		"Origin":                        "https://app.example.com",
+		"Access-Control-Request-Method": "POST",
+	})
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 204 {
+		t.Fatalf("expected 204, got %d", resp.statusCode)
+	}
+	if got := resp.headers.Get("Access-Control-Allow-Origin"); got != "https://app.example.com" {
+		t.Fatalf("Allow-Origin = %q", got)
+	}
+	if got := resp.headers.Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Fatalf("Allow-Credentials = %q", got)
+	}
+	if got := resp.headers.Get("Vary"); got != "Origin" {
+		t.Fatalf("Vary = %q", got)
+	}
+	if got := resp.headers.Get("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q", got)
+	}
+	if got := resp.headers.Get("X-Frame-Options"); got != "DENY" {
+		t.Fatalf("X-Frame-Options = %q", got)
+	}
+	if got := resp.headers.Get("Referrer-Policy"); got != "strict-origin-when-cross-origin" {
+		t.Fatalf("Referrer-Policy = %q", got)
+	}
+	if got := resp.headers.Get("Server"); got != "" {
+		t.Fatalf("Server header should not be set, got %q", got)
+	}
+}
+
 func TestCORS_NonPreflightRequest(t *testing.T) {
 	called := false
 	handler := func(c *kruda.Ctx) error {

--- a/security_test.go
+++ b/security_test.go
@@ -632,6 +632,40 @@ func TestDoSDefaultBodyLimit(t *testing.T) {
 	}
 }
 
+func TestSecurityOptionsDefaultToExplicitOptIn(t *testing.T) {
+	app := New()
+	if app.config.SecurityHeaders {
+		t.Fatal("SecurityHeaders should default to false")
+	}
+	if app.config.PathTraversal {
+		t.Fatal("PathTraversal should default to false")
+	}
+
+	headersOnly := New(WithSecureHeaders())
+	if !headersOnly.config.SecurityHeaders {
+		t.Fatal("WithSecureHeaders should enable SecurityHeaders")
+	}
+	if headersOnly.config.PathTraversal {
+		t.Fatal("WithSecureHeaders should not enable PathTraversal")
+	}
+
+	pathOnly := New(WithPathTraversal())
+	if pathOnly.config.SecurityHeaders {
+		t.Fatal("WithPathTraversal should not enable SecurityHeaders")
+	}
+	if !pathOnly.config.PathTraversal {
+		t.Fatal("WithPathTraversal should enable PathTraversal")
+	}
+
+	allSecurity := New(WithSecurity())
+	if !allSecurity.config.SecurityHeaders {
+		t.Fatal("WithSecurity should enable SecurityHeaders")
+	}
+	if !allSecurity.config.PathTraversal {
+		t.Fatal("WithSecurity should enable PathTraversal")
+	}
+}
+
 func TestDoSMaxBodySize(t *testing.T) {
 	app := New(WithMaxBodySize(1024)) // 1KB limit for fast test
 	app.Post("/upload", func(c *Ctx) error {
@@ -815,6 +849,45 @@ func TestSecureCookieFlags(t *testing.T) {
 	}
 	if !contains(setCookie, "SameSite=Strict") {
 		t.Errorf("Set-Cookie should contain SameSite=Strict, got: %q", setCookie)
+	}
+}
+
+func TestSecureHeadersPreserveCookiesOnNormalResponse(t *testing.T) {
+	app := New(WithSecureHeaders())
+	app.Get("/setcookie", func(c *Ctx) error {
+		c.SetCookie(&Cookie{
+			Name:     "session",
+			Value:    "abc123",
+			Path:     "/",
+			HTTPOnly: true,
+			Secure:   true,
+			SameSite: http.SameSiteLaxMode,
+		})
+		return c.JSON(Map{"ok": true})
+	})
+	app.Compile()
+
+	tc := NewTestClient(app)
+	resp, err := tc.Get("/setcookie")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode() != 200 {
+		t.Fatalf("expected 200, got %d", resp.StatusCode())
+	}
+
+	setCookie := resp.Header("Set-Cookie")
+	if !contains(setCookie, "session=abc123") {
+		t.Fatalf("Set-Cookie missing session value: %q", setCookie)
+	}
+	if got := resp.Header("X-Content-Type-Options"); got != "nosniff" {
+		t.Fatalf("X-Content-Type-Options = %q", got)
+	}
+	if got := resp.Header("X-Frame-Options"); got != "DENY" {
+		t.Fatalf("X-Frame-Options = %q", got)
+	}
+	if got := resp.Header("Server"); got != "" {
+		t.Fatalf("Server header should not be set, got %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Preserve pending cookies and custom response headers when the embedded net/http JSON/Text response paths are used.
- Add regression coverage for net/http security headers/cookies, CORS plus secure headers, and opt-in security configuration.
- Harden transport smoke test readiness so async transports must serve an HTTP request before assertions run, with bounded shutdown on failure.
- Clarify security opt-in behavior and benchmark review guidance for maintainers.

## Root Cause

The embedded net/http JSON/Text fast paths wrote response headers and bodies directly, bypassing the shared header writer. That could drop pending cookies or custom headers on direct `ServeHTTP` usage when handlers used `c.JSON()` or `c.Text()`.

The default fast path is still used when there are no pending cookies/custom headers/cache/location headers. Requests that set extra response metadata fall back to the normal header writer.

## Performance Notes

- Default no-extra-header responses keep the existing fast path.
- The fallback cost applies only when the app has pending cookies or custom response metadata.
- Benchmark smoke against same-runner `main` showed unchanged allocations and ns/op movement below the documented 10% regression threshold.

## Verification

- `go test -count=1 -tags kruda_stdjson -run 'TestCORS_PreflightWithSecureHeadersPreservesBothHeaderSets|TestSecurityOptionsDefaultToExplicitOptIn|TestSecureHeadersPreserveCookiesOnNormalResponse|TestTransportSecurityHeadersAndCookies_NetHTTP'`
- `go test -count=1 -tags kruda_stdjson ./...`
- `go test -race -count=1 -tags kruda_stdjson ./...`
- `go test -race -count=1 -tags kruda_stdjson -coverprofile=/tmp/coverage.out ./...`
- `npm run build --prefix docs`
- `go test -run '^$' -bench 'BenchmarkKruda_(StaticGET|POSTJSON)$' -benchmem -count=5`

## Release

No tag or version release in this PR.
