### PR TITLE
bench: support default Kruda JSON encoder runs

### DIFF
--- a/bench/reproducible/README.md
+++ b/bench/reproducible/README.md
@@ -58,6 +58,31 @@ Run one route:
 ./bench.sh json-static
 ```
 
+## Kruda JSON Encoder Mode
+
+The harness builds Kruda with `KRUDA_GO_TAGS=kruda_stdjson` by default so
+portable CPU-bound evidence does not depend on CGO availability. For JSON
+handler profile investigation, set `KRUDA_GO_TAGS=default` or an empty
+`KRUDA_GO_TAGS` value to build Kruda without explicit Go build tags. On
+CGO-enabled systems, that selects the default Sonic encoder path.
+
+Compare the JSON serialization route with stdlib JSON:
+
+```bash
+KRUDA_GO_TAGS=kruda_stdjson RESULT_DIR=results/json-stdjson-$(date -u +%Y%m%dT%H%M%SZ) ./bench.sh json-serialize
+```
+
+Compare the same route with Kruda's default build tags:
+
+```bash
+KRUDA_GO_TAGS=default RESULT_DIR=results/json-default-$(date -u +%Y%m%dT%H%M%SZ) ./bench.sh json-serialize
+```
+
+Use the same `KRUDA_GO_TAGS` values with `resource.sh`, `profile-kruda.sh`, or
+`syscall-profile.sh` when a JSON profile candidate needs resource or diagnostic
+evidence. The generated `environment.txt` records the effective
+`kruda_go_tags` value for each run.
+
 Run opt-in DB routes:
 
 ```bash

--- a/bench/reproducible/bench.sh
+++ b/bench/reproducible/bench.sh
@@ -27,9 +27,15 @@ KRUDA_WORKERS_VALUE="${KRUDA_WORKERS:-4}"
 KRUDA_READ_BUF_SIZE_VALUE="${KRUDA_READ_BUF_SIZE:-}"
 BENCH_ENABLE_DB_VALUE="${BENCH_ENABLE_DB:-0}"
 BENCH_ENABLE_PPROF_VALUE="${BENCH_ENABLE_PPROF:-0}"
-KRUDA_GO_TAGS_VALUE="${KRUDA_GO_TAGS:-kruda_stdjson}"
+KRUDA_GO_TAGS_VALUE="${KRUDA_GO_TAGS-kruda_stdjson}"
+if [ "$KRUDA_GO_TAGS_VALUE" = "default" ] || [ "$KRUDA_GO_TAGS_VALUE" = "none" ]; then
+  KRUDA_GO_TAGS_VALUE=""
+fi
 if [ "$BENCH_ENABLE_PPROF_VALUE" = "1" ]; then
-  KRUDA_GO_TAGS_VALUE="$KRUDA_GO_TAGS_VALUE bench_pprof"
+  case " $KRUDA_GO_TAGS_VALUE " in
+    *" bench_pprof "*) ;;
+    *) KRUDA_GO_TAGS_VALUE="${KRUDA_GO_TAGS_VALUE:+$KRUDA_GO_TAGS_VALUE }bench_pprof" ;;
+  esac
 fi
 BENCH_ROUNDS_VALUE="${BENCH_ROUNDS:-5}"
 BENCH_DURATION_VALUE="${BENCH_DURATION:-15s}"
@@ -109,7 +115,12 @@ build_all() {
   require_cmd wrk
   require_cmd curl
 
-  (cd "$SCRIPT_DIR/kruda" && GOWORK=off go build -tags "$KRUDA_GO_TAGS_VALUE" -o kruda-bench .)
+  local kruda_tag_args=()
+  if [ -n "$KRUDA_GO_TAGS_VALUE" ]; then
+    kruda_tag_args=(-tags "$KRUDA_GO_TAGS_VALUE")
+  fi
+
+  (cd "$SCRIPT_DIR/kruda" && GOWORK=off go build "${kruda_tag_args[@]}" -o kruda-bench .)
   (cd "$SCRIPT_DIR/fiber" && GOWORK=off go build -o fiber-bench .)
   (cd "$SCRIPT_DIR/actix" && cargo build --release)
 }
@@ -121,7 +132,7 @@ write_environment() {
     echo "result_dir=$RESULT_DIR"
     echo "bench_enable_db=$BENCH_ENABLE_DB_VALUE"
     echo "bench_enable_pprof=$BENCH_ENABLE_PPROF_VALUE"
-    echo "kruda_go_tags=$KRUDA_GO_TAGS_VALUE"
+    echo "kruda_go_tags=${KRUDA_GO_TAGS_VALUE:-default}"
     echo "gomaxprocs=$GOMAXPROCS_VALUE"
     echo "kruda_workers=$KRUDA_WORKERS_VALUE"
     echo "kruda_read_buf_size=${KRUDA_READ_BUF_SIZE_VALUE:-default}"

--- a/bench/reproducible/profile-kruda.sh
+++ b/bench/reproducible/profile-kruda.sh
@@ -25,7 +25,14 @@ BENCH_DURATION_VALUE="${BENCH_DURATION:-15}"
 WARMUP_DURATION_VALUE="${WARMUP_DURATION:-3}"
 THREADS_VALUE="${THREADS:-4}"
 CONNECTIONS_VALUE="${CONNECTIONS:-256}"
-KRUDA_GO_TAGS_VALUE="${KRUDA_GO_TAGS:-kruda_stdjson bench_pprof}"
+KRUDA_GO_TAGS_VALUE="${KRUDA_GO_TAGS-kruda_stdjson}"
+if [ "$KRUDA_GO_TAGS_VALUE" = "default" ] || [ "$KRUDA_GO_TAGS_VALUE" = "none" ]; then
+  KRUDA_GO_TAGS_VALUE=""
+fi
+case " $KRUDA_GO_TAGS_VALUE " in
+  *" bench_pprof "*) ;;
+  *) KRUDA_GO_TAGS_VALUE="${KRUDA_GO_TAGS_VALUE:+$KRUDA_GO_TAGS_VALUE }bench_pprof" ;;
+esac
 
 ROUTES=("$@")
 if [ "${#ROUTES[@]}" -eq 0 ]; then
@@ -83,7 +90,7 @@ write_environment() {
     echo "connections=$CONNECTIONS_VALUE"
     echo "profile_seconds=$BENCH_DURATION_VALUE"
     echo "warmup_seconds=$WARMUP_DURATION_VALUE"
-    echo "kruda_go_tags=$KRUDA_GO_TAGS_VALUE"
+    echo "kruda_go_tags=${KRUDA_GO_TAGS_VALUE:-default}"
     echo
     echo "== CPU =="
     if command -v lscpu >/dev/null 2>&1; then
@@ -107,7 +114,12 @@ build_kruda() {
   require_cmd wrk
   require_cmd curl
   mkdir -p "$RAW_DIR" "$PROFILE_DIR" "$REPORT_DIR"
-  (cd "$KRUDA_DIR" && GOWORK=off go build -tags "$KRUDA_GO_TAGS_VALUE" -o kruda-bench .)
+  local kruda_tag_args=()
+  if [ -n "$KRUDA_GO_TAGS_VALUE" ]; then
+    kruda_tag_args=(-tags "$KRUDA_GO_TAGS_VALUE")
+  fi
+
+  (cd "$KRUDA_DIR" && GOWORK=off go build "${kruda_tag_args[@]}" -o kruda-bench .)
 }
 
 start_kruda() {

--- a/bench/reproducible/resource.sh
+++ b/bench/reproducible/resource.sh
@@ -28,9 +28,15 @@ KRUDA_WORKERS_VALUE="${KRUDA_WORKERS:-4}"
 KRUDA_READ_BUF_SIZE_VALUE="${KRUDA_READ_BUF_SIZE:-}"
 BENCH_ENABLE_DB_VALUE="${BENCH_ENABLE_DB:-0}"
 BENCH_ENABLE_PPROF_VALUE="${BENCH_ENABLE_PPROF:-0}"
-KRUDA_GO_TAGS_VALUE="${KRUDA_GO_TAGS:-kruda_stdjson}"
+KRUDA_GO_TAGS_VALUE="${KRUDA_GO_TAGS-kruda_stdjson}"
+if [ "$KRUDA_GO_TAGS_VALUE" = "default" ] || [ "$KRUDA_GO_TAGS_VALUE" = "none" ]; then
+  KRUDA_GO_TAGS_VALUE=""
+fi
 if [ "$BENCH_ENABLE_PPROF_VALUE" = "1" ]; then
-  KRUDA_GO_TAGS_VALUE="$KRUDA_GO_TAGS_VALUE bench_pprof"
+  case " $KRUDA_GO_TAGS_VALUE " in
+    *" bench_pprof "*) ;;
+    *) KRUDA_GO_TAGS_VALUE="${KRUDA_GO_TAGS_VALUE:+$KRUDA_GO_TAGS_VALUE }bench_pprof" ;;
+  esac
 fi
 BENCH_DURATION_VALUE="${BENCH_DURATION:-15s}"
 RESOURCE_INTERVAL_VALUE="${RESOURCE_INTERVAL:-1}"
@@ -114,7 +120,12 @@ build_all() {
   require_cmd curl
   require_cmd pidstat
 
-  (cd "$SCRIPT_DIR/kruda" && GOWORK=off go build -tags "$KRUDA_GO_TAGS_VALUE" -o kruda-bench .)
+  local kruda_tag_args=()
+  if [ -n "$KRUDA_GO_TAGS_VALUE" ]; then
+    kruda_tag_args=(-tags "$KRUDA_GO_TAGS_VALUE")
+  fi
+
+  (cd "$SCRIPT_DIR/kruda" && GOWORK=off go build "${kruda_tag_args[@]}" -o kruda-bench .)
   (cd "$SCRIPT_DIR/fiber" && GOWORK=off go build -o fiber-bench .)
   (cd "$SCRIPT_DIR/actix" && cargo build --release)
 }
