### PR TITLE
perf: stream Wing stdjson responses into pooled buffers

### DIFF
--- a/bench/reproducible/results/2026-06-02-wing-json-stream-response-evidence.md
+++ b/bench/reproducible/results/2026-06-02-wing-json-stream-response-evidence.md
@@ -1,0 +1,137 @@
+# Wing JSON Stream Response Evidence
+
+Date: 2026-06-02
+
+Scope: local microbenchmark evidence plus focused tiger diagnostic pipeline
+evidence for the Wing handler-path JSON serialization response path. This is
+not a public broad "faster than Actix" claim and not a 20% win claim.
+
+## Candidate
+
+Candidate commit: `d77ff70` (`perf: stream Wing stdjson responses into pooled buffers`)
+
+When the active JSON encoder is `encoding/json`, Wing now lets `Ctx.JSON` encode
+directly into a response-owned `bytes.Buffer` before using Wing's JSON fast
+response builder. This avoids the intermediate `[]byte` allocation from
+`encoding/json.Marshal` on the Wing JSON serialization route.
+
+The candidate is intentionally limited to the stdjson build because Sonic's
+current `MarshalToBuffer` path still calls `sonic.Marshal` and then writes the
+result into a buffer, which did not improve the route in the rejected Sonic
+buffer encoder experiment.
+
+Custom `WithJSONEncoder` behavior is preserved: a custom encoder still uses the
+configured encoder and does not enter the stdjson stream response path unless a
+stream encoder is configured for a build where the stream path is enabled.
+
+## Local Microbenchmark
+
+Baseline worktree: `origin/main` at `6ad22a7`
+
+Candidate branch: `perf/wing-json-response-path` at `d77ff70`
+
+Command:
+
+```bash
+go test -run '^$' -tags kruda_stdjson \
+  -bench 'BenchmarkCPU(ResponseJSON|HandlerJSON(Static|StaticBytes|Serialize)Feather)$' \
+  -benchmem -count=10 .
+```
+
+Environment:
+
+- Host: local Apple M3
+- OS/arch: `darwin/arm64`
+- Build tags: `kruda_stdjson`
+
+Median comparison from the count=10 raw benchmark outputs:
+
+| Benchmark | Main ns/op | Candidate ns/op | Delta | Main B/op | Candidate B/op | Main alloc/op | Candidate alloc/op |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `BenchmarkCPUHandlerJSONSerializeFeather` | 312.80 | 297.65 | -4.84% | 192 | 160 | 2 | 1 |
+| `BenchmarkCPUHandlerJSONStaticBytesFeather` | 232.20 | 236.20 | +1.72% | 160 | 160 | 1 | 1 |
+| `BenchmarkCPUHandlerJSONStaticFeather` | 224.00 | 220.85 | -1.41% | 160 | 160 | 1 | 1 |
+| `BenchmarkCPUResponseJSON` | 42.86 | 43.30 | +1.01% | 160 | 160 | 1 | 1 |
+
+Interpretation:
+
+- The targeted JSON serialization handler path improves by 4.84%.
+- The targeted path drops from 2 alloc/op and 192 B/op to 1 alloc/op and
+  160 B/op.
+- Static JSON helper paths stay within the 5% regression gate with no allocation
+  increase.
+
+## Tiger Diagnostic Pipeline Evidence
+
+Result directory:
+`/home/tiger/kruda-wing-json-response-path-d77ff70/bench/reproducible/results/pipeline-json-stdjson-candidate-20260602T144713Z`
+
+Command shape:
+
+```bash
+BENCH_FRAMEWORKS="kruda actix" \
+BENCH_ROUNDS=3 \
+PIPELINE_DURATION=5s \
+PIPELINE_WARMUP=2s \
+PIPELINE_PROFILES="pipeline-c128-d8:128:8 pipeline-c256-d8:256:8" \
+KRUDA_GO_TAGS=kruda_stdjson \
+./bench/reproducible/pipeline.sh json-serialize
+```
+
+Environment summary:
+
+- CPU: 13th Gen Intel Core i5-13500, 8 online CPUs
+- OS/kernel: Linux `6.8.0-117-generic`
+- Go: `go1.26.3 linux/amd64`
+- Rust: `rustc 1.93.1`
+- `GOMAXPROCS=8`
+- `KRUDA_WORKERS=4`
+- Kruda tags: `kruda_stdjson`
+- Kruda server log: `[kruda] JSON encoder: encoding/json`
+- Route: `json-serialize`
+- Frameworks: Kruda and Actix
+- Errors: zero socket errors and zero non-2xx responses in all rounds
+
+Median result:
+
+| Profile | Kruda median RPS | Actix median RPS | RPS delta | Kruda p99 ms | Actix p99 ms | p99 delta | Errors | Non-2xx |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| `pipeline-c128-d8` | 2,931,759.93 | 2,797,118.54 | +4.81% | 1.384 | 2.385 | -41.97% | 0 | 0 |
+| `pipeline-c256-d8` | 2,997,507.41 | 2,921,522.08 | +2.60% | 2.658 | 3.589 | -25.94% | 0 | 0 |
+
+## Default/Sonic Control
+
+Control result directory:
+`/home/tiger/kruda-wing-pipeline-io-d270381/bench/reproducible/results/pipeline-json-default-20260602T143225Z`
+
+This was run before the stdjson stream candidate with `KRUDA_GO_TAGS=default`.
+The Kruda server log reported `[kruda] JSON encoder: sonic`.
+
+Median result:
+
+| Profile | Kruda median RPS | Actix median RPS | RPS delta | Kruda p99 ms | Actix p99 ms | Errors | Non-2xx |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `pipeline-c128-d8` | 2,879,487.12 | 2,902,411.98 | -0.79% | 1.415 | 2.667 | 0 | 0 |
+| `pipeline-c256-d8` | 2,919,853.62 | 2,920,094.44 | -0.01% | 2.746 | 3.833 | 0 | 0 |
+
+Interpretation:
+
+- Default Sonic already sits very close to Actix for this diagnostic route and
+  has better p99 in these runs.
+- The kept runtime change is for the stdjson Wing JSON serialization path only.
+- The Sonic control does not justify changing the default Sonic response path.
+
+## Decision
+
+Keep the stdjson Wing JSON stream response candidate.
+
+This is a real normal handler-path improvement for `json-serialize` under
+`kruda_stdjson`: it reduces one allocation in the local hot-path benchmark and
+turns the focused tiger pipelined diagnostic comparison from a previous deficit
+into positive RPS deltas with materially better p99 latency.
+
+Do not claim a broad Actix win from this evidence. The `pipeline-c128-d8` profile
+passes the 3% RPS and p99 gate, but `pipeline-c256-d8` is only +2.60% RPS, below
+the public claim threshold. The correct wording is that this narrows/improves
+the Wing JSON serialization path and remains in the same ballpark as Actix for
+this diagnostic workload.

