### PR TITLE
ci: add workflow timeouts

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -33,6 +33,7 @@ jobs:
   benchmark:
     name: Benchmark
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,6 +29,7 @@ jobs:
   build:
     name: Build Documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout code
@@ -70,6 +71,7 @@ jobs:
     needs: build
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
   release-preflight:
     name: Release Preflight
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout tag
         uses: actions/checkout@v6
@@ -67,6 +68,7 @@ jobs:
     needs: release-preflight
     name: Security Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -86,6 +88,7 @@ jobs:
     name: Create Release
     needs: [release-preflight, test, security]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
   test:
     name: Test (Go ${{ matrix.go-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- Add job-level timeouts to CI test, benchmark, docs, and release workflows.
- Keep timeouts above normal observed runtimes while bounding stuck jobs.
- Avoid runtime or benchmark implementation changes.

## Timeout Policy

- Tests: 20 minutes per matrix job.
- Benchmark: 20 minutes.
- Documentation build/deploy: 10 minutes each.
- Release preflight/create release: 10 minutes each.
- Release security scan: 15 minutes.

## Verification

- `git diff --check`
- YAML parse check for all modified workflow files.

## Release

No tag or version release in this PR.
