### PR TITLE
bench: add pipelined I/O diagnostic harness

### DIFF
--- a/bench/reproducible/.gitignore
+++ b/bench/reproducible/.gitignore
@@ -1,4 +1,5 @@
 # Compiled binaries (don't commit, build locally)
 kruda/kruda-bench
 fiber/fiber-bench
+pipeline-client/pipeline-client
 actix/target/

--- a/bench/reproducible/README.md
+++ b/bench/reproducible/README.md
@@ -23,6 +23,8 @@ bench/reproducible/
 ├── actix/          # Actix Web 4
 ├── bench.sh        # Automated benchmark script
 ├── resource.sh     # CPU/RAM resource benchmark script
+├── pipeline.sh     # HTTP/1.1 pipelined I/O diagnostic harness
+├── pipeline-client/ # Go pipelined HTTP/1.1 load generator
 ├── profile-kruda.sh # Kruda-only pprof capture helper
 └── README.md
 ```
@@ -57,6 +59,43 @@ Run one route:
 ```bash
 ./bench.sh json-static
 ```
+
+## Pipelined I/O Diagnostic
+
+Use `pipeline.sh` when investigating whether an HTTP backend benefits from
+batched writes and multiple in-flight HTTP/1.1 requests per TCP connection.
+This is a diagnostic workload for I/O architecture decisions. Keep it separate
+from the default `wrk --latency` handler-path benchmark claims because many
+real clients do not use HTTP/1.1 pipelining.
+
+```bash
+cd bench/reproducible
+./pipeline.sh plaintext-handler
+```
+
+The default profiles are:
+
+| Profile | Connections | Pipeline depth |
+|---------|------------:|---------------:|
+| `baseline-c128-d1` | 128 | 1 |
+| `pipeline-c128-d8` | 128 | 8 |
+| `pipeline-c256-d8` | 256 | 8 |
+
+Override profiles with `PIPELINE_PROFILES` entries in
+`name:connections:depth` format:
+
+```bash
+PIPELINE_PROFILES="baseline-c128-d1:128:1 pipeline-c128-d16:128:16" ./pipeline.sh
+```
+
+The harness builds Kruda, Fiber, Actix, and `pipeline-client` from their own
+directories, starts servers by PID, waits for readiness, and writes raw logs
+plus `summary.csv`, `summary.md`, and `environment.txt` under
+`results/pipeline-<timestamp>/`.
+
+Use these results to decide whether to implement a workload-specific Wing I/O
+profile or Feather. Do not use pipelined results as a blanket real-world API
+claim unless the public wording labels the workload explicitly.
 
 ## Kruda JSON Encoder Mode
 
@@ -187,6 +226,16 @@ Results are written to `bench/reproducible/results/<timestamp>/`:
 | `summary.csv` | Machine-readable per-round RPS, p50, p90, p99, max latency, socket errors, and non-2xx responses |
 | `summary.md` | Markdown table for PR evidence |
 | `raw/*.txt` | Raw `wrk --latency` output and server logs |
+
+Pipelined diagnostic results are written to
+`bench/reproducible/results/pipeline-<timestamp>/`:
+
+| File | Purpose |
+|------|---------|
+| `environment.txt` | CPU, OS, toolchain, route, profile, worker, and pipeline metadata |
+| `summary.csv` | Machine-readable per-round requests, RPS, p50, p90, p99, max latency, socket errors, and non-2xx responses |
+| `summary.md` | Markdown table for diagnostic evidence |
+| `raw/*.txt` | Raw `pipeline-client` output and server logs |
 
 Resource results are written to `bench/reproducible/results/resource-<timestamp>/`:
 

--- a/bench/reproducible/pipeline-client/main.go
+++ b/bench/reproducible/pipeline-client/main.go
@@ -1,0 +1,434 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+const userAgent = "kruda-pipeline-client/1"
+
+type config struct {
+	target      string
+	connections int
+	depth       int
+	duration    time.Duration
+	warmup      time.Duration
+	timeout     time.Duration
+}
+
+type target struct {
+	url        string
+	addr       string
+	hostHeader string
+	requestURI string
+}
+
+type result struct {
+	requests     int64
+	socketErrors int64
+	non2xx       int64
+	latencies    []int64
+}
+
+func main() {
+	cfg := parseFlags()
+	target, err := parseTarget(cfg.target)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "target: %v\n", err)
+		os.Exit(2)
+	}
+
+	if cfg.warmup > 0 {
+		warmupCfg := cfg
+		warmupCfg.duration = cfg.warmup
+		warm, elapsed := run(warmupCfg, target, false)
+		fmt.Printf("Warmup requests: %d\n", warm.requests)
+		fmt.Printf("Warmup elapsed: %.3fs\n", elapsed.Seconds())
+		fmt.Printf("Warmup socket errors: %d\n", warm.socketErrors)
+	}
+
+	measured, elapsed := run(cfg, target, true)
+	printSummary(cfg, target, measured, elapsed)
+}
+
+func parseFlags() config {
+	var cfg config
+	flag.StringVar(&cfg.target, "url", "http://127.0.0.1:3000/plaintext-handler", "HTTP URL to benchmark")
+	flag.IntVar(&cfg.connections, "connections", 128, "parallel TCP connections")
+	flag.IntVar(&cfg.depth, "depth", 8, "HTTP/1.1 pipelined requests per connection write")
+	flag.DurationVar(&cfg.duration, "duration", 15*time.Second, "measured run duration")
+	flag.DurationVar(&cfg.warmup, "warmup", 5*time.Second, "warmup duration before the measured run")
+	flag.DurationVar(&cfg.timeout, "timeout", 5*time.Second, "per-read and per-write timeout")
+	flag.Parse()
+
+	if cfg.connections < 1 {
+		failFlag("connections must be >= 1")
+	}
+	if cfg.depth < 1 {
+		failFlag("depth must be >= 1")
+	}
+	if cfg.duration <= 0 {
+		failFlag("duration must be > 0")
+	}
+	if cfg.timeout <= 0 {
+		failFlag("timeout must be > 0")
+	}
+	return cfg
+}
+
+func failFlag(msg string) {
+	fmt.Fprintln(os.Stderr, msg)
+	flag.Usage()
+	os.Exit(2)
+}
+
+func parseTarget(raw string) (target, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return target{}, err
+	}
+	if parsed.Scheme != "http" {
+		return target{}, fmt.Errorf("only http URLs are supported, got %q", parsed.Scheme)
+	}
+	if parsed.Hostname() == "" {
+		return target{}, errors.New("URL host is required")
+	}
+
+	port := parsed.Port()
+	if port == "" {
+		port = "80"
+	}
+	requestURI := parsed.RequestURI()
+	if requestURI == "" {
+		requestURI = "/"
+	}
+
+	return target{
+		url:        raw,
+		addr:       net.JoinHostPort(parsed.Hostname(), port),
+		hostHeader: parsed.Host,
+		requestURI: requestURI,
+	}, nil
+}
+
+func run(cfg config, target target, collectLatencies bool) (result, time.Duration) {
+	startCh := make(chan struct{})
+	results := make(chan result, cfg.connections)
+	var wg sync.WaitGroup
+	wg.Add(cfg.connections)
+
+	for id := 0; id < cfg.connections; id++ {
+		go func() {
+			defer wg.Done()
+			<-startCh
+			results <- runConnection(cfg, target, collectLatencies)
+		}()
+	}
+
+	start := time.Now()
+	close(startCh)
+	wg.Wait()
+	elapsed := time.Since(start)
+	close(results)
+
+	var total result
+	for r := range results {
+		total.requests += r.requests
+		total.socketErrors += r.socketErrors
+		total.non2xx += r.non2xx
+		if collectLatencies {
+			total.latencies = append(total.latencies, r.latencies...)
+		}
+	}
+	return total, elapsed
+}
+
+func runConnection(cfg config, target target, collectLatencies bool) result {
+	deadline := time.Now().Add(cfg.duration)
+	req := buildRequest(target)
+	batch := strings.Repeat(req, cfg.depth)
+	var out result
+	if collectLatencies {
+		out.latencies = make([]int64, 0, estimateLatencyCapacity(cfg))
+	}
+
+	var conn net.Conn
+	var reader *bufio.Reader
+	dial := func() bool {
+		if conn != nil {
+			_ = conn.Close()
+		}
+		c, err := net.DialTimeout("tcp", target.addr, cfg.timeout)
+		if err != nil {
+			out.socketErrors++
+			return false
+		}
+		if tcp, ok := c.(*net.TCPConn); ok {
+			_ = tcp.SetNoDelay(true)
+		}
+		conn = c
+		reader = bufio.NewReaderSize(c, 64*1024)
+		return true
+	}
+	defer func() {
+		if conn != nil {
+			_ = conn.Close()
+		}
+	}()
+
+	if !dial() {
+		return out
+	}
+
+	for time.Now().Before(deadline) {
+		sentAt := time.Now()
+		_ = conn.SetWriteDeadline(sentAt.Add(cfg.timeout))
+		if _, err := io.WriteString(conn, batch); err != nil {
+			out.socketErrors++
+			if !dial() {
+				return out
+			}
+			continue
+		}
+
+		batchOK := true
+		for i := 0; i < cfg.depth; i++ {
+			_ = conn.SetReadDeadline(time.Now().Add(cfg.timeout))
+			status, err := readResponse(reader)
+			if err != nil {
+				out.socketErrors++
+				batchOK = false
+				break
+			}
+			out.requests++
+			if status < 200 || status >= 300 {
+				out.non2xx++
+			}
+			if collectLatencies {
+				out.latencies = append(out.latencies, time.Since(sentAt).Nanoseconds())
+			}
+		}
+
+		if !batchOK && !dial() {
+			return out
+		}
+	}
+
+	return out
+}
+
+func estimateLatencyCapacity(cfg config) int {
+	const defaultPerConnection = 4096
+	if cfg.depth > defaultPerConnection {
+		return cfg.depth
+	}
+	return defaultPerConnection
+}
+
+func buildRequest(target target) string {
+	return "GET " + target.requestURI + " HTTP/1.1\r\n" +
+		"Host: " + target.hostHeader + "\r\n" +
+		"User-Agent: " + userAgent + "\r\n" +
+		"Accept: */*\r\n" +
+		"Connection: keep-alive\r\n\r\n"
+}
+
+func readResponse(reader *bufio.Reader) (int, error) {
+	line, err := reader.ReadSlice('\n')
+	if err != nil {
+		return 0, err
+	}
+	status, err := parseStatus(line)
+	if err != nil {
+		return 0, err
+	}
+
+	contentLength := int64(-1)
+	chunked := false
+	for {
+		line, err = reader.ReadSlice('\n')
+		if err != nil {
+			return 0, err
+		}
+		if isBlankLine(line) {
+			break
+		}
+		name, value, ok := splitHeader(line)
+		if !ok {
+			continue
+		}
+		if asciiEqualFold(name, []byte("Content-Length")) {
+			n, err := strconv.ParseInt(string(bytes.TrimSpace(value)), 10, 64)
+			if err != nil || n < 0 {
+				return 0, fmt.Errorf("bad Content-Length header: %q", string(value))
+			}
+			contentLength = n
+			continue
+		}
+		if asciiEqualFold(name, []byte("Transfer-Encoding")) && asciiContainsFold(value, []byte("chunked")) {
+			chunked = true
+		}
+	}
+
+	if chunked {
+		return status, drainChunked(reader)
+	}
+	if contentLength >= 0 {
+		if contentLength == 0 {
+			return status, nil
+		}
+		_, err := io.CopyN(io.Discard, reader, contentLength)
+		return status, err
+	}
+	return status, errors.New("response has no Content-Length or chunked Transfer-Encoding")
+}
+
+func parseStatus(line []byte) (int, error) {
+	firstSpace := bytes.IndexByte(line, ' ')
+	if firstSpace < 0 {
+		return 0, fmt.Errorf("bad status line: %q", string(line))
+	}
+	value := bytes.TrimSpace(line[firstSpace+1:])
+	if len(value) < 3 {
+		return 0, fmt.Errorf("bad status line: %q", string(line))
+	}
+	status, err := strconv.Atoi(string(value[:3]))
+	if err != nil {
+		return 0, fmt.Errorf("bad status code: %q", string(value[:3]))
+	}
+	return status, nil
+}
+
+func splitHeader(line []byte) ([]byte, []byte, bool) {
+	sep := bytes.IndexByte(line, ':')
+	if sep <= 0 {
+		return nil, nil, false
+	}
+	return bytes.TrimSpace(line[:sep]), bytes.TrimSpace(line[sep+1:]), true
+}
+
+func isBlankLine(line []byte) bool {
+	return len(line) == 1 && line[0] == '\n' || len(line) == 2 && line[0] == '\r' && line[1] == '\n'
+}
+
+func drainChunked(reader *bufio.Reader) error {
+	for {
+		line, err := reader.ReadSlice('\n')
+		if err != nil {
+			return err
+		}
+		sizeText := bytes.TrimSpace(line)
+		if semi := bytes.IndexByte(sizeText, ';'); semi >= 0 {
+			sizeText = sizeText[:semi]
+		}
+		size, err := strconv.ParseInt(string(sizeText), 16, 64)
+		if err != nil || size < 0 {
+			return fmt.Errorf("bad chunk size: %q", string(sizeText))
+		}
+		if size == 0 {
+			for {
+				line, err = reader.ReadSlice('\n')
+				if err != nil {
+					return err
+				}
+				if isBlankLine(line) {
+					return nil
+				}
+			}
+		}
+		if _, err := io.CopyN(io.Discard, reader, size+2); err != nil {
+			return err
+		}
+	}
+}
+
+func asciiEqualFold(a, b []byte) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if lowerASCII(a[i]) != lowerASCII(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func asciiContainsFold(haystack, needle []byte) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	if len(haystack) < len(needle) {
+		return false
+	}
+	for i := 0; i <= len(haystack)-len(needle); i++ {
+		if asciiEqualFold(haystack[i:i+len(needle)], needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func lowerASCII(c byte) byte {
+	if c >= 'A' && c <= 'Z' {
+		return c + ('a' - 'A')
+	}
+	return c
+}
+
+func printSummary(cfg config, target target, r result, elapsed time.Duration) {
+	latencies := r.latencies
+	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+
+	rps := float64(r.requests) / elapsed.Seconds()
+	fmt.Println("Pipeline benchmark")
+	fmt.Printf("URL: %s\n", target.url)
+	fmt.Printf("Connections: %d\n", cfg.connections)
+	fmt.Printf("Pipeline depth: %d\n", cfg.depth)
+	fmt.Printf("Duration: %.3fs\n", elapsed.Seconds())
+	fmt.Printf("Requests: %d\n", r.requests)
+	fmt.Printf("Requests/sec: %.2f\n", rps)
+	fmt.Printf("Latency p50: %.3fms\n", nanosToMillis(percentile(latencies, 50)))
+	fmt.Printf("Latency p90: %.3fms\n", nanosToMillis(percentile(latencies, 90)))
+	fmt.Printf("Latency p99: %.3fms\n", nanosToMillis(percentile(latencies, 99)))
+	fmt.Printf("Latency max: %.3fms\n", nanosToMillis(maxLatency(latencies)))
+	fmt.Printf("Socket errors: %d\n", r.socketErrors)
+	fmt.Printf("Non-2xx responses: %d\n", r.non2xx)
+}
+
+func percentile(sorted []int64, pct int) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	idx := (len(sorted)*pct + 99) / 100
+	if idx < 1 {
+		idx = 1
+	}
+	if idx > len(sorted) {
+		idx = len(sorted)
+	}
+	return sorted[idx-1]
+}
+
+func maxLatency(sorted []int64) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	return sorted[len(sorted)-1]
+}
+
+func nanosToMillis(ns int64) float64 {
+	return float64(ns) / float64(time.Millisecond)
+}

--- a/bench/reproducible/pipeline-client/main_test.go
+++ b/bench/reproducible/pipeline-client/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+func TestParseTarget(t *testing.T) {
+	got, err := parseTarget("http://127.0.0.1:3000/plaintext-handler?q=1")
+	if err != nil {
+		t.Fatalf("parseTarget returned error: %v", err)
+	}
+	if got.addr != "127.0.0.1:3000" {
+		t.Fatalf("addr = %q", got.addr)
+	}
+	if got.hostHeader != "127.0.0.1:3000" {
+		t.Fatalf("hostHeader = %q", got.hostHeader)
+	}
+	if got.requestURI != "/plaintext-handler?q=1" {
+		t.Fatalf("requestURI = %q", got.requestURI)
+	}
+}
+
+func TestReadResponseContentLength(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader(
+		"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello" +
+			"HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n",
+	))
+
+	status, err := readResponse(reader)
+	if err != nil {
+		t.Fatalf("first readResponse returned error: %v", err)
+	}
+	if status != 200 {
+		t.Fatalf("first status = %d", status)
+	}
+
+	status, err = readResponse(reader)
+	if err != nil {
+		t.Fatalf("second readResponse returned error: %v", err)
+	}
+	if status != 204 {
+		t.Fatalf("second status = %d", status)
+	}
+}
+
+func TestReadResponseChunked(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader(
+		"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n" +
+			"5\r\nhello\r\n0\r\n\r\n",
+	))
+
+	status, err := readResponse(reader)
+	if err != nil {
+		t.Fatalf("readResponse returned error: %v", err)
+	}
+	if status != 200 {
+		t.Fatalf("status = %d", status)
+	}
+}
+
+func TestReadResponseRejectsUnboundedKeepAliveBody(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("HTTP/1.1 200 OK\r\nConnection: keep-alive\r\n\r\nhello"))
+
+	if _, err := readResponse(reader); err == nil {
+		t.Fatal("readResponse succeeded without Content-Length or chunked Transfer-Encoding")
+	}
+}