--- a/ctx_response.go
+++ b/ctx_response.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"sync"
 
+	krudajson "github.com/go-kruda/kruda/json"
 	"github.com/go-kruda/kruda/transport"
 )
 
@@ -27,6 +28,10 @@ var jsonBufPool = sync.Pool{
 // jsonContentType is a pre-allocated byte slice for the JSON content type header.
 // Used by both the fasthttp fast path (SetContentTypeBytes) and generic paths.
 var jsonContentType = []byte("application/json; charset=utf-8")
+
+type jsonStreamResponder interface {
+	SetJSONStream(status int, enc func(buf *bytes.Buffer, v any) error, v any) error
+}
 
 // ErrAlreadyResponded is returned when a handler attempts to write a response
 // after one has already been sent. Check with errors.Is(err, ErrAlreadyResponded).
@@ -67,6 +72,13 @@ func (c *Ctx) JSON(v any) error {
 	// Wing fast path: Marshal → SetJSON directly, skip pooled buffer.
 	if jr, ok := c.writer.(transport.JSONResponder); ok {
 		if c.canBypassHeaderWrite(true) {
+			if sr, ok := c.writer.(jsonStreamResponder); ok && c.app.config.JSONStreamEncoder != nil && shouldUseWingJSONStream() {
+				if err := sr.SetJSONStream(c.status, c.app.config.JSONStreamEncoder, v); err != nil {
+					return err
+				}
+				c.responded = true
+				return nil
+			}
 			data, err := c.app.config.JSONEncoder(v)
 			if err != nil {
 				return err
@@ -658,6 +670,10 @@ func init() {
 	for i := range contentLengthStrings {
 		contentLengthStrings[i] = strconv.Itoa(i)
 	}
+}
+
+func shouldUseWingJSONStream() bool {
+	return krudajson.EncoderName == "encoding/json"
 }
 
 func contentLengthString(length int) string {

--- a/wing_feather_internal_test.go
+++ b/wing_feather_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"testing"
 
+	krudajson "github.com/go-kruda/kruda/json"
 	"github.com/go-kruda/kruda/transport"
 )
 
@@ -387,6 +388,83 @@ func TestWingSendStaticJSONUsesJSONResponder(t *testing.T) {
 	}
 	if !bytes.Contains(data, []byte("\r\n\r\n{\"message\":\"ok\"}")) {
 		t.Fatalf("JSON fast response missing body:\n%s", data)
+	}
+}
+
+func TestWingJSONSerializeUsesStreamResponderWithStdJSON(t *testing.T) {
+	if krudajson.EncoderName != "encoding/json" {
+		t.Skip("stream responder is used only when the active encoder avoids an intermediate marshal allocation")
+	}
+
+	app := New(Wing(), WithJSONStreamEncoder(func(buf *bytes.Buffer, v any) error {
+		buf.WriteString(`{"message":"streamed"}`)
+		return nil
+	}))
+	var handlerRan bool
+	app.Get("/json-serialize", func(c *Ctx) error {
+		handlerRan = true
+		return c.JSON(benchJSONMessage{Message: "Hello, World!"})
+	}, WingJSON())
+	app.Compile()
+
+	tr, ok := app.transport.(*Transport)
+	if !ok {
+		t.Skip("Wing transport unavailable on this platform")
+	}
+	f := tr.config.Feathers["GET /json-serialize"]
+	if len(f.handlers) == 0 {
+		t.Fatal("WingJSON route did not retain its handler chain")
+	}
+
+	resp := acquireResponse()
+	defer releaseResponse(resp)
+
+	app.serveKrudaRoute(resp, &wingRequest{method: "GET", path: "/json-serialize", keepAlive: true}, f.handlers)
+
+	if !handlerRan {
+		t.Fatal("handler did not run")
+	}
+	if !resp.jsonFast {
+		t.Fatal("JSON serialize did not use Wing JSON responder")
+	}
+	if string(resp.body) != `{"message":"streamed"}` {
+		t.Fatalf("body = %q", string(resp.body))
+	}
+}
+
+func TestWingJSONSerializeCustomEncoderStillUsesEncoder(t *testing.T) {
+	app := New(Wing(), WithJSONEncoder(func(v any) ([]byte, error) {
+		return []byte(`{"custom":true}`), nil
+	}))
+	var handlerRan bool
+	app.Get("/json-serialize", func(c *Ctx) error {
+		handlerRan = true
+		return c.JSON(benchJSONMessage{Message: "Hello, World!"})
+	}, WingJSON())
+	app.Compile()
+
+	tr, ok := app.transport.(*Transport)
+	if !ok {
+		t.Skip("Wing transport unavailable on this platform")
+	}
+	f := tr.config.Feathers["GET /json-serialize"]
+	if len(f.handlers) == 0 {
+		t.Fatal("WingJSON route did not retain its handler chain")
+	}
+
+	resp := acquireResponse()
+	defer releaseResponse(resp)
+
+	app.serveKrudaRoute(resp, &wingRequest{method: "GET", path: "/json-serialize", keepAlive: true}, f.handlers)
+
+	if !handlerRan {
+		t.Fatal("handler did not run")
+	}
+	if !resp.jsonFast {
+		t.Fatal("JSON serialize did not use Wing JSON responder")
+	}
+	if string(resp.body) != `{"custom":true}` {
+		t.Fatalf("body = %q", string(resp.body))
 	}
 }
 

--- a/wing_http.go
+++ b/wing_http.go
@@ -704,6 +704,7 @@ func acquireResponse() *wingResponse {
 	r.body = r.body[:0]
 	r.buf = r.buf[:0]
 	r.staticResp = nil
+	r.jsonFast = false
 	r.fileFd = 0
 	r.fileSize = 0
 	r.responseMode = responseGeneric
@@ -734,6 +735,11 @@ func releaseResponse(r *wingResponse) {
 	} else {
 		r.body = r.body[:0]
 	}
+	if r.jsonBuf.Cap() > 65536 {
+		r.jsonBuf = bytes.Buffer{}
+	} else {
+		r.jsonBuf.Reset()
+	}
 	respPool.Put(r)
 }
 
@@ -743,6 +749,7 @@ type wingResponse struct {
 	headers              wingHeaders
 	body                 []byte
 	buf                  []byte // scratch buffer for serialization
+	jsonBuf              bytes.Buffer
 	staticResp           []byte // pre-built full response (if set, buildZeroCopy returns this)
 	jsonFast             bool   // SetJSON fast path — skip header interface, write status+json directly
 	responseMode         responseMode
@@ -784,6 +791,16 @@ func (r *wingResponse) SetJSON(status int, data []byte) {
 	r.status = status
 	r.body = data
 	r.jsonFast = true
+}
+func (r *wingResponse) SetJSONStream(status int, enc func(buf *bytes.Buffer, v any) error, v any) error {
+	r.jsonBuf.Reset()
+	if err := enc(&r.jsonBuf, v); err != nil {
+		return err
+	}
+	r.status = status
+	r.body = r.jsonBuf.Bytes()
+	r.jsonFast = true
+	return nil
 }
 
 // Pre-computed status lines to avoid strconv per response.


### PR DESCRIPTION
## Summary

- stream Wing `kruda_stdjson` JSON serialization responses into a response-owned buffer before using the Wing JSON fast response builder
- preserve custom `WithJSONEncoder` behavior and leave the default Sonic response path unchanged
- add focused Wing tests for the stdjson stream responder and custom encoder behavior
- record local microbenchmark evidence plus focused tiger diagnostic pipeline evidence

## Scope

This is a narrow normal handler-path optimization for `Ctx.JSON` on Wing when the active JSON encoder is `encoding/json`. It does not change the default Sonic runtime behavior, static bypass semantics, middleware behavior, lifecycle behavior, security headers, cookies, CORS, or response ordering.

This PR does not claim a broad Actix win. The evidence supports that the Wing stdjson JSON serialization path improves and remains in the same ballpark as Actix for this diagnostic workload. One pipeline profile clears the 3% RPS gate, while the higher-connection profile is +2.60% RPS and therefore below the public claim threshold.

## Evidence

Evidence note: `bench/reproducible/results/2026-06-02-wing-json-stream-response-evidence.md`

Local microbenchmark median comparison, `origin/main` at `6ad22a7` vs candidate `d77ff70`:

| Benchmark | Main ns/op | Candidate ns/op | Delta | Main B/op | Candidate B/op | Main alloc/op | Candidate alloc/op |
|---|---:|---:|---:|---:|---:|---:|---:|
| `BenchmarkCPUHandlerJSONSerializeFeather` | 312.80 | 297.65 | -4.84% | 192 | 160 | 2 | 1 |
| `BenchmarkCPUHandlerJSONStaticBytesFeather` | 232.20 | 236.20 | +1.72% | 160 | 160 | 1 | 1 |
| `BenchmarkCPUHandlerJSONStaticFeather` | 224.00 | 220.85 | -1.41% | 160 | 160 | 1 | 1 |
| `BenchmarkCPUResponseJSON` | 42.86 | 43.30 | +1.01% | 160 | 160 | 1 | 1 |

Focused tiger diagnostic pipeline evidence, `json-serialize`, `KRUDA_GO_TAGS=kruda_stdjson`, zero socket errors and zero non-2xx responses:

| Profile | Kruda median RPS | Actix median RPS | RPS delta | Kruda p99 ms | Actix p99 ms | p99 delta |
|---|---:|---:|---:|---:|---:|---:|
| `pipeline-c128-d8` | 2,931,759.93 | 2,797,118.54 | +4.81% | 1.384 | 2.385 | -41.97% |
| `pipeline-c256-d8` | 2,997,507.41 | 2,921,522.08 | +2.60% | 2.658 | 3.589 | -25.94% |

Default/Sonic control from tiger is also recorded in the evidence note; it remains unchanged by this PR.

## Validation

```bash
/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin \
  GOTOOLCHAIN=local GOWORK=off \
  GOCACHE=/private/tmp/kruda-go-build-cache-jsonpath \
  GOMODCACHE=/private/tmp/kruda-go-mod-cache-jsonpath \
  go test -count=1 -tags kruda_stdjson ./...
```

Passed locally on 2026-06-02.