### PR TITLE
perf: cache Wing exact route feathers

### DIFF
--- a/wing_feather_internal_test.go
+++ b/wing_feather_internal_test.go
@@ -59,6 +59,74 @@ func TestWorkerServeRouteFallsBackWhenSingleHandlerDeclines(t *testing.T) {
 	}
 }
 
+func TestWorkerLookupFeatherCachesExactRoute(t *testing.T) {
+	w := &worker{feathers: NewFeatherTable(map[string]Feather{
+		"GET /plaintext": Plaintext,
+	}, Arrow)}
+
+	got := w.lookupFeather("GET", "/plaintext")
+	if got.path != "/plaintext" {
+		t.Fatalf("first lookup path = %q, want /plaintext", got.path)
+	}
+	if w.lastMethod0 != "GET" || w.lastPath0 != "/plaintext" {
+		t.Fatalf("cache = %q %q, want GET /plaintext", w.lastMethod0, w.lastPath0)
+	}
+
+	got = w.lookupFeather("GET", "/plaintext")
+	if got.Dispatch != Plaintext.Dispatch || got.ResponseMode != Plaintext.ResponseMode {
+		t.Fatalf("cached lookup = %+v, want Plaintext", got)
+	}
+}
+
+func TestWorkerLookupFeatherDoesNotCacheParamOrDefaultPath(t *testing.T) {
+	w := &worker{feathers: NewFeatherTable(map[string]Feather{
+		"GET /plaintext": Plaintext,
+		"GET /users/:id": Arrow,
+	}, Bolt)}
+
+	_ = w.lookupFeather("GET", "/plaintext")
+	if w.lastPath0 != "/plaintext" {
+		t.Fatalf("exact route was not cached: %q", w.lastPath0)
+	}
+
+	got := w.lookupFeather("GET", "/users/42")
+	if got.Dispatch != Arrow.Dispatch {
+		t.Fatalf("param lookup dispatch = %v, want Arrow", got.Dispatch)
+	}
+	if w.lastPath0 != "/plaintext" {
+		t.Fatalf("param lookup replaced exact cache with %q", w.lastPath0)
+	}
+
+	got = w.lookupFeather("GET", "/missing")
+	if got.Dispatch != Bolt.Dispatch {
+		t.Fatalf("default lookup dispatch = %v, want Bolt", got.Dispatch)
+	}
+	if w.lastPath0 != "/plaintext" {
+		t.Fatalf("default lookup replaced exact cache with %q", w.lastPath0)
+	}
+}
+
+func TestWorkerLookupFeatherPromotesSecondExactCacheSlot(t *testing.T) {
+	w := &worker{feathers: NewFeatherTable(map[string]Feather{
+		"GET /plaintext": Plaintext,
+		"GET /json":      JSON,
+	}, Arrow)}
+
+	_ = w.lookupFeather("GET", "/plaintext")
+	_ = w.lookupFeather("GET", "/json")
+	if w.lastPath0 != "/json" || w.lastPath1 != "/plaintext" {
+		t.Fatalf("cache = [%q, %q], want [/json, /plaintext]", w.lastPath0, w.lastPath1)
+	}
+
+	got := w.lookupFeather("GET", "/plaintext")
+	if got.ResponseMode != Plaintext.ResponseMode {
+		t.Fatalf("promoted lookup = %+v, want Plaintext", got)
+	}
+	if w.lastPath0 != "/plaintext" || w.lastPath1 != "/json" {
+		t.Fatalf("promoted cache = [%q, %q], want [/plaintext, /json]", w.lastPath0, w.lastPath1)
+	}
+}
+
 func TestWingResponsePlaintextModeUsesHandlerFastPath(t *testing.T) {
 	resp := acquireResponse()
 	defer releaseResponse(resp)
@@ -303,6 +371,34 @@ func TestWingResponseJSONAppendMatchesBuildZeroCopy(t *testing.T) {
 
 	if !bytes.Equal(direct, built) {
 		t.Fatalf("direct JSON response differs from buildZeroCopy:\ndirect:\n%s\nbuilt:\n%s", direct, built)
+	}
+}
+
+func BenchmarkWorkerLookupFeatherCachedExact(b *testing.B) {
+	w := &worker{feathers: NewFeatherTable(map[string]Feather{
+		"GET /plaintext": Plaintext,
+		"GET /json":      JSON,
+	}, Arrow)}
+	_ = w.lookupFeather("GET", "/plaintext")
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = w.lookupFeather("GET", "/plaintext")
+	}
+}
+
+func BenchmarkWorkerLookupFeatherAlternatingExact(b *testing.B) {
+	w := &worker{feathers: NewFeatherTable(map[string]Feather{
+		"GET /plaintext": Plaintext,
+		"GET /json":      JSON,
+	}, Arrow)}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = w.lookupFeather("GET", "/plaintext")
+		_ = w.lookupFeather("GET", "/json")
 	}
 }
 

--- a/wing_feather_table_test.go
+++ b/wing_feather_table_test.go
@@ -82,3 +82,20 @@ func BenchmarkFeatherTableLookup(b *testing.B) {
 		_ = ft.Lookup("GET", "/unknown")
 	}
 }
