### PR TITLE
docs: clarify CPU-bound Actix benchmark claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ Default CPU-bound routes:
 
 The benchmark runs Kruda, Fiber, and Actix with `wrk --latency` across latency and throughput profiles. Kruda should be described as "faster than Actix" only when median RPS is at least 3% higher and p99 is no worse than 10% above Actix with zero errors. Otherwise, use "same ballpark as Actix."
 
+Current committed evidence satisfies that gate for the CPU-bound Wing handler routes below:
+
+| Route | Profile | Kruda vs Actix median RPS | Kruda vs Actix p99 |
+|------|---------|---------------------------:|-------------------:|
+| `/plaintext-handler` | throughput | +10.68% | -76.99% |
+| `/json-static` | throughput | +13.97% | -69.33% |
+| `/json-serialize` | throughput | +12.14% | -68.01% |
+
+Evidence: `bench/reproducible/results/20260523T123854Z-plaintext-final-k4/` and `bench/reproducible/results/20260524Tphase3-json-final/`. These are normal handler-path routes, not Wing static bypass routes.
+
 Wing transport uses raw `epoll` + `eventfd` on Linux and bypasses both fasthttp and net/http. macOS defaults to fasthttp.
 
 ## Documentation

--- a/bench/reproducible/README.md
+++ b/bench/reproducible/README.md
@@ -85,3 +85,15 @@ Results are written to `bench/reproducible/results/<timestamp>/`:
 Use "faster than Actix" only when Kruda median RPS is at least 3% higher than Actix and p99 is no worse than 10% above Actix with zero socket errors and zero non-2xx responses.
 
 When those conditions are not met, use "same ballpark as Actix." Do not make RPS-only claims.
+
+## Current Evidence
+
+The committed evidence below satisfies the "faster than Actix" gate for CPU-bound Wing handler routes under the throughput profile:
+
+| Route | Evidence directory | Kruda vs Actix median RPS | Kruda vs Actix p99 |
+|------|--------------------|---------------------------:|-------------------:|
+| `/plaintext-handler` | `results/20260523T123854Z-plaintext-final-k4/` | +10.68% | -76.99% |
+| `/json-static` | `results/20260524Tphase3-json-final/` | +13.97% | -69.33% |
+| `/json-serialize` | `results/20260524Tphase3-json-final/` | +12.14% | -68.01% |
+
+These are normal handler-path routes. Static bypass route options are intentionally separate from fair handler-path benchmark claims.

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -337,4 +337,14 @@ The harness runs both `wrk --latency -t4 -c128 -d15s` and `wrk --latency -t4 -c2
 
 **Claim rule:** say "faster than Actix" only when Kruda median RPS is at least 3% higher and p99 is no worse than 10% above Actix with zero socket errors and zero non-2xx responses. Otherwise, say "same ballpark as Actix."
 
+Current committed evidence satisfies that rule for these CPU-bound Wing handler routes:
+
+| Route | Profile | Kruda median RPS | Actix median RPS | Kruda vs Actix RPS | Kruda vs Actix p99 | Evidence |
+|------|---------|-----------------:|-----------------:|-------------------:|-------------------:|----------|
+| `/plaintext-handler` | throughput | 812782.42 | 734378.34 | +10.68% | -76.99% | `20260523T123854Z-plaintext-final-k4` |
+| `/json-static` | throughput | 811740.53 | 712263.97 | +13.97% | -69.33% | `20260524Tphase3-json-final` |
+| `/json-serialize` | throughput | 791812.23 | 706101.18 | +12.14% | -68.01% | `20260524Tphase3-json-final` |
+
+These are fair handler-path benchmark claims. Wing static bypass route options are documented separately and should not be mixed into handler-path comparison claims.
+
 DB and fortunes workloads are opt-in with `BENCH_ENABLE_DB=1` because database driver, pool, and schema configuration can dominate framework overhead.


### PR DESCRIPTION
## Summary

- document the current scoped "faster than Actix" CPU-bound handler-route evidence
- keep the public claim tied to the existing RPS, p99, socket error, and non-2xx gate
- separate normal handler-path benchmark claims from Wing static bypass route options

## Evidence

Committed benchmark evidence used by this documentation update:

- `bench/reproducible/results/20260523T123854Z-plaintext-final-k4/`
- `bench/reproducible/results/20260524Tphase3-json-final/`

Throughput-profile median results:

| Route | Kruda vs Actix median RPS | Kruda vs Actix p99 |
|---|---:|---:|
| `/plaintext-handler` | +10.68% | -76.99% |
| `/json-static` | +13.97% | -69.33% |
| `/json-serialize` | +12.14% | -68.01% |

The wording is limited to CPU-bound Wing handler routes and does not apply to DB, fortunes, or static bypass routes.

## Verification

```bash
git diff --check
/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go test -count=1 -tags kruda_stdjson ./...
```

No release or version bump.
