### PR TITLE
docs: clarify Wing query profile guidance

### DIFF
--- a/bench/reproducible/README.md
+++ b/bench/reproducible/README.md
@@ -117,6 +117,16 @@ The sweep runs Kruda only, stores per-run `bench.sh` output under
 `results/kruda-db-dispatch-sweep-<timestamp>/runs/`, and writes aggregate
 median RPS/p99/error summaries to `dispatch-summary.csv` and `summary.md`.
 
+Current Phase 6 tiger sweep evidence is in
+`results/phase6-profile-inventory-pr79-20260602T031308Z/`. In that run,
+Takeover/Spear was the best throughput fit for `/db`, `/queries`, and
+`/fortunes` with zero socket errors and zero non-2xx responses. The write-heavy
+`/updates` route did not have a clean universal winner: Takeover/Spear kept
+errors at zero but had high p99 latency, while Inline produced socket errors in
+the throughput profile. Use this evidence as query-profile guidance, not as a
+cross-runtime benchmark claim or a blanket recommendation for every DB write
+route.
+
 Kruda's benchmark pprof server is excluded from the default CPU-only benchmark binary so the runtime comparison does not include a diagnostic HTTP server that the Fiber and Actix apps do not run. The harness adds the `bench_pprof` Go build tag only when `BENCH_ENABLE_PPROF=1`:
 
 ```bash

--- a/cmd/kruda/cmd_mcp.go
+++ b/cmd/kruda/cmd_mcp.go
@@ -614,7 +614,7 @@ func toolSuggestWing(args map[string]any) (string, error) {
 	sb.WriteString("\nAvailable hints:\n")
 	sb.WriteString("  WingPlaintext() — minimal responses (health, ping, plain text)\n")
 	sb.WriteString("  WingJSON()      — JSON serialization endpoints\n")
-	sb.WriteString("  WingQuery()     — database read/write operations\n")
+	sb.WriteString("  WingQuery()     — DB/Redis read-style queries; benchmark write-heavy routes separately\n")
 	sb.WriteString("  WingRender()    — HTML template rendering\n")
 	sb.WriteString("\nStreaming and SSE routes do not have a Wing route hint; keep them on a normal handler route and choose transport-level compatibility deliberately.\n")
 
@@ -644,15 +644,20 @@ func suggestFeather(r routeInfo) (string, string) {
 		return "WingRender()", "HTML template rendering"
 	}
 
-	// DB operations: write methods or paths with :id
+	// Write-heavy routes need workload evidence because latency and lock
+	// contention can dominate dispatch overhead.
 	if r.Method == "POST" || r.Method == "PUT" || r.Method == "PATCH" || r.Method == "DELETE" {
-		return "WingQuery()", "database write operation"
+		return "WingQuery()", "write-heavy route; benchmark with your DB pool and p99 target"
 	}
 
-	// DB read: path with :id param or typical DB patterns
+	// DB read: path with :id param or typical DB/query patterns
 	if strings.Contains(r.Path, ":id") || strings.Contains(lpath, "/db") ||
-		strings.Contains(lpath, "/queries") || strings.Contains(lpath, "/updates") {
-		return "WingQuery()", "database read/write"
+		strings.Contains(lpath, "/queries") {
+		return "WingQuery()", "DB/Redis read-style query"
+	}
+
+	if strings.Contains(lpath, "/updates") {
+		return "WingQuery()", "write-heavy benchmark route; validate dispatch with p99 and errors"
 	}
 
 	// JSON endpoint
@@ -884,7 +889,7 @@ Per-route I/O strategy optimization. Add as the last argument to route registrat
 ` + "```" + `go
 app.Get("/json", handler, kruda.WingJSON())         // JSON serialization
 app.Get("/text", handler, kruda.WingPlaintext())     // minimal plain text
-app.Get("/db",   handler, kruda.WingQuery())         // database operations
+app.Get("/db",   handler, kruda.WingQuery())         // DB/Redis read-style query
 app.Get("/page", handler, kruda.WingRender())        // HTML template rendering
 ` + "```" + `
 
@@ -892,10 +897,11 @@ app.Get("/page", handler, kruda.WingRender())        // HTML template rendering
 |---------|----------|-------------|
 | WingPlaintext | /health, /ping, static text | Pre-allocated headers, minimal alloc |
 | WingJSON | JSON APIs | Sonic encoder, pre-sized buffers |
-| WingQuery | DB read/write | Connection-aware scheduling |
+| WingQuery | DB/Redis read-style queries | Connection-aware scheduling |
 | WingRender | HTML templates | Buffer pooling for large responses |
 
 Feather hints are optional — routes work fine without them.
+Benchmark write-heavy routes with your DB pool, p99 target, and error gate before treating them as query-profile routes.
 Streaming and SSE routes do not have a Wing route hint; keep them on normal handlers and choose the transport for compatibility deliberately.`,
 
 	"config": `# Configuration

--- a/cmd/kruda/cmd_mcp_test.go
+++ b/cmd/kruda/cmd_mcp_test.go
@@ -22,3 +22,36 @@ func TestMCPDocsDoNotMentionWingStream(t *testing.T) {
 		}
 	}
 }
+
+func TestSuggestFeatherDBReadStyleRoute(t *testing.T) {
+	feather, reason := suggestFeather(routeInfo{Method: "GET", Path: "/queries"})
+	if feather != "WingQuery()" {
+		t.Fatalf("feather = %q, want WingQuery()", feather)
+	}
+	if !strings.Contains(reason, "read-style query") {
+		t.Fatalf("reason = %q, want read-style query guidance", reason)
+	}
+}
+
+func TestSuggestFeatherWriteRouteRequiresBenchmarking(t *testing.T) {
+	feather, reason := suggestFeather(routeInfo{Method: "POST", Path: "/products"})
+	if feather != "WingQuery()" {
+		t.Fatalf("feather = %q, want WingQuery()", feather)
+	}
+	if !strings.Contains(reason, "benchmark") || !strings.Contains(reason, "p99") {
+		t.Fatalf("reason = %q, want benchmark and p99 guidance", reason)
+	}
+}
+
+func TestMCPWingDocsKeepQueryAndWriteGuidanceSeparate(t *testing.T) {
+	doc := krudaDocs["wing"]
+	if strings.Contains(doc, "DB read/write") || strings.Contains(doc, "database read/write") {
+		t.Fatalf("wing docs use broad read/write guidance: %q", doc)
+	}
+	if !strings.Contains(doc, "DB/Redis read-style queries") {
+		t.Fatalf("wing docs missing read-style query guidance")
+	}
+	if !strings.Contains(doc, "Benchmark write-heavy routes") {
+		t.Fatalf("wing docs missing write-heavy benchmark guidance")
+	}
+}

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -213,7 +213,9 @@ app.Get("/fortunes",  handler, kruda.WingRender())     // Blocking goroutine per
 
 CPU-bound routes (plaintext, JSON) use **Inline** dispatch — handler runs directly on the epoll worker with zero overhead.
 
-I/O-bound routes (DB, Redis) use **Spear** dispatch — handler runs in a blocking goroutine that owns the connection, and the Go runtime auto-creates OS threads as needed.
+Read-style I/O routes (DB, Redis) use **Spear** dispatch — handler runs in a blocking goroutine that owns the connection, and the Go runtime auto-creates OS threads as needed.
+
+Phase 6 tiger evidence supports `WingQuery()`/Spear for DB read-style workloads in the reproducible harness: `/db`, `/queries`, and `/fortunes` had much higher median throughput than Inline with zero socket errors and zero non-2xx responses. Write-heavy routes are different. The `/updates` route had zero errors with `WingQuery()` but much higher p99 latency, while Inline produced socket errors in the throughput profile. Treat write-heavy DB routes as workload-specific tuning: benchmark with your real DB pool, p99 target, and error gate before choosing a dispatch hint.
 
 ### Handler-Level Static JSON
 


### PR DESCRIPTION
## Summary

Clarifies Wing query-profile guidance so docs and the `kruda_suggest_wing` MCP helper do not describe `WingQuery()` as a blanket DB read/write recommendation.

## What Changed

- Documents that Phase 6 DB dispatch evidence supports `WingQuery()`/Spear for read-style DB workloads such as `/db`, `/queries`, and `/fortunes`.
- Calls out write-heavy routes separately because `/updates` did not have a clean universal winner: `WingQuery()` kept errors at zero but had high p99, while Inline produced socket errors in the throughput profile.
- Updates `kruda_suggest_wing` wording and docs to recommend benchmarking write-heavy routes with the real DB pool, p99 target, and error gate.
- Adds focused tests so the MCP docs and suggestions do not drift back to broad DB read/write wording.

## Behavior

No runtime behavior changes. This only updates guidance and CLI/MCP text.

## Verification

```bash
/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOTOOLCHAIN=local GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache-phase6 GOMODCACHE=/private/tmp/kruda-go-mod-cache-phase6 go test -count=1 -tags kruda_stdjson ./...
```

Run from `cmd/kruda`:

```bash
/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOTOOLCHAIN=local GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache-phase6 GOMODCACHE=/private/tmp/kruda-go-mod-cache-phase6 go test -count=1 -tags kruda_stdjson ./...
```
