### PR TITLE
perf: fast-path Wing common headers

### DIFF
--- a/wing_http.go
+++ b/wing_http.go
@@ -158,21 +158,16 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 			return nil, 0, false
 		}
 
-		key := trimHTTPSpaces(hline[:colon])
+		key := hline[:colon]
 		val := trimHTTPSpaces(hline[colon+1:])
-
-		// Validate header name characters (RFC 7230 token set).
-		if !isValidTokenName(key) {
-			return nil, 0, false
-		}
 
 		// Reject bare CR or LF in header values (CRLF injection).
 		if containsCRLF(val) {
 			return nil, 0, false
 		}
 
-		switch {
-		case len(key) == 14 && asciiEqualFold(key, bContentLength):
+		switch knownHeader(key) {
+		case headerContentLength:
 			// Reject duplicate Content-Length headers.
 			if contentLengthSeen {
 				return nil, 0, false
@@ -185,20 +180,66 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 				return nil, 0, false
 			}
 			contentLength = btoi(val)
-		case len(key) == 12 && asciiEqualFold(key, bContentType):
+			continue
+		case headerContentType:
 			contentType = string(val)
-		case len(key) == 10 && asciiEqualFold(key, bConnection):
+			continue
+		case headerConnection:
 			if asciiEqualFold(val, bClose) {
 				keepAlive = false
 			}
-		case len(key) == 17 && asciiEqualFold(key, bTransferEncoding):
+			continue
+		case headerTransferEncoding:
 			hasTE = true
-		case len(key) == 6 && asciiEqualFold(key, bCookie):
+			continue
+		case headerCookie:
 			cookie = string(val)
-		case len(key) == 4 && asciiEqualFold(key, bHost):
+			continue
+		case headerHost:
 			host = copyOrUnsafeString(val, unsafePath)
 			hostUnsafe = unsafePath && len(val) > 0
-		case len(key) == 6 && asciiEqualFold(key, bAccept):
+			continue
+		case headerAccept:
+			accept = copyOrUnsafeString(val, unsafePath)
+			acceptUnsafe = unsafePath && len(val) > 0
+			continue
+		}
+
+		key = trimHTTPSpaces(key)
+
+		// Validate header name characters (RFC 7230 token set).
+		if !isValidTokenName(key) {
+			return nil, 0, false
+		}
+
+		switch knownHeader(key) {
+		case headerContentLength:
+			// Reject duplicate Content-Length headers.
+			if contentLengthSeen {
+				return nil, 0, false
+			}
+			contentLengthSeen = true
+			hasCL = true
+
+			// Reject non-numeric Content-Length values.
+			if !isAllDigits(val) {
+				return nil, 0, false
+			}
+			contentLength = btoi(val)
+		case headerContentType:
+			contentType = string(val)
+		case headerConnection:
+			if asciiEqualFold(val, bClose) {
+				keepAlive = false
+			}
+		case headerTransferEncoding:
+			hasTE = true
+		case headerCookie:
+			cookie = string(val)
+		case headerHost:
+			host = copyOrUnsafeString(val, unsafePath)
+			hostUnsafe = unsafePath && len(val) > 0
+		case headerAccept:
 			accept = copyOrUnsafeString(val, unsafePath)
 			acceptUnsafe = unsafePath && len(val) > 0
 		default:
@@ -314,6 +355,50 @@ var (
 	bHTTPVersionPrefix = []byte("HTTP/")
 	bStar              = []byte("*")
 )
+
+const (
+	headerUnknown uint8 = iota
+	headerContentLength
+	headerContentType
+	headerConnection
+	headerTransferEncoding
+	headerCookie
+	headerHost
+	headerAccept
+)
+
+func knownHeader(key []byte) uint8 {
+	switch len(key) {
+	case 4:
+		if asciiEqualFold(key, bHost) {
+			return headerHost
+		}
+	case 6:
+		if asciiEqualFold(key, bCookie) {
+			return headerCookie
+		}
+		if asciiEqualFold(key, bAccept) {
+			return headerAccept
+		}
+	case 10:
+		if asciiEqualFold(key, bConnection) {
+			return headerConnection
+		}
+	case 12:
+		if asciiEqualFold(key, bContentType) {
+			return headerContentType
+		}
+	case 14:
+		if asciiEqualFold(key, bContentLength) {
+			return headerContentLength
+		}
+	case 17:
+		if asciiEqualFold(key, bTransferEncoding) {
+			return headerTransferEncoding
+		}
+	}
+	return headerUnknown
+}
 
 // noLimits is a zero-value parserLimits (all unlimited).
 var noLimits = parserLimits{}

--- a/wing_http_test.go
+++ b/wing_http_test.go
@@ -181,6 +181,24 @@ func TestParseHTTPRequest_CommonHeadersAreSafeCopies(t *testing.T) {
 	}
 }
 
+func TestParseHTTPRequest_CommonHeaderNamesWithWhitespace(t *testing.T) {
+	raw := []byte("POST /safe HTTP/1.1\r\nHost : example.test\r\nContent-Type : application/json\r\nContent-Length : 2\r\n\r\n{}")
+	req, _, ok := parseHTTPRequest(raw, noLimits)
+	if !ok {
+		t.Fatal("parse failed")
+	}
+	if got := req.Header("Host"); got != "example.test" {
+		t.Fatalf("Header(Host) = %q, want example.test", got)
+	}
+	if got := req.Header("Content-Type"); got != "application/json" {
+		t.Fatalf("Header(Content-Type) = %q, want application/json", got)
+	}
+	body, _ := req.Body()
+	if string(body) != "{}" {
+		t.Fatalf("Body = %q, want {}", body)
+	}
+}
+
 func TestParseHTTPRequestFast_FinalizedStaticPathIsSafe(t *testing.T) {
 	raw := []byte("GET /plaintext-handler HTTP/1.1\r\nHost: example.test\r\n\r\n")
 	req, _, ok := parseHTTPRequestFast(raw, noLimits)


### PR DESCRIPTION
## Summary

This PR reduces Wing HTTP parser overhead for common request headers by adding a small `knownHeader` fast path before the fallback trim/validate path.

Scope is intentionally narrow:

- No default behavior change.
- No release, tag, or version bump.
- Normal handler, middleware, lifecycle, timeout, and security behavior remain unchanged.
- Header limits, CRLF rejection, duplicate `Content-Length` rejection, and `Transfer-Encoding` plus `Content-Length` rejection remain covered.
- Safe-copy behavior for retained request values is preserved.

## Implementation Notes

- Common header names with no whitespace around the key now avoid extra trimming and repeated length/equal-fold checks.
- Headers with legal but uncommon formatting, such as `Host : value`, still fall back through trim and token validation.
- Unknown headers keep the existing lowercase-copy path.
- Added targeted coverage for common header names with key-side whitespace.

## Local Benchmark Evidence

Environment:

- CPU: Apple M3
- OS/arch: darwin/arm64
- Go: go1.26.1
- Baseline: `origin/main` at `5f7d889`
- Branch: `317bdd6`
- Command:

```bash
go test -run '^$' -tags kruda_stdjson -bench 'Benchmark(Plaintext|JSON|CPUParse(GET|POST)|CPUResponse(Build|JSON|Plaintext)|CPUFullCycle|CPUHandler(Inline|PlaintextFeather|JSONStaticFeather|JSONSerializeFeather)|FeatherTableLookup|GetStaticResponseStringCached)$' -benchmem -count=5 ./...
benchstat /private/tmp/kruda-phase14-main-bench.txt /private/tmp/kruda-phase14-parser-full-branch.txt
```

Highlights:

- `CPUParseGET`: 184.3 ns/op -> 159.5 ns/op, -13.46%
- `CPUParsePOST`: 300.7 ns/op -> 212.1 ns/op, -29.46%
- `CPUFullCycle`: 261.1 ns/op -> 240.8 ns/op, -7.77%
- `Plaintext`: 52.88 ns/op -> 47.89 ns/op, -9.44%
- `JSON`: 307.8 ns/op -> 289.5 ns/op, -5.95%
- Hot-path geomean: 145.9 ns/op -> 134.1 ns/op, -8.11%
- No B/op or allocs/op increases in the measured CPU hot paths.
- `GetStaticResponseStringCached` remains unchanged within noise, with 0 B/op and 0 allocs/op.

## Verification

```bash
/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go test -count=1 -tags kruda_stdjson ./...
/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go test -race -count=1 -tags kruda_stdjson ./...
/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go vet -tags kruda_stdjson ./...
/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache scripts/test-standalone-modules.sh --verbose --race transport/wing
git diff --check
```
