### PR TITLE
perf: pre-size Wing JSON response buffers

### DIFF
--- a/wing_http.go
+++ b/wing_http.go
@@ -815,6 +815,8 @@ func init() {
 // cachedDateHdr holds "Date: <RFC1123>\r\n" updated every second.
 var cachedDateHdr atomic.Pointer[[]byte]
 
+const jsonHeaderContentLength = "Content-Type: application/json; charset=utf-8\r\nContent-Length: "
+
 func init() {
 	updateDateHdr()
 	go func() {
@@ -874,13 +876,12 @@ func (r *wingResponse) buildZeroCopy() []byte {
 
 	// JSON fast path — status + Date + Content-Type:json + Content-Length + body
 	if r.jsonFast {
-		if r.status > 0 && r.status < len(statusLines) && statusLines[r.status] != nil {
-			b = append(b, statusLines[r.status]...)
-		} else {
-			b = append(b, "HTTP/1.1 200 OK\r\n"...)
-		}
-		b = append(b, dateHdr()...)
-		b = append(b, "Content-Type: application/json; charset=utf-8\r\nContent-Length: "...)
+		statusLine := jsonStatusLine(r.status)
+		date := dateHdr()
+		b = growForAppend(b, len(statusLine)+len(date)+len(jsonHeaderContentLength)+contentLengthValueLen(len(r.body))+4+len(r.body))
+		b = append(b, statusLine...)
+		b = append(b, date...)
+		b = append(b, jsonHeaderContentLength...)
 		b = appendContentLengthValue(b, len(r.body))
 		b = append(b, "\r\n\r\n"...)
 		b = append(b, r.body...)
@@ -955,17 +956,32 @@ func (r *wingResponse) appendPlaintextTo(b []byte) []byte {
 }
 
 func (r *wingResponse) appendJSONTo(b []byte) []byte {
-	if r.status > 0 && r.status < len(statusLines) && statusLines[r.status] != nil {
-		b = append(b, statusLines[r.status]...)
-	} else {
-		b = append(b, "HTTP/1.1 200 OK\r\n"...)
-	}
-	b = append(b, dateHdr()...)
-	b = append(b, "Content-Type: application/json; charset=utf-8\r\nContent-Length: "...)
+	statusLine := jsonStatusLine(r.status)
+	date := dateHdr()
+	b = growForAppend(b, len(statusLine)+len(date)+len(jsonHeaderContentLength)+contentLengthValueLen(len(r.body))+4+len(r.body))
+	b = append(b, statusLine...)
+	b = append(b, date...)
+	b = append(b, jsonHeaderContentLength...)
 	b = appendContentLengthValue(b, len(r.body))
 	b = append(b, "\r\n\r\n"...)
 	b = append(b, r.body...)
 	return b
+}
+
+func jsonStatusLine(status int) []byte {
+	if status > 0 && status < len(statusLines) && statusLines[status] != nil {
+		return statusLines[status]
+	}
+	return statusLines[200]
+}
+
+func growForAppend(b []byte, extra int) []byte {
+	if cap(b)-len(b) >= extra {
+		return b
+	}
+	out := make([]byte, len(b), len(b)+extra)
+	copy(out, b)
+	return out
 }
 
 func appendContentLengthValue(b []byte, n int) []byte {
@@ -973,6 +989,28 @@ func appendContentLengthValue(b []byte, n int) []byte {
 		return append(b, contentLengthStrings[n]...)
 	}
 	return strconv.AppendInt(b, int64(n), 10)
+}
+
+func contentLengthValueLen(n int) int {
+	if n >= 0 && n < len(contentLengthStrings) {
+		return len(contentLengthStrings[n])
+	}
+	if n == 0 {
+		return 1
+	}
+	if n < 0 {
+		return 1 + decimalLen(-n)
+	}
+	return decimalLen(n)
+}
+
+func decimalLen(n int) int {
+	digits := 0
+	for n > 0 {
+		digits++
+		n /= 10
+	}
+	return digits
 }
 
 // build serialises the HTTP response with a safe copy (for async dispatch).


### PR DESCRIPTION
## Summary

This PR pre-sizes Wing JSON response buffers before appending the status line, date header, JSON content type, content length, separator, and body bytes.

The change is intentionally narrow:

- no public API changes
- no default behavior changes
- no middleware, lifecycle, parser, timeout, or security contract changes
- no benchmark claim wording changes

## Why

The Wing JSON fast path previously appended response chunks into an empty or undersized buffer, which caused several slice growth steps in the CPU-bound JSON response path. Pre-sizing the buffer removes those intermediate reallocations while keeping the same response bytes and ownership model.

## Evidence

Baseline: `origin/main` at `6c4e78f`.

Candidate: `perf/wing-json-build-buffer`.

Machine: Apple M3, `darwin/arm64`.

Stdlib JSON build tag:

```text
CPUResponseJSON-8                         109.30n -> 40.39n  -63.04%
CPUHandlerJSONStaticFeather-8             277.2n  -> 213.8n  -22.89%
CPUHandlerJSONSerializeFeather-8          356.2n  -> 289.1n  -18.82%

CPUResponseJSON-8                         472 B/op -> 160 B/op  -66.10%, 4 -> 1 allocs/op
CPUHandlerJSONStaticFeather-8             472 B/op -> 160 B/op  -66.10%, 4 -> 1 allocs/op
CPUHandlerJSONSerializeFeather-8          504 B/op -> 192 B/op  -61.90%, 5 -> 2 allocs/op
```

Default JSON encoder:

```text
CPUResponseJSON-8                         105.90n -> 39.87n  -62.35%
CPUHandlerJSONStaticFeather-8             268.2n  -> 204.4n  -23.79%
CPUHandlerJSONSerializeFeather-8          449.1n  -> 368.7n  -17.89%

CPUResponseJSON-8                         472 B/op   -> 160 B/op  -66.10%, 4 -> 1 allocs/op
CPUHandlerJSONStaticFeather-8             472 B/op   -> 160 B/op  -66.10%, 4 -> 1 allocs/op
CPUHandlerJSONSerializeFeather-8          551.5 B/op -> 217 B/op  -60.65%, 6 -> 3 allocs/op
```

## Validation

```bash
/usr/bin/env GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache go test -count=1 -tags kruda_stdjson ./...
/usr/bin/env GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache go test -race -count=1 -tags kruda_stdjson ./...
/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOARCH=arm64 GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache go test -run '^$' -tags kruda_stdjson -bench 'Benchmark(CPUHandlerJSONStaticFeather|CPUHandlerJSONSerializeFeather|CPUResponseJSON)$' -benchmem -count=8 ./...
/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOARCH=arm64 GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache go test -run '^$' -bench 'Benchmark(CPUHandlerJSONStaticFeather|CPUHandlerJSONSerializeFeather|CPUResponseJSON)$' -benchmem -count=8 ./...
git diff --check
```