@@ -126,7 +137,7 @@ write_environment() {
     echo "result_dir=$RESULT_DIR"
     echo "bench_enable_db=$BENCH_ENABLE_DB_VALUE"
     echo "bench_enable_pprof=$BENCH_ENABLE_PPROF_VALUE"
-    echo "kruda_go_tags=$KRUDA_GO_TAGS_VALUE"
+    echo "kruda_go_tags=${KRUDA_GO_TAGS_VALUE:-default}"
     echo "gomaxprocs=$GOMAXPROCS_VALUE"
     echo "kruda_workers=$KRUDA_WORKERS_VALUE"
     echo "kruda_read_buf_size=${KRUDA_READ_BUF_SIZE_VALUE:-default}"

--- a/bench/reproducible/syscall-profile.sh
+++ b/bench/reproducible/syscall-profile.sh
@@ -33,7 +33,10 @@ GOMAXPROCS_VALUE="${GOMAXPROCS:-8}"
 KRUDA_WORKERS_VALUE="${KRUDA_WORKERS:-4}"
 KRUDA_READ_BUF_SIZE_VALUE="${KRUDA_READ_BUF_SIZE:-4096}"
 BENCH_ENABLE_DB_VALUE="${BENCH_ENABLE_DB:-0}"
-KRUDA_GO_TAGS_VALUE="${KRUDA_GO_TAGS:-kruda_stdjson}"
+KRUDA_GO_TAGS_VALUE="${KRUDA_GO_TAGS-kruda_stdjson}"
+if [ "$KRUDA_GO_TAGS_VALUE" = "default" ] || [ "$KRUDA_GO_TAGS_VALUE" = "none" ]; then
+  KRUDA_GO_TAGS_VALUE=""
+fi
 PERF_EVENTS="${PERF_EVENTS:-task-clock,cycles,instructions,context-switches,cpu-migrations,page-faults}"
 PROFILE_SUDO="${PROFILE_SUDO:-0}"
 
@@ -113,7 +116,12 @@ build_all() {
   require_cmd perf
   require_cmd strace
 
-  (cd "$SCRIPT_DIR/kruda" && GOWORK=off go build -tags "$KRUDA_GO_TAGS_VALUE" -o kruda-bench .)
+  local kruda_tag_args=()
+  if [ -n "$KRUDA_GO_TAGS_VALUE" ]; then
+    kruda_tag_args=(-tags "$KRUDA_GO_TAGS_VALUE")
+  fi
+
+  (cd "$SCRIPT_DIR/kruda" && GOWORK=off go build "${kruda_tag_args[@]}" -o kruda-bench .)
   (cd "$SCRIPT_DIR/actix" && cargo build --release)
 }
 
@@ -132,6 +140,7 @@ write_environment() {
     echo "kruda_workers=$KRUDA_WORKERS_VALUE"
     echo "kruda_read_buf_size=$KRUDA_READ_BUF_SIZE_VALUE"
     echo "bench_enable_db=$BENCH_ENABLE_DB_VALUE"
+    echo "kruda_go_tags=${KRUDA_GO_TAGS_VALUE:-default}"
     echo "routes=${ROUTES[*]}"
     echo "frameworks=${FRAMEWORKS[*]}"
     echo


### PR DESCRIPTION
## Summary

This PR prepares the reproducible benchmark harness for Wing Phase 6 JSON handler profile investigation.

It does not change Kruda runtime behavior, framework defaults, public APIs, benchmark results, release metadata, or benchmark claims.

## Changes

- Allow `KRUDA_GO_TAGS=default`, `KRUDA_GO_TAGS=none`, or an empty `KRUDA_GO_TAGS` value to build the Kruda benchmark app without explicit Go build tags.
- Keep the harness default as `KRUDA_GO_TAGS=kruda_stdjson` for portable CPU-bound evidence.
- Omit `go build -tags` entirely when the effective tag set is empty instead of passing `-tags ""`.
- Preserve `bench_pprof` handling for profiling runs without duplicating the tag.
- Record the effective `kruda_go_tags` value in benchmark environment metadata.
- Document JSON-only stdlib JSON vs default/Sonic comparison commands.

## Validation

- `/bin/bash -n bench/reproducible/bench.sh`
- `/bin/bash -n bench/reproducible/resource.sh`
- `/bin/bash -n bench/reproducible/profile-kruda.sh`
- `/bin/bash -n bench/reproducible/syscall-profile.sh`
- `go build -tags kruda_stdjson -o /private/tmp/kruda-bench-stdjson .` from `bench/reproducible/kruda`
- `go build -o /private/tmp/kruda-bench-default .` from `bench/reproducible/kruda`
- `git diff --cached --check`
- Added-line scan for non-ASCII public text and attribution or benchmark overclaim terms

The full cross-runtime harness was not run locally because this machine does not have `cargo` and `pidstat` available. The next evidence step should run the documented JSON-only commands on the Linux benchmark server.
