### PR TITLE
perf: cache clean Wing route paths

### DIFF
--- a/wing_feather_internal_test.go
+++ b/wing_feather_internal_test.go
@@ -59,6 +59,40 @@ func TestWorkerServeRouteFallsBackWhenSingleHandlerDeclines(t *testing.T) {
 	}
 }
 
+func TestWorkerServeRouteUsesCleanExactRouteFlag(t *testing.T) {
+	spy := &workerSingleHandlerSpy{singleHandled: true}
+	w := &worker{handler: spy}
+	resp := acquireResponse()
+	defer releaseResponse(resp)
+
+	w.serveRoute(resp, &wingRequest{method: "GET", path: "/plaintext", keepAlive: true}, Feather{
+		handlers:  []HandlerFunc{func(c *Ctx) error { return nil }},
+		path:      "/plaintext",
+		pathClean: true,
+	})
+
+	if spy.singleCalls != 1 || spy.routeCalls != 0 || spy.serveCalls != 0 {
+		t.Fatalf("single=%d route=%d serve=%d", spy.singleCalls, spy.routeCalls, spy.serveCalls)
+	}
+}
+
+func TestWorkerServeRouteSkipsFastPathForDirtyExactRoute(t *testing.T) {
+	spy := &workerSingleHandlerSpy{singleHandled: true}
+	w := &worker{handler: spy}
+	resp := acquireResponse()
+	defer releaseResponse(resp)
+
+	w.serveRoute(resp, &wingRequest{method: "GET", path: "/assets/app.js", keepAlive: true}, Feather{
+		handlers:  []HandlerFunc{func(c *Ctx) error { return nil }},
+		path:      "/assets/app.js",
+		pathClean: false,
+	})
+
+	if spy.singleCalls != 0 || spy.routeCalls != 0 || spy.serveCalls != 1 {
+		t.Fatalf("single=%d route=%d serve=%d", spy.singleCalls, spy.routeCalls, spy.serveCalls)
+	}
+}
+
 func TestWorkerLookupFeatherCachesExactRoute(t *testing.T) {
 	w := &worker{feathers: NewFeatherTable(map[string]Feather{
 		"GET /plaintext": Plaintext,

--- a/wing_feather_table.go
+++ b/wing_feather_table.go
@@ -74,6 +74,8 @@ func NewFeatherTable(routes map[string]Feather, def Feather) FeatherTable {
 			// Param route: store as prefix match
 			if colonIdx := wingIndexByte(path, ':'); colonIdx > 0 {
 				f.handlers = nil
+				f.path = ""
+				f.pathClean = false
 				ft.prefixes[idx] = append(ft.prefixes[idx], prefixFeather{
 					prefix: path[:colonIdx], feather: f,
 				})
@@ -82,6 +84,7 @@ func NewFeatherTable(routes map[string]Feather, def Feather) FeatherTable {
 					ft.routes[idx] = make(map[string]Feather, 4)
 				}
 				f.path = path
+				f.pathClean = !containsDotPercent(path)
 				ft.routes[idx][path] = f
 			}
 		} else {

--- a/wing_feather_table_test.go
+++ b/wing_feather_table_test.go
@@ -45,6 +45,29 @@ func TestFeatherTableDefaultsApplied(t *testing.T) {
 	}
 }
 
+func TestFeatherTableMarksCleanExactRoutes(t *testing.T) {
+	ft := NewFeatherTable(map[string]Feather{
+		"GET /plaintext":     Bolt,
+		"GET /assets/app.js": Bolt,
+		"GET /encoded%2F":    Bolt,
+		"GET /users/:id":     Arrow,
+	}, Arrow)
+
+	if got := ft.Lookup("GET", "/plaintext"); !got.pathClean {
+		t.Fatalf("clean exact route pathClean = false")
+	}
+	if got := ft.Lookup("GET", "/assets/app.js"); got.pathClean {
+		t.Fatalf("dotted exact route pathClean = true")
+	}
+	if got := ft.Lookup("GET", "/encoded%2F"); got.pathClean {
+		t.Fatalf("encoded exact route pathClean = true")
+	}
+	got := ft.Lookup("GET", "/users/42")
+	if got.path != "" || got.pathClean {
+		t.Fatalf("param route cached path = %q pathClean=%v, want empty/false", got.path, got.pathClean)
+	}
+}
+
 func TestSplitKey(t *testing.T) {
 	tests := []struct {
 		key          string

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -145,6 +145,8 @@ func (t *Transport) SetRouteFeather(method, path string, feather any) {
 	if t.config.Feathers == nil {
 		t.config.Feathers = make(map[string]Feather)
 	}
+	f.path = path
+	f.pathClean = !containsDotPercent(path)
 	t.config.Feathers[method+" "+path] = f
 }
 
@@ -339,7 +341,7 @@ func (p *workerPool) loop(h transport.Handler) {
 }
 
 func (w *worker) serveRoute(resp *wingResponse, req *wingRequest, f Feather) {
-	if len(f.handlers) > 0 && !containsDotPercent(req.path) {
+	if len(f.handlers) > 0 && (f.pathClean || (f.path == "" && !containsDotPercent(req.path))) {
 		if len(f.handlers) == 1 {
 			if h, ok := w.handler.(wingSingleHandler); ok && h.serveKrudaSingleHandler(resp, req, f.handlers[0]) {
 				return

--- a/wing_types_shared.go
+++ b/wing_types_shared.go
@@ -102,6 +102,7 @@ type Feather struct {
 	ResponseMode   responseMode
 	handlers       []HandlerFunc
 	path           string
+	pathClean      bool
 }
 
 // FeatherOption modifies a Feather in-place.


### PR DESCRIPTION
## Summary

Caches whether an exact Wing route path can use the fast handler dispatch path without scanning the request path for `.` or `%` on every request.

- Adds an internal `pathClean` Feather bit for exact routes.
- Marks exact routes as clean during route Feather registration and Feather table construction.
- Keeps param routes uncached for this purpose.
- Keeps exact routes containing `.` or `%` on the existing fallback path.
- Leaves parser limits, path traversal checks, middleware, lifecycle hooks, and response behavior unchanged.

## Performance Evidence

Local machine: macOS, Apple M3, Go 1.26.1.

Commands:

```bash
/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go test -run '^$' -tags kruda_stdjson -bench 'Benchmark(Plaintext|JSON|CPUParse(GET|POST)|CPUResponse(Build|JSON|Plaintext)|CPUFullCycle|CPUHandler(Inline|PlaintextFeather|JSONStaticFeather|JSONSerializeFeather)|FeatherTableLookup|GetStaticResponseStringCached)$' -benchmem -count=5 . ./transport

/Users/emetworks/go/bin/benchstat /private/tmp/kruda-phase13-main-bench.txt /private/tmp/kruda-phase13-branch-bench.txt
```

Benchstat against `origin/main`:

- `BenchmarkCPUHandlerJSONStaticFeather`: `279.1ns -> 270.6ns` (`-3.05%`), `488 B/op -> 472 B/op`, `5 allocs/op -> 4 allocs/op`.
- `BenchmarkCPUHandlerJSONSerializeFeather`: `355.2ns -> 342.8ns` (`-3.49%`), `521 B/op -> 505 B/op`, `6 allocs/op -> 5 allocs/op`.
- Common hot-path geomean: `139.0ns -> 138.5ns` (`-0.37%`).
- No B/op or allocs/op increases.
- No CPU hot-path regression above the 5% gate.

Note: the B/op and alloc/op drops are partly from making the registered Feather metadata include the canonical route path for direct benchmark use. Runtime workers already canonicalize exact route paths via `NewFeatherTable`; the runtime win in this PR is skipping the per-request `containsDotPercent` scan for clean exact routes.

## Verification

```bash
/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go test -count=1 -tags kruda_stdjson ./...

/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go test -race -count=1 -tags kruda_stdjson ./...

/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go vet -tags kruda_stdjson ./...

/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache scripts/test-standalone-modules.sh --verbose --race transport/wing

/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin git diff --check
```

All passed locally. Loopback-binding tests were run outside the sandbox.

## Scope

This is a release-neutral Wing handler-path optimization. It does not change default public behavior, public benchmark claims, tags, releases, or versions.