--- a/bench/reproducible/pipeline.sh
+++ b/bench/reproducible/pipeline.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+# Diagnostic HTTP/1.1 pipelined benchmark harness.
+#
+# This workload is intentionally separate from bench.sh. It tests whether a
+# server benefits from multiple in-flight requests per TCP connection and should
+# not be used as the default fair handler-path claim without that label.
+
+set -euo pipefail
+
+export PATH="$PATH:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
+TIMESTAMP="$(date -u '+%Y%m%dT%H%M%SZ')"
+RESULT_DIR="${RESULT_DIR:-"$SCRIPT_DIR/results/pipeline-$TIMESTAMP"}"
+RAW_DIR="$RESULT_DIR/raw"
+SUMMARY_CSV="$RESULT_DIR/summary.csv"
+SUMMARY_MD="$RESULT_DIR/summary.md"
+META_FILE="$RESULT_DIR/environment.txt"
+CLIENT_BIN="$SCRIPT_DIR/pipeline-client/pipeline-client"
+
+GOMAXPROCS_VALUE="${GOMAXPROCS:-8}"
+KRUDA_WORKERS_VALUE="${KRUDA_WORKERS:-4}"
+KRUDA_READ_BUF_SIZE_VALUE="${KRUDA_READ_BUF_SIZE:-}"
+KRUDA_POOL_SIZE_VALUE="${KRUDA_POOL_SIZE:-}"
+BENCH_ENABLE_DB_VALUE="${BENCH_ENABLE_DB:-0}"
+BENCH_ENABLE_PPROF_VALUE="${BENCH_ENABLE_PPROF:-0}"
+BENCH_KRUDA_DB_DISPATCH_VALUE="${BENCH_KRUDA_DB_DISPATCH:-takeover}"
+KRUDA_GO_TAGS_VALUE="${KRUDA_GO_TAGS-kruda_stdjson}"
+if [ "$KRUDA_GO_TAGS_VALUE" = "default" ] || [ "$KRUDA_GO_TAGS_VALUE" = "none" ]; then
+  KRUDA_GO_TAGS_VALUE=""
+fi
+if [ "$BENCH_ENABLE_PPROF_VALUE" = "1" ]; then
+  case " $KRUDA_GO_TAGS_VALUE " in
+    *" bench_pprof "*) ;;
+    *) KRUDA_GO_TAGS_VALUE="${KRUDA_GO_TAGS_VALUE:+$KRUDA_GO_TAGS_VALUE }bench_pprof" ;;
+  esac
+fi
+BENCH_ROUNDS_VALUE="${BENCH_ROUNDS:-5}"
+PIPELINE_DURATION_VALUE="${PIPELINE_DURATION:-15s}"
+PIPELINE_WARMUP_VALUE="${PIPELINE_WARMUP:-5s}"
+PIPELINE_TIMEOUT_VALUE="${PIPELINE_TIMEOUT:-5s}"
+DATABASE_URL_VALUE="${DATABASE_URL:-postgres://benchmarkdbuser:benchmarkdbpass@localhost:5432/hello_world?pool_max_conns=64&pool_min_conns=8}"
+
+read -r -a FRAMEWORKS <<< "${BENCH_FRAMEWORKS:-kruda fiber actix}"
+read -r -a PIPELINE_PROFILES <<< "${PIPELINE_PROFILES:-baseline-c128-d1:128:1 pipeline-c128-d8:128:8 pipeline-c256-d8:256:8}"
+
+if [ "$#" -gt 0 ]; then
+  ROUTES=("$@")
+else
+  ROUTES=(plaintext-handler json-static json-serialize)
+fi
+
+KRUDA_PID=""
+FIBER_PID=""
+ACTIX_PID=""
+
+mkdir -p "$RAW_DIR"
+
+cleanup() {
+  for fw in "${FRAMEWORKS[@]}"; do
+    stop_server "$fw"
+  done
+}
+trap cleanup EXIT INT TERM
+
+port_for() {
+  case "$1" in
+    kruda) echo "${KRUDA_PORT:-3000}" ;;
+    fiber) echo "${FIBER_PORT:-3002}" ;;
+    actix) echo "${ACTIX_PORT:-3003}" ;;
+    *) echo "unknown framework: $1" >&2; exit 1 ;;
+  esac
+}
+
+pid_for() {
+  case "$1" in
+    kruda) echo "$KRUDA_PID" ;;
+    fiber) echo "$FIBER_PID" ;;
+    actix) echo "$ACTIX_PID" ;;
+    *) echo "unknown framework: $1" >&2; exit 1 ;;
+  esac
+}
+
+set_pid() {
+  case "$1" in
+    kruda) KRUDA_PID="$2" ;;
+    fiber) FIBER_PID="$2" ;;
+    actix) ACTIX_PID="$2" ;;
+    *) echo "unknown framework: $1" >&2; exit 1 ;;
+  esac
+}
+
+clear_pid() {
+  case "$1" in
+    kruda) KRUDA_PID="" ;;
+    fiber) FIBER_PID="" ;;
+    actix) ACTIX_PID="" ;;
+    *) echo "unknown framework: $1" >&2; exit 1 ;;
+  esac
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+build_all() {
+  require_cmd go
+  require_cmd curl
+
+  (cd "$SCRIPT_DIR/pipeline-client" && GOWORK=off go build -o "$CLIENT_BIN" .)
+
+  local kruda_tag_args=()
+  if [ -n "$KRUDA_GO_TAGS_VALUE" ]; then
+    kruda_tag_args=(-tags "$KRUDA_GO_TAGS_VALUE")
+  fi
+
+  for fw in "${FRAMEWORKS[@]}"; do
+    case "$fw" in
+      kruda)
+        (cd "$SCRIPT_DIR/kruda" && GOWORK=off go build "${kruda_tag_args[@]}" -o kruda-bench .)
+        ;;
+      fiber)
+        (cd "$SCRIPT_DIR/fiber" && GOWORK=off go build -o fiber-bench .)
+        ;;
+      actix)
+        require_cmd cargo
+        (cd "$SCRIPT_DIR/actix" && cargo build --release)
+        ;;
+      *)
+        echo "unknown framework: $fw" >&2
+        exit 1
+        ;;
+    esac
+  done
+}
+
+write_environment() {
+  {
+    echo "timestamp_utc=$TIMESTAMP"
+    echo "script_dir=$SCRIPT_DIR"
+    echo "repo_root=$REPO_ROOT"
+    echo "git_commit=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || true)"
+    echo "result_dir=$RESULT_DIR"
+    echo "workload=http1_pipelined_diagnostic"
+    echo "bench_enable_db=$BENCH_ENABLE_DB_VALUE"
+    echo "bench_enable_pprof=$BENCH_ENABLE_PPROF_VALUE"
+    echo "bench_kruda_db_dispatch=$BENCH_KRUDA_DB_DISPATCH_VALUE"
+    echo "kruda_go_tags=${KRUDA_GO_TAGS_VALUE:-default}"
+    echo "gomaxprocs=$GOMAXPROCS_VALUE"
+    echo "kruda_workers=$KRUDA_WORKERS_VALUE"
+    echo "kruda_read_buf_size=${KRUDA_READ_BUF_SIZE_VALUE:-default}"
+    echo "kruda_pool_size=${KRUDA_POOL_SIZE_VALUE:-default}"
+    echo "bench_rounds=$BENCH_ROUNDS_VALUE"
+    echo "pipeline_duration=$PIPELINE_DURATION_VALUE"
+    echo "pipeline_warmup=$PIPELINE_WARMUP_VALUE"
+    echo "pipeline_timeout=$PIPELINE_TIMEOUT_VALUE"
+    echo "pipeline_profiles=${PIPELINE_PROFILES[*]}"
+    echo "frameworks=${FRAMEWORKS[*]}"
+    echo "routes=${ROUTES[*]}"
+    echo
+    echo "== CPU =="
+    if command -v lscpu >/dev/null 2>&1; then
+      lscpu
+    elif command -v sysctl >/dev/null 2>&1; then
+      sysctl -n machdep.cpu.brand_string 2>/dev/null || true
+      sysctl -n hw.physicalcpu hw.logicalcpu 2>/dev/null || true
+    fi
+    echo
+    echo "== OS =="
+    uname -a
+    echo
+    echo "== Toolchain =="
+    go version
+    if command -v rustc >/dev/null 2>&1; then
+      rustc --version 2>/dev/null || echo "rustc=not usable"
+    else
+      echo "rustc=not found"
+    fi
+    if command -v cargo >/dev/null 2>&1; then
+      cargo --version 2>/dev/null || echo "cargo=not usable"
+    else
+      echo "cargo=not found"
+    fi
+    "$CLIENT_BIN" -h 2>&1 | head -n 20 || true
+  } > "$META_FILE"
+}
+
+start_server() {
+  local fw="$1"
+  local port
+  port="$(port_for "$fw")"
+  local log="$RAW_DIR/server-$fw.log"
+
+  case "$fw" in
+    kruda)
+      (
+        cd "$SCRIPT_DIR/kruda"
+        env GOMAXPROCS="$GOMAXPROCS_VALUE" KRUDA_WORKERS="$KRUDA_WORKERS_VALUE" \
+          KRUDA_READ_BUF_SIZE="$KRUDA_READ_BUF_SIZE_VALUE" \
+          KRUDA_POOL_SIZE="$KRUDA_POOL_SIZE_VALUE" \
+          PORT="$port" BENCH_ENABLE_DB="$BENCH_ENABLE_DB_VALUE" BENCH_ENABLE_PPROF="$BENCH_ENABLE_PPROF_VALUE" \
+          BENCH_KRUDA_DB_DISPATCH="$BENCH_KRUDA_DB_DISPATCH_VALUE" \
+          DATABASE_URL="$DATABASE_URL_VALUE" \
+          ./kruda-bench
+      ) > "$log" 2>&1 &
+      ;;
+    fiber)
+      (
+        cd "$SCRIPT_DIR/fiber"
+        env GOMAXPROCS="$GOMAXPROCS_VALUE" PORT="$port" BENCH_ENABLE_DB="$BENCH_ENABLE_DB_VALUE" \
+          DATABASE_URL="$DATABASE_URL_VALUE" ./fiber-bench
+      ) > "$log" 2>&1 &
+      ;;
+    actix)
+      (
+        cd "$SCRIPT_DIR/actix"
+        env PORT="$port" BENCH_ENABLE_DB="$BENCH_ENABLE_DB_VALUE" DATABASE_URL="$DATABASE_URL_VALUE" \
+          ./target/release/actix-bench
+      ) > "$log" 2>&1 &
+      ;;
+    *)
+      echo "unknown framework: $fw" >&2
+      exit 1
+      ;;
+  esac
+
+  set_pid "$fw" "$!"
+  wait_ready "$fw" "$port" "$log"
+}
+
+stop_server() {
+  local fw="$1"
+  local pid
+  pid="$(pid_for "$fw")"
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    kill "$pid" 2>/dev/null || true
+    wait "$pid" 2>/dev/null || true
+  fi
+  clear_pid "$fw"
+}
+
+wait_ready() {
+  local fw="$1"
+  local port="$2"
+  local log="$3"
+  local url="http://127.0.0.1:$port/plaintext-handler"
+
+  for _ in $(seq 1 100); do
+    if ! kill -0 "$(pid_for "$fw")" 2>/dev/null; then
+      echo "$fw exited before it became ready on port $port" >&2
+      cat "$log" >&2 || true
+      exit 1
+    fi
+    if curl -fsS "$url" >/dev/null 2>&1; then
+      return
+    fi
+    sleep 0.1
+  done
+
+  echo "$fw did not become ready on port $port" >&2
+  cat "$log" >&2 || true
+  exit 1
+}
+
+extract_pipeline_summary() {
+  local raw="$1"
+  awk '
+    function to_ms(v, num, unit) {
+      num = v
+      unit = v
+      gsub(/[a-zA-Z]+/, "", num)
+      gsub(/[0-9.]+/, "", unit)
+      if (unit == "us") return num / 1000
+      if (unit == "s") return num * 1000
+      if (unit == "m") return num * 60000
+      return num
+    }
+    /^Requests:/ { requests = $2 }
+    /^Requests\/sec:/ { rps = $2 }
+    /^Latency p50:/ { p50 = to_ms($3) }
+    /^Latency p90:/ { p90 = to_ms($3) }
+    /^Latency p99:/ { p99 = to_ms($3) }
+    /^Latency max:/ { max = to_ms($3) }
+    /^Socket errors:/ { socket_errors = $3 }
+    /^Non-2xx responses:/ { non2xx = $3 }
+    END {
+      printf "%d,%.2f,%.3f,%.3f,%.3f,%.3f,%d,%d", requests+0, rps+0, p50+0, p90+0, p99+0, max+0, socket_errors+0, non2xx+0
+    }
+  ' "$raw"
+}
+
+run_pipeline() {
+  local fw="$1"
+  local route="$2"
+  local profile="$3"
+  local connections="$4"
+  local depth="$5"
+  local round="$6"
+  local port
+  port="$(port_for "$fw")"
+  local url="http://127.0.0.1:$port/$route"
+  local raw="$RAW_DIR/$fw-$profile-$route-round-$round.txt"
+
+  "$CLIENT_BIN" \
+    -url "$url" \
+    -connections "$connections" \
+    -depth "$depth" \
+    -duration "$PIPELINE_DURATION_VALUE" \
+    -warmup "$PIPELINE_WARMUP_VALUE" \
+    -timeout "$PIPELINE_TIMEOUT_VALUE" \
+    > "$raw" 2>&1
+
+  local values
+  values="$(extract_pipeline_summary "$raw")"
+  echo "$TIMESTAMP,$profile,$fw,$route,$round,$connections,$depth,$PIPELINE_DURATION_VALUE,$PIPELINE_WARMUP_VALUE,$values,$raw" >> "$SUMMARY_CSV"
+  echo "| $profile | $fw | $route | $round | $connections | $depth | ${values//,/ | } | $raw |" >> "$SUMMARY_MD"
+}
+
+init_summary() {
+  echo "timestamp_utc,profile,framework,route,round,connections,depth,duration,warmup,requests,rps,p50_ms,p90_ms,p99_ms,max_ms,socket_errors,non_2xx,raw_file" > "$SUMMARY_CSV"
+  {
+    echo "# HTTP/1.1 Pipelined Benchmark Summary"
+    echo
+    echo "This is a diagnostic workload for I/O batching and pipelined request handling. Keep it separate from the default \`wrk --latency\` handler-path benchmark claims."
+    echo
+    echo "Environment: \`$META_FILE\`"
+    echo
+    echo "| Profile | Framework | Route | Round | Connections | Depth | Requests | RPS | p50 ms | p90 ms | p99 ms | max ms | Socket errors | Non-2xx | Raw file |"
+    echo "|---|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|"
+  } > "$SUMMARY_MD"
+}
+
+parse_profile() {
+  local profile_def="$1"
+  local name connections depth
+  IFS=: read -r name connections depth <<< "$profile_def"
+  if [ -z "$name" ] || [ -z "$connections" ] || [ -z "$depth" ]; then
+    echo "bad PIPELINE_PROFILES entry: $profile_def" >&2
+    echo "expected format: name:connections:depth" >&2
+    exit 1
+  fi
+  echo "$name" "$connections" "$depth"
+}
+
+echo "== Building pipelined benchmark binaries =="
+build_all
+write_environment
+init_summary
+
+for fw in "${FRAMEWORKS[@]}"; do
+  echo "== $fw =="
+  start_server "$fw"
+  for profile_def in "${PIPELINE_PROFILES[@]}"; do
+    read -r profile connections depth < <(parse_profile "$profile_def")
+    for route in "${ROUTES[@]}"; do
+      for round in $(seq 1 "$BENCH_ROUNDS_VALUE"); do
+        echo "round $round: $fw $profile /$route connections=$connections depth=$depth"
+        run_pipeline "$fw" "$route" "$profile" "$connections" "$depth" "$round"
+      done
+    done
+  done
+  stop_server "$fw"
+done
+
+echo "summary: $SUMMARY_MD"
+echo "raw: $RAW_DIR"

--- a/bench/reproducible/results/2026-06-02-pipelined-io-diagnostic-tiger.md
+++ b/bench/reproducible/results/2026-06-02-pipelined-io-diagnostic-tiger.md
@@ -1,0 +1,66 @@
+# Pipelined I/O Diagnostic Evidence
+
+This note records a tiger Linux diagnostic run for the HTTP/1.1 pipelined
+benchmark harness added on branch `perf/wing-pipelined-io-profile`.
+
+This is diagnostic evidence for I/O architecture decisions. It is not a
+replacement for the default `wrk --latency` fair handler-path benchmark claim.
+HTTP/1.1 pipelining must be labeled explicitly when used in public wording.
+
+## Environment
+
+- Host: `dev-server`
+- CPU: 13th Gen Intel(R) Core(TM) i5-13500, 8 online CPUs
+- OS: Linux `6.8.0-117-generic` x86_64
+- Commit: `d270381`
+- Go: `go1.26.3 linux/amd64`
+- Rust: `rustc 1.93.1`
+- Cargo: `cargo 1.93.1`
+- Result directory: `/home/tiger/kruda-wing-pipeline-io-d270381/bench/reproducible/results/pipeline-diagnostic-20260602T134636Z/`
+- Raw logs: `/home/tiger/kruda-wing-pipeline-io-d270381/bench/reproducible/results/pipeline-diagnostic-20260602T134636Z/raw/`
+
+## Command
+
+```bash
+DIR="$HOME/kruda-wing-pipeline-io-d270381"
+cd "$DIR"
+
+BENCH_FRAMEWORKS="kruda fiber actix" \
+BENCH_ROUNDS=3 \
+PIPELINE_DURATION=5s \
+PIPELINE_WARMUP=2s \
+PIPELINE_PROFILES="baseline-c128-d1:128:1 pipeline-c128-d8:128:8 pipeline-c256-d8:256:8" \
+KRUDA_PORT=3921 \
+FIBER_PORT=3922 \
+ACTIX_PORT=3923 \
+RESULT_DIR="$DIR/bench/reproducible/results/pipeline-diagnostic-$(date -u +%Y%m%dT%H%M%SZ)" \
+./bench/reproducible/pipeline.sh plaintext-handler json-static json-serialize
+```
+
+## Kruda vs Actix Median Summary
+
+All rows had zero socket errors and zero non-2xx responses.
+
+| Profile | Route | Kruda median RPS | Actix median RPS | Kruda RPS delta | Kruda p99 ms | Actix p99 ms | Kruda p99 delta |
+|---|---|---:|---:|---:|---:|---:|---:|
+| `baseline-c128-d1` | `json-serialize` | 652,351.23 | 620,710.37 | +5.10% | 1.172 | 2.087 | -43.84% |
+| `baseline-c128-d1` | `json-static` | 666,219.02 | 617,313.77 | +7.92% | 1.191 | 2.088 | -42.96% |
+| `baseline-c128-d1` | `plaintext-handler` | 669,746.20 | 618,462.71 | +8.29% | 1.282 | 2.144 | -40.21% |
+| `pipeline-c128-d8` | `json-serialize` | 2,674,306.18 | 2,792,210.05 | -4.22% | 1.486 | 2.720 | -45.37% |
+| `pipeline-c128-d8` | `json-static` | 3,046,756.83 | 2,846,599.09 | +7.03% | 1.679 | 2.616 | -35.82% |
+| `pipeline-c128-d8` | `plaintext-handler` | 2,990,920.56 | 2,867,565.42 | +4.30% | 1.713 | 2.499 | -31.45% |
+| `pipeline-c256-d8` | `json-serialize` | 2,760,753.71 | 2,847,653.69 | -3.05% | 3.036 | 3.645 | -16.71% |
+| `pipeline-c256-d8` | `json-static` | 3,134,569.50 | 2,933,410.98 | +6.86% | 3.192 | 3.730 | -14.42% |
+| `pipeline-c256-d8` | `plaintext-handler` | 3,133,652.83 | 2,910,802.83 | +7.66% | 3.279 | 3.958 | -17.16% |
+
+## Interpretation
+
+- The new harness is working across Kruda, Fiber, and Actix on Linux.
+- Pipelining strongly increases absolute RPS for all runtimes, so it is a useful
+  diagnostic profile for I/O batching behavior.
+- Kruda beats Actix on plaintext and static JSON in these diagnostic profiles,
+  but the margin is roughly 4-8%, not a 20% blanket win.
+- Kruda p99 is lower than Actix in every measured row.
+- Kruda trails Actix on JSON serialization under the pipelined profiles, so the
+  next performance candidate should focus on the JSON serialization/response
+  path before expecting a broad pipelined benchmark win.


