### PR TITLE
bench: record rejected Wing JSON bytes candidate

### DIFF
--- a/bench/reproducible/results/2026-06-02-wing-json-bytes-responder-rejection.md
+++ b/bench/reproducible/results/2026-06-02-wing-json-bytes-responder-rejection.md
@@ -1,0 +1,130 @@
+# Wing JSON Bytes Responder Rejection Evidence
+
+Date: 2026-06-02
+
+Scope: local microbenchmark evidence plus a fresh tiger CPU profile check for a
+narrow Wing handler-path JSON bytes candidate. This is not cross-runtime Actix
+evidence and not a public performance claim.
+
+## Candidate
+
+The candidate moved the Wing `JSONResponder` check in
+`Ctx.SendStaticWithTypeBytes` before the fasthttp static-body fast path when the
+content type is Kruda's JSON content type.
+
+Rationale:
+
+- `SendStaticJSON` already benefits from trying Wing's `JSONResponder` before a
+  guaranteed fasthttp miss on Wing.
+- `SendStaticWithTypeBytes(jsonContentType, data)` reaches the same Wing JSON
+  response builder but still checked the fasthttp static-body path first.
+
+The runtime change was reverted because it did not produce a statistically
+meaningful improvement.
+
+## Added Benchmark Coverage
+
+This PR keeps a non-public microbenchmark for the previously unmeasured static
+JSON bytes helper:
+
+- `BenchmarkCPUHandlerJSONStaticBytesFeather`
+
+The benchmark exercises a normal Wing handler route using:
+
+```go
+c.SendStaticWithTypeBytes(jsonContentType, benchStaticJSONBody)
+```
+
+## Local Command
+
+Baseline worktree: `origin/main` at
+`1395a66a32c3e7ce71cb0dbe34b694e040d72302`, with only the new benchmark added
+for measurement.
+
+Candidate branch: `perf/wing-json-bytes-responder-first`, before the runtime
+change was reverted.
+
+```bash
+/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin \
+  GOTOOLCHAIN=local \
+  GOWORK=off \
+  GOCACHE=/private/tmp/kruda-go-build-cache-phase8 \
+  GOMODCACHE=/private/tmp/kruda-go-mod-cache-phase8 \
+  go test -run '^$' -tags kruda_stdjson \
+    -bench 'Benchmark(CPUHandlerJSONStatic(Bytes)?Feather)$' \
+    -benchmem -count=10 ./
+```
+
+Environment:
+
+- Host: local Apple M3
+- OS/arch: darwin/arm64
+- Go: local toolchain reported `go1.26.1`
+- Build tags: `kruda_stdjson`
+
+## Benchstat
+
+```text
+name                                  main sec/op    candidate sec/op    delta
+CPUHandlerJSONStaticFeather-8         219.7n +/- 6%  220.4n +/- 1%      ~ (p=0.468 n=10)
+CPUHandlerJSONStaticBytesFeather-8    221.6n +/- 1%  221.4n +/- 2%      ~ (p=0.684 n=10)
+geomean                               220.6n         220.9n             +0.15%
+
+name                                  main B/op      candidate B/op      delta
+CPUHandlerJSONStaticFeather-8         160.0 +/- 0%   160.0 +/- 0%       no change
+CPUHandlerJSONStaticBytesFeather-8    160.0 +/- 0%   160.0 +/- 0%       no change
+
+name                                  main alloc/op  candidate alloc/op  delta
+CPUHandlerJSONStaticFeather-8         1.000 +/- 0%   1.000 +/- 0%       no change
+CPUHandlerJSONStaticBytesFeather-8    1.000 +/- 0%   1.000 +/- 0%       no change
+```
+
+## Tiger Profile Check
+
+Worktree:
+`/home/tiger/kruda-main-1395a66-20260602` at
+`1395a66a32c3e7ce71cb0dbe34b694e040d72302`.
+
+Result directory:
+`/home/tiger/kruda-main-1395a66-20260602/bench/reproducible/results/profile-20260602T092329Z`.
+
+Command:
+
+```bash
+PORT=3310 PPROF_PORT=6310 BENCH_FRAMEWORKS=kruda BENCH_ROUNDS=1 BENCH_DURATION=10 \
+  ./profile-kruda.sh plaintext-handler json-static json-serialize
+```
+
+Environment summary:
+
+- CPU: 13th Gen Intel Core i5-13500, 8 online CPUs
+- OS: Linux `6.8.0-117-generic`
+- Go: `go1.26.3 linux/amd64`
+- wrk: Debian `4.1.0-4build2`
+- `GOMAXPROCS=8`
+- `KRUDA_WORKERS=4`
+- `KRUDA_READ_BUF_SIZE=4096`
+- Build tags: `kruda_stdjson bench_pprof`
+- wrk shape: 4 threads, 256 connections
+
+Fresh profile summary:
+
+| Route | RPS during profile | p99 | Dominant flat CPU |
+|---|---:|---:|---:|
+| `plaintext-handler` | 853,329.87 | 0.90 ms | `internal/runtime/syscall/linux.Syscall6` 83.67% |
+| `json-static` | 818,812.95 | 1.16 ms | `internal/runtime/syscall/linux.Syscall6` 86.68% |
+| `json-serialize` | 792,773.15 | 1.01 ms | `internal/runtime/syscall/linux.Syscall6` 83.17% |
+
+The wrk outputs did not report socket errors or non-2xx responses. This is
+diagnostic profile evidence only because pprof was enabled and only Kruda was
+measured.
+
+## Decision
+
+Reject the Wing-first `SendStaticWithTypeBytes` JSON responder reorder.
+
+The candidate did not improve the directly targeted microbenchmark and did not
+change allocation behavior. The fresh tiger profile still shows the CPU-bound
+routes are dominated by socket/syscall cost, so further fair-handler CPU-bound
+runtime work should start from a new I/O architecture hypothesis or a narrowed
+JSON-serialization-only goal.

--- a/docs/superpowers/specs/2026-05-29-wing-phase6-workload-profiles-design.md
+++ b/docs/superpowers/specs/2026-05-29-wing-phase6-workload-profiles-design.md
@@ -113,6 +113,7 @@ Do not repeat without new evidence:
 - Worker count increase from 4 to 8 for the current tiger throughput profile.
 - Lowering `GOMAXPROCS` from 8 to 4 for the current tiger throughput profile.
 - Concrete Wing responder assertion in `Ctx.Text` or `Ctx.JSON`; local microbenchmarks rejected it on 2026-05-30.
+- Moving the Wing `JSONResponder` check before the fasthttp static-body path in `SendStaticWithTypeBytes`; local microbenchmarks on 2026-06-02 showed no meaningful improvement for `BenchmarkCPUHandlerJSONStaticBytesFeather`.
 
 ### Static Bypass Profile
 

--- a/wing_bench_test.go
+++ b/wing_bench_test.go
@@ -176,6 +176,30 @@ func BenchmarkCPUHandlerJSONStaticFeather(b *testing.B) {
 	runtime.KeepAlive(out)
 }
 
+func BenchmarkCPUHandlerJSONStaticBytesFeather(b *testing.B) {
+	app := New(Wing())
+	app.Get("/json-static", func(c *Ctx) error {
+		return c.SendStaticWithTypeBytes(jsonContentType, benchStaticJSONBody)
+	}, WingJSON())
+	app.Compile()
+	f := app.transport.(*Transport).config.Feathers["GET /json-static"]
+	w := &worker{handler: app}
+
+	b.ReportAllocs()
+	out := make([]byte, 0, 256)
+	for b.Loop() {
+		req, _, _ := parseHTTPRequestFast(rawJSONStaticGET, noLimits)
+		finalizeRequestPath(req, f)
+		resp := acquireResponse()
+		resp.responseMode = f.ResponseMode
+		w.serveRoute(resp, req, f)
+		out = append(out[:0], resp.buildZeroCopy()...)
+		releaseResponse(resp)
+		releaseRequest(req)
+	}
+	runtime.KeepAlive(out)
+}
+
 func BenchmarkCPUHandlerJSONSerializeFeather(b *testing.B) {
 	app := New(Wing())
 	app.Get("/json-serialize", func(c *Ctx) error {


### PR DESCRIPTION
## Summary

This PR records a rejected Wing JSON bytes responder candidate and adds one focused benchmark for the previously unmeasured helper path.

No runtime behavior changes are included.

## Changes

- Add `BenchmarkCPUHandlerJSONStaticBytesFeather` for `SendStaticWithTypeBytes(jsonContentType, ...)` on a normal Wing handler route.
- Record local benchstat evidence rejecting the Wing-first `SendStaticWithTypeBytes` JSON responder reorder.
- Record a fresh tiger Kruda-only CPU profile for current `main` at `1395a66`.
- Update the Phase 6 do-not-repeat list with this rejected candidate.

## Evidence

Local microbench, `kruda_stdjson`, Apple M3, `-count=10`:

- `BenchmarkCPUHandlerJSONStaticBytesFeather`: `221.6n +/- 1%` to `221.4n +/- 2%`, not significant (`p=0.684`).
- `BenchmarkCPUHandlerJSONStaticFeather`: `219.7n +/- 6%` to `220.4n +/- 1%`, not significant (`p=0.468`).
- No B/op or alloc/op changes.

Tiger profile, current `main` at `1395a66`:

- `plaintext-handler`: `internal/runtime/syscall/linux.Syscall6` 83.67% flat CPU.
- `json-static`: `internal/runtime/syscall/linux.Syscall6` 86.68% flat CPU.
- `json-serialize`: `internal/runtime/syscall/linux.Syscall6` 83.17% flat CPU.

This profile was diagnostic Kruda-only evidence with pprof enabled. It is not cross-runtime Actix evidence and not a public benchmark claim.

## Verification

```bash
/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin \
  GOTOOLCHAIN=local GOWORK=off \
  GOCACHE=/private/tmp/kruda-go-build-cache-phase8 \
  GOMODCACHE=/private/tmp/kruda-go-mod-cache-phase8 \
  go test -count=1 -tags kruda_stdjson ./...

/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin \
  GOTOOLCHAIN=local GOWORK=off \
  GOCACHE=/private/tmp/kruda-go-build-cache-phase8 \
  GOMODCACHE=/private/tmp/kruda-go-mod-cache-phase8 \
  go test -race -count=1 -tags kruda_stdjson ./...

/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin \
  GOTOOLCHAIN=local GOWORK=off \
  GOCACHE=/private/tmp/kruda-go-build-cache-phase8 \
  GOMODCACHE=/private/tmp/kruda-go-mod-cache-phase8 \
  go test -run '^$' -tags kruda_stdjson \
    -bench 'BenchmarkCPUHandlerJSONStaticBytesFeather$' \
    -benchmem -count=1 ./
```
