### PR TITLE
docs: add v1.2.4 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to Kruda are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.2.4] — 2026-05-28
+
+### Added
+- Added opt-in Wing static response route options for public static hot paths: `WingStaticText` and `WingStaticJSON`.
+- Added reproducible CPU-bound benchmark evidence for Kruda, Fiber, and Actix, including latency percentiles, error counts, non-2xx counts, CPU/RAM resource data, syscall traces, and CPU profiles.
+- Added Wing flight model documentation defining Transport, Wing, Feather, and Bone terminology.
+
+### Changed
+- Improved Wing CPU-bound handler paths with single-handler dispatch, inline JSON response writing, common-header parsing, route Feather caching, clean path caching, lazy peer address lookup, read buffer tuning, and lower fair-handler overhead.
+- Updated public performance documentation to use balanced CPU-bound claim gates for throughput, p99 latency, socket errors, and non-2xx responses.
+- Hardened the reproducible benchmark harness to run CPU-only routes for Kruda, Fiber, and Actix with warmups, multiple rounds, latency profiles, throughput profiles, raw logs, and summaries.
+
+### Fixed
+- Fixed static response cache keys to include status codes and avoid cross-status cache reuse.
+- Preserved normal handler, middleware, lifecycle, cookie, CORS, and secure-header behavior outside explicitly documented static bypass routes.
+
 ## [1.2.3] — 2026-05-23
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Add the v1.2.4 changelog entry for the performance, benchmark, and documentation work already merged to `main`.
- Keep this PR release-neutral: it does not tag or publish a release.

## Verification
- `/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache-release go test -count=1 -tags kruda_stdjson ./...`
- `/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache-release go test -race -count=1 -tags kruda_stdjson ./...`
- `/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache-release ./scripts/pre-release.sh`
- `git diff --check`
- `git diff --cached --check`

## Notes
- Latest `main` CI for `0080da78aefd5a7df5ec73279df992c4bda68e9c` is green for Tests, Benchmark, and Deploy Docs.
- `revive` is not installed locally, so the pre-release script skipped the optional godoc completeness check exactly as scripted.
- No release tag is created by this PR.