### PR DESCRIPTION
## Summary

Adds a diagnostic HTTP/1.1 pipelined benchmark harness for Kruda, Fiber, and Actix. This PR does not change runtime behavior. It adds tooling and a tiger Linux evidence note so future Wing I/O architecture work can be measured before implementation.

## Scope

- Add `bench/reproducible/pipeline-client`, a Go HTTP/1.1 pipelined load generator.
- Add `bench/reproducible/pipeline.sh`, a script-relative cross-runtime harness that builds and runs Kruda, Fiber, and Actix by PID with trap cleanup.
- Document the pipelined diagnostic workflow in `bench/reproducible/README.md`.
- Record tiger Linux diagnostic evidence in `bench/reproducible/results/2026-06-02-pipelined-io-diagnostic-tiger.md`.

## Evidence

Tiger diagnostic run at commit `d270381` used:

- `BENCH_ROUNDS=3`
- `PIPELINE_DURATION=5s`
- `PIPELINE_WARMUP=2s`
- `PIPELINE_PROFILES="baseline-c128-d1:128:1 pipeline-c128-d8:128:8 pipeline-c256-d8:256:8"`
- routes: `plaintext-handler`, `json-static`, `json-serialize`

All measured rows had zero socket errors and zero non-2xx responses.

Median Kruda vs Actix highlights:

- `baseline-c128-d1`: Kruda leads Actix by +5.10% to +8.29% RPS across the CPU routes, with lower p99 latency.
- `pipeline-c128-d8`: Kruda leads plaintext/static JSON by +4.30% to +7.03% RPS, with lower p99 latency, but trails JSON serialization by -4.22% RPS.
- `pipeline-c256-d8`: Kruda leads plaintext/static JSON by +6.86% to +7.66% RPS, with lower p99 latency, but trails JSON serialization by -3.05% RPS.

## Claim Boundary

This is diagnostic evidence for I/O batching and pipelined request handling. It is not a replacement for the default `wrk --latency` fair handler-path benchmark claims. Public wording must label HTTP/1.1 pipelining explicitly when using this evidence.

## Validation

- `go test -count=1 ./reproducible/pipeline-client` from the `bench` module.
- Local Kruda-only pipeline smoke.
- Tiger cross-runtime pipeline smoke.
- Tiger cross-runtime diagnostic sweep across three CPU routes.

## Next Work

Use this harness to investigate the remaining `json-serialize` gap before attempting a broader runtime I/O architecture change.