### PR TITLE
Prepare v1.2.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to Kruda are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.2.3] — 2026-05-23
+
+### Fixed
+- Preserved response headers on fast response paths, including secure-header middleware output and net/http responses.
+- Preserved overflow Wing headers so responses with more than the fixed inline header slots still serialize all configured headers.
+- Preserved session cookie attributes when destroying sessions so deletion cookies keep the configured security policy.
+
+### Changed
+- Updated the documented Go patch baseline for currently supported secure toolchains.
+- Tightened CI and benchmark reporting guardrails, including workflow timeouts, docs-only benchmark skips, standalone module coverage, and summarized benchmark output.
+
 ## [1.2.2] — 2026-05-20
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Add the v1.2.3 changelog entry for the fixes and release/CI guardrails already merged on main since v1.2.2.
- Keep this as a patch release for security, header-preservation, session-cookie, CI, and benchmark-reporting improvements.

## Validation
- `GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go test -count=1 -tags kruda_stdjson ./...`
- `GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin scripts/pre-release.sh`

## Release Notes
- Tag `v1.2.3` only after this PR is merged and the merge commit on `main` has green `Tests` and `Benchmark` workflow runs.