### PR TITLE
ci: summarize benchmark results

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -89,6 +89,48 @@ jobs:
             sed -E 's/[[:space:]]+[0-9.]+ MB\/s//g' main-output.txt > main-benchmark.txt
           fi
 
+      - name: Summarize benchmark metrics
+        run: |
+          set -euo pipefail
+
+          {
+            echo "## Benchmark Metrics"
+            echo
+            echo "Current run snapshot from normalized Go benchmark output."
+            echo
+            echo "| Benchmark | ns/op | B/op | allocs/op |"
+            echo "| --- | ---: | ---: | ---: |"
+            awk '
+              /^Benchmark/ {
+                bench = $1
+                ns = "-"
+                bytes = "-"
+                allocs = "-"
+                for (i = 2; i <= NF; i++) {
+                  if ($i == "ns/op") {
+                    ns = $(i - 1)
+                  } else if ($i == "B/op") {
+                    bytes = $(i - 1)
+                  } else if ($i == "allocs/op") {
+                    allocs = $(i - 1)
+                  }
+                }
+                if (rows < 25) {
+                  printf("| `%s` | %s | %s | %s |\n", bench, ns, bytes, allocs)
+                }
+                rows++
+              }
+              END {
+                if (rows == 0) {
+                  print "| _No benchmark rows found_ | - | - | - |"
+                } else if (rows > 25) {
+                  printf("\nShowing 25 of %d benchmark rows.\n", rows)
+                }
+              }
+            ' benchmark.txt
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Compare PR benchmarks with same-runner main
         if: github.event_name == 'pull_request'
         run: |
@@ -113,6 +155,55 @@ jobs:
               }
             }
           ' benchstat.txt
+
+      - name: Summarize PR benchmark comparison
+        if: ${{ always() && github.event_name == 'pull_request' }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo "## Same-runner Benchmark Comparison"
+            echo
+            echo "- Gate: fail on non-noisy same-runner benchmark regressions above 10%."
+            echo "- Read ns/op together with B/op and allocs/op; allocation increases are reviewed even when latency is noisy."
+            echo
+
+            if [ ! -f benchstat.txt ]; then
+              echo "_benchstat output was not produced._"
+              exit 0
+            fi
+
+            regressions="$(
+              awk '
+                /^[^[:space:]]/ && $0 ~ /\+[0-9.]+%/ && $0 !~ /~$/ {
+                  for (i = 1; i <= NF; i++) {
+                    if ($i ~ /^\+[0-9.]+%$/) {
+                      change = $i
+                      gsub(/^\+|%$/, "", change)
+                      if ((change + 0) > 10) {
+                        printf("- `%s` %s\n", $1, $i)
+                      }
+                    }
+                  }
+                }
+              ' benchstat.txt
+            )"
+
+            if [ -n "$regressions" ]; then
+              echo "Regressions above 10%:"
+              echo "$regressions"
+            else
+              echo "Regressions above 10%: none"
+            fi
+            echo
+            echo "<details><summary>benchstat output</summary>"
+            echo
+            echo '```text'
+            cat benchstat.txt
+            echo '```'
+            echo
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Get system information
         uses: kenchan0130/actions-system-info@v1.4.0


### PR DESCRIPTION
## Summary

- Add a concise benchmark metrics table to the GitHub Actions job summary.
- Add a PR-only same-runner benchstat summary with the 10% regression gate called out.
- Keep the existing benchmark commands and merge-blocking gate unchanged.

## Details

- Current run summary shows `ns/op`, `B/op`, and `allocs/op` for the first 25 benchmark rows.
- PR comparison summary includes the same-runner benchstat output in a collapsible block.
- If a non-noisy same-runner benchmark regresses by more than 10%, the summary lists the affected benchmark while the existing gate still fails the job.

## Verification

- `git diff --check`
- YAML parse check for `.github/workflows/benchmark.yml`
- Shell syntax check for all `run:` scripts in `.github/workflows/benchmark.yml`
- Local simulation of the new summary scripts with sample benchmark and benchstat files

## Release

No tag or version release in this PR.