+
+func BenchmarkFeatherTableLookupExactOne(b *testing.B) {
+	ft := NewFeatherTable(map[string]Feather{
+		"GET /plaintext": Bolt,
+		"GET /json":      Bolt,
+		"POST /db":       Arrow,
+		"GET /fortunes":  Arrow,
+		"GET /queries":   Arrow,
+		"GET /updates":   Arrow,
+	}, Arrow)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = ft.Lookup("GET", "/plaintext")
+	}
+}

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -219,19 +219,27 @@ type doneMsg struct {
 }
 
 type worker struct {
-	id           int
-	listenFd     int
-	eng          engine
-	handler      transport.Handler
-	config       WingConfig
-	limits       parserLimits
-	maxConns     int
-	conns        map[int32]*conn
-	events       [maxEventsPerWait]event
-	evfd         int // eventfd for wake signaling
-	doneCh       chan doneMsg
-	pool         *workerPool
-	feathers     FeatherTable
+	id       int
+	listenFd int
+	eng      engine
+	handler  transport.Handler
+	config   WingConfig
+	limits   parserLimits
+	maxConns int
+	conns    map[int32]*conn
+	events   [maxEventsPerWait]event
+	evfd     int // eventfd for wake signaling
+	doneCh   chan doneMsg
+	pool     *workerPool
+	feathers FeatherTable
+	// Exact-route MRU cache. Paths stored here must come from Feather.path,
+	// never directly from the read buffer's unsafe request path.
+	lastFeather0 Feather
+	lastFeather1 Feather
+	lastMethod0  string
+	lastMethod1  string
+	lastPath0    string
+	lastPath1    string
 	shutdown     *atomic.Bool
 	hasTimeout   bool
 	readTimeout  int64 // nanoseconds (0 = disabled)
@@ -343,6 +351,34 @@ func (w *worker) serveRoute(resp *wingResponse, req *wingRequest, f Feather) {
 		}
 	}
 	w.handler.ServeKruda(resp, req)
+}
+
+func (w *worker) lookupFeather(method, path string) Feather {
+	if w.lastPath0 != "" && method == w.lastMethod0 && path == w.lastPath0 {
+		return w.lastFeather0
+	}
+	if w.lastPath1 != "" && method == w.lastMethod1 && path == w.lastPath1 {
+		f := w.lastFeather1
+		m := w.lastMethod1
+		p := w.lastPath1
+		w.lastFeather1 = w.lastFeather0
+		w.lastMethod1 = w.lastMethod0
+		w.lastPath1 = w.lastPath0
+		w.lastFeather0 = f
+		w.lastMethod0 = m
+		w.lastPath0 = p
+		return f
+	}
+	f := w.feathers.Lookup(method, path)
+	if f.path != "" {
+		w.lastFeather1 = w.lastFeather0
+		w.lastMethod1 = w.lastMethod0
+		w.lastPath1 = w.lastPath0
+		w.lastFeather0 = f
+		w.lastMethod0 = method
+		w.lastPath0 = f.path
+	}
+	return f
 }
 
 func newWorker(id, listenFd int, cfg WingConfig, handler transport.Handler) (*worker, error) {
@@ -577,7 +613,7 @@ func (w *worker) tryParse(c *conn) {
 			c.lastActive = time.Now().UnixNano()
 		}
 
-		f := w.feathers.Lookup(req.method, req.path)
+		f := w.lookupFeather(req.method, req.path)
 		finalizeRequestPath(req, f)
 
 		// For async dispatch modes, only one in-flight handler per conn.


### PR DESCRIPTION
## Summary

Adds a small Wing handler-path optimization for exact route Feather lookup:

- Adds a per-worker 2-slot MRU cache for exact-route Feather hits.
- Caches only canonical `Feather.path` values from the immutable Feather table, never unsafe request path strings from the read buffer.
- Leaves param routes, default Feather fallback, middleware, lifecycle hooks, parser limits, and response behavior unchanged.
- Adds tests for exact cache hits, second-slot promotion, and no cache replacement from param/default lookups.

## Performance Evidence

Local machine: macOS, Apple M3, Go 1.26.1.

Commands:

```bash
/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go test -run '^$' -tags kruda_stdjson -bench 'Benchmark(Plaintext|JSON|CPUParse(GET|POST)|CPUResponse(Build|JSON|Plaintext)|CPUFullCycle|CPUHandler(Inline|PlaintextFeather|JSONStaticFeather|JSONSerializeFeather)|FeatherTableLookup|GetStaticResponseStringCached)$' -benchmem -count=5 . ./transport

/Users/emetworks/go/bin/benchstat /private/tmp/kruda-phase12-main-bench.txt /private/tmp/kruda-phase12-branch-common-bench.txt

/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go test -run '^$' -tags kruda_stdjson -bench 'BenchmarkWorkerLookupFeather' -benchmem -count=5 .
```

Benchstat against `origin/main` for common hot-path benchmarks:

- No B/op or allocs/op increases.
- No CPU hot-path regression above the 5% gate.
- Common benchmark geomean: `135.8ns -> 135.1ns` (`-0.55%`).

Cache-specific benchmarks:

- Direct exact table lookup: about `9.3ns/op`, `0 B/op`, `0 allocs/op`.
- Cached exact lookup: about `4.3ns/op`, `0 B/op`, `0 allocs/op`.
- Alternating two exact routes: about `17.2ns/op` for two lookups, `0 B/op`, `0 allocs/op`.

## Verification

```bash
/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go test -count=1 -tags kruda_stdjson ./...

/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go test -race -count=1 -tags kruda_stdjson ./...

/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin git diff --check
```

All passed locally. Loopback-binding tests were run outside the sandbox.

## Scope

This is a release-neutral performance PR. It does not change default public behavior, public docs wording, benchmark claims, tags, releases, or versions.
