### PR TITLE
perf: skip duplicate Linux accept rearm

### DIFF
--- a/bench/go.mod
+++ b/bench/go.mod
@@ -3,7 +3,7 @@ module github.com/go-kruda/kruda/bench
 go 1.25.10
 
 replace (
-	github.com/go-kruda/kruda => ..
+	github.com/go-kruda/kruda => ../
 	github.com/go-kruda/kruda/transport/wing => ../transport/wing
 )
 

--- a/bench/reproducible/README.md
+++ b/bench/reproducible/README.md
@@ -209,7 +209,12 @@ The script runs both profiles for every framework and route:
 
 The harness sets `GOMAXPROCS=8` and `KRUDA_WORKERS=4` by default. The Kruda worker count matches the `wrk -t4` CPU-bound profiles and is recorded in every `environment.txt`. Override `KRUDA_WORKERS` explicitly when studying worker scaling.
 
-Memory footprint experiments may set `KRUDA_READ_BUF_SIZE`, for example `KRUDA_READ_BUF_SIZE=4096`, to reduce Wing's per-connection read buffer for short-header CPU-only workloads. This is not the framework default and must be labeled as a workload-specific memory profile; smaller buffers can reject requests whose request line and headers do not fit the configured size.
+Memory footprint experiments may set `KRUDA_READ_BUF_SIZE`, for example
+`KRUDA_READ_BUF_SIZE=4096` for the current balanced benchmark profile or
+`KRUDA_READ_BUF_SIZE=2048` for a more aggressive short-header memory candidate.
+This is not the framework default and must be labeled as a workload-specific
+memory profile; smaller buffers can reject requests whose request line and
+headers do not fit the configured size.
 
 Each framework/route/profile combination gets one warmup run and five measured rounds.
 
@@ -281,6 +286,15 @@ When those conditions are not met, use "same ballpark as Actix." Do not make RPS
 
 ## Current Evidence
 
+The latest clean tiger evidence on `perf/wing-nonpipelined-io-profile` is in
+`results/2026-06-04-clean-cross-runtime-evidence.md` and
+`results/2026-06-04-clean-resource-evidence.md`. It uses the normal
+CPU-bound handler routes, `GOMAXPROCS=8`, `KRUDA_WORKERS=4`, and
+`KRUDA_READ_BUF_SIZE=4096`. The run satisfied the "faster than Actix" gate on
+all measured route/profile rows with zero socket errors and zero non-2xx
+responses. The resource evidence shows Kruda with higher RPS/core than Actix
+while Actix still uses less RSS.
+
 The committed tiger evidence captured at commit `984f0d6` satisfies the "faster than Actix" gate for CPU-bound Wing handler routes under both the latency and throughput profiles. Throughput-profile medians:
 
 | Route | Evidence directory | Kruda vs Actix median RPS | Kruda vs Actix p99 |
@@ -294,5 +308,13 @@ These are normal handler-path routes. Static bypass route options are intentiona
 The corresponding resource evidence is in `results/resource-main-984f0d6-20260524T174429Z/`, with a summary note in `results/2026-05-25-main-984f0d6-tiger-evidence.md`. It uses `GOMAXPROCS=8`, `KRUDA_WORKERS=4`, and a default Kruda benchmark binary without the `bench_pprof` build tag to match the harness `wrk -t4` CPU-bound profiles. The run shows zero socket errors and zero non-2xx responses, with Kruda throughput, p99, and RPS/core ahead of Actix while RSS remains higher than Actix.
 
 The optional short-header read-buffer resource profile is in `results/resource-20260524Tphase7-readbuf4k/`, with a summary note in `results/2026-05-24-read-buffer-size-evidence.md`. It uses `KRUDA_READ_BUF_SIZE=4096`; compared with the phase 6 baseline, Kruda max RSS dropped by 10.77%, 17.61%, and 10.85% on the throughput routes. Actix still has lower RSS, so this is RSS reduction evidence, not a memory-footprint win claim.
+
+The repeated `KRUDA_READ_BUF_SIZE=2048` resource candidate is documented in
+`results/2026-06-04-read-buffer-2048-evidence.md`. It reduced Kruda max RSS by
+roughly 12-16% versus the clean `4096` resource evidence while preserving zero
+socket errors, zero non-2xx responses, and the Actix throughput/p99 gate. Some
+Kruda p99 rows were higher than the clean `4096` profile, so keep `4096` as the
+published throughput/p99 evidence profile and treat `2048` as an optional
+short-header memory profile candidate.
 
 The lazy Wing peer-address lookup evidence is in `results/resource-20260524Tphase8-lazy-remote-addr-final-readbuf4k/`, with a summary note in `results/2026-05-24-lazy-remote-addr-evidence.md`. It shows the same CPU-bound handler routes with zero socket errors and zero non-2xx responses, and a short `strace` check confirms that routes which do not call `RemoteAddr()` no longer pay eager `getpeername` syscalls on accept.

--- a/bench/reproducible/results/2026-06-04-clean-cross-runtime-evidence.md
+++ b/bench/reproducible/results/2026-06-04-clean-cross-runtime-evidence.md
@@ -1,0 +1,72 @@
+# Clean Cross-Runtime CPU-Bound Evidence
+
+Date: 2026-06-04
+Host: tiger dev server
+Branch: `perf/wing-nonpipelined-io-profile`
+Commit under test: `a7005aa`
+
+## Scope
+
+This run validates the reproducible CPU-bound benchmark after the readiness
+guard fix in `e7fda49` (`bench: reject occupied readiness ports`). The run used
+non-default high ports to avoid tiger services already bound to `:3000`.
+
+Result directory:
+`/home/tiger/kruda-wing-nonpipelined-io-ef3fb05/bench/reproducible/results/clean-cross-runtime-20260604T153451Z`
+
+Raw logs, `summary.csv`, `summary.md`, `claim-gates.md`, and environment
+metadata are stored in that result directory on tiger.
+
+## Method
+
+Command shape:
+
+```bash
+BENCH_FRAMEWORKS="kruda fiber actix" \
+BENCH_ROUNDS=5 \
+BENCH_DURATION=15s \
+KRUDA_GO_TAGS=kruda_stdjson \
+KRUDA_PORT=3200 \
+FIBER_PORT=3202 \
+ACTIX_PORT=3203 \
+./bench.sh plaintext-handler json-static json-serialize
+```
+
+Environment highlights:
+
+- CPU: 13th Gen Intel Core i5-13500, 8 cores, SMT off in the guest
+- OS/kernel: Linux 6.8.0-117-generic
+- Go: 1.25.10 linux/amd64
+- Rust: 1.93.1
+- wrk: 4.1.0
+- `GOMAXPROCS=8`
+- `KRUDA_WORKERS=4`
+- profiles:
+  - latency: `wrk --latency -t4 -c128 -d15s`
+  - throughput: `wrk --latency -t4 -c256 -d15s`
+
+## Claim Gates
+
+Rule: faster-than-Actix requires Kruda median RPS at least 3% higher than Actix,
+Kruda p99 no worse than 10% above Actix, and zero socket errors plus zero
+non-2xx responses.
+
+| Profile | Route | Kruda median RPS | Actix median RPS | RPS delta | Kruda median p99 ms | Actix median p99 ms | p99 delta | Errors | Gate |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---|
+| latency | `json-serialize` | 805,923.52 | 693,355.72 | +16.24% | 0.556 | 2.610 | -78.70% | 0 | faster-than-Actix |
+| latency | `json-static` | 805,026.96 | 699,120.41 | +15.15% | 0.816 | 2.840 | -71.27% | 0 | faster-than-Actix |
+| latency | `plaintext-handler` | 819,826.88 | 698,019.92 | +17.45% | 0.850 | 3.150 | -73.02% | 0 | faster-than-Actix |
+| throughput | `json-serialize` | 806,171.49 | 718,018.99 | +12.28% | 0.746 | 3.080 | -75.78% | 0 | faster-than-Actix |
+| throughput | `json-static` | 810,602.58 | 722,192.60 | +12.24% | 0.718 | 3.110 | -76.91% | 0 | faster-than-Actix |
+| throughput | `plaintext-handler` | 813,090.51 | 729,007.30 | +11.53% | 0.818 | 3.350 | -75.58% | 0 | faster-than-Actix |
+
+## Interpretation
+
+- After the readiness guard fix, the clean cross-runtime CPU-bound handler-path
+  evidence satisfies the public faster-than-Actix gate on every measured route
+  and profile.
+- This is not an io_uring, PGO, CPU-affinity, static-bypass, DB, TLS, HTTP/2,
+  or production-network claim.
+- The evidence supports public wording for high-performance, low-latency,
+  high-throughput CPU-bound Wing handler routes, with the benchmark scope and
+  environment stated explicitly.

--- a/bench/reproducible/results/2026-06-04-clean-resource-evidence.md
+++ b/bench/reproducible/results/2026-06-04-clean-resource-evidence.md
@@ -1,0 +1,74 @@
+# Clean CPU/RAM Resource Evidence
+
+Date: 2026-06-04
+Host: tiger dev server
+Branch: `perf/wing-nonpipelined-io-profile`
+Commit under test: `805b0d5`
+
+## Scope
+
+This run records CPU and RSS evidence after the readiness guard fix. It uses the
+same CPU-bound handler routes as the reproducible cross-runtime benchmark and
+non-default high ports to avoid tiger service collisions.
+
+Result directory:
+`/home/tiger/kruda-wing-nonpipelined-io-ef3fb05/bench/reproducible/results/clean-resource-20260604T160505Z`
+
+Raw `wrk` logs, pidstat logs, `resource-summary.csv`,
+`resource-aggregated.csv`, and environment metadata are stored in that result
+directory on tiger.
+
+## Method
+
+Command shape:
+
+```bash
+BENCH_FRAMEWORKS="kruda fiber actix" \
+BENCH_DURATION=15s \
+KRUDA_GO_TAGS=kruda_stdjson \
+KRUDA_PORT=3210 \
+FIBER_PORT=3212 \
+ACTIX_PORT=3213 \
+./resource.sh plaintext-handler json-static json-serialize
+```
+
+Resource columns:
+
+- CPU percentage is process CPU across cores.
+- RSS is resident memory from `pidstat`.
+- RPS/core is RPS divided by average CPU cores consumed.
+
+## Summary
+
+| Profile | Framework | Route | RPS | p99 ms | Avg CPU % | Max RSS MB | RPS/core | Errors |
+|---|---|---|---:|---:|---:|---:|---:|---:|
+| latency | kruda | `plaintext-handler` | 828,851.98 | 0.727 | 385.41 | 16.25 | 215,057 | 0 |
+| latency | kruda | `json-static` | 796,923.79 | 0.496 | 386.67 | 17.75 | 206,099 | 0 |
+| latency | kruda | `json-serialize` | 829,753.22 | 0.454 | 387.81 | 19.00 | 213,959 | 0 |
+| throughput | kruda | `plaintext-handler` | 826,693.71 | 0.692 | 387.13 | 20.38 | 213,544 | 0 |
+| throughput | kruda | `json-static` | 832,430.88 | 0.767 | 385.87 | 21.75 | 215,728 | 0 |
+| throughput | kruda | `json-serialize` | 828,632.90 | 0.716 | 387.94 | 21.38 | 213,598 | 0 |
+| latency | fiber | `plaintext-handler` | 641,758.92 | 2.490 | 409.60 | 11.88 | 156,679 | 0 |
+| latency | fiber | `json-static` | 634,531.59 | 2.720 | 407.52 | 12.00 | 155,706 | 0 |
+| latency | fiber | `json-serialize` | 609,036.86 | 2.920 | 414.32 | 17.38 | 146,997 | 0 |
+| throughput | fiber | `plaintext-handler` | 647,843.65 | 3.480 | 412.37 | 17.69 | 157,103 | 0 |
+| throughput | fiber | `json-static` | 646,294.17 | 3.370 | 410.06 | 17.69 | 157,610 | 0 |
+| throughput | fiber | `json-serialize` | 627,159.76 | 3.620 | 414.18 | 22.14 | 151,422 | 0 |
+| latency | actix | `plaintext-handler` | 712,201.01 | 3.060 | 397.20 | 7.95 | 179,305 | 0 |
+| latency | actix | `json-static` | 693,051.73 | 2.890 | 385.07 | 8.07 | 179,981 | 0 |
+| latency | actix | `json-serialize` | 704,911.81 | 2.940 | 391.75 | 8.07 | 179,939 | 0 |
+| throughput | actix | `plaintext-handler` | 728,631.13 | 3.120 | 389.00 | 10.32 | 187,309 | 0 |
+| throughput | actix | `json-static` | 730,945.89 | 3.250 | 398.93 | 10.45 | 183,227 | 0 |
+| throughput | actix | `json-serialize` | 726,368.87 | 3.180 | 391.45 | 10.45 | 185,559 | 0 |
+
+## Interpretation
+
+- Kruda has the highest RPS/core across every measured route and profile.
+- Kruda CPU consumption is roughly in the same band as Actix and lower than
+  Fiber in this run, while producing higher RPS and lower p99 latency.
+- Kruda RSS is higher than Actix, especially in throughput profiles, but is in
+  the same general band as Fiber and lower than Fiber for throughput
+  `json-serialize`.
+- This supports the current public claim shape: faster-than-Actix on the
+  measured CPU-bound handler routes, with the resource caveat that Actix still
+  has lower RSS on this host.

--- a/bench/reproducible/results/2026-06-04-linux-accept-rearm-evidence.md
+++ b/bench/reproducible/results/2026-06-04-linux-accept-rearm-evidence.md
@@ -1,0 +1,64 @@
+# Linux Accept Re-arm Evidence
+
+Date: 2026-06-04
+Host: tiger dev server
+Branch: `perf/wing-nonpipelined-io-profile`
+Change under test: `2f0f728` (`perf: skip duplicate Linux accept rearm`)
+
+## Scope
+
+Linux Wing uses persistent edge-triggered epoll for the listener fd. Successful
+accept events do not need a worker-level `SubmitAccept` re-arm, but the previous
+epoll event adapter did not mark accepted connections with `cqeFMore`. That
+caused `handleAccept` to issue duplicate `epoll_ctl(ADD)` calls against the
+already-registered listener/eventfd pair after successful accepts.
+
+This change marks successful Linux epoll accept events with `cqeFMore`, matching
+the existing worker contract that skips re-arm when the backend is still armed.
+It does not change request parsing, handler execution, middleware, lifecycle
+hooks, response semantics, or the default route behavior.
+
+## Validation
+
+Local macOS validation:
+
+```bash
+GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go test -count=1 -tags kruda_stdjson ./...
+GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go test -race -count=1 -tags kruda_stdjson ./...
+cd bench
+PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOTOOLCHAIN=local GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go test ./...
+```
+
+Tiger Linux validation:
+
+```bash
+CI=1 GOWORK=off GOCACHE=/tmp/kruda-go-build-cache GOMODCACHE=/tmp/kruda-go-mod-cache go test -count=1 -tags kruda_stdjson ./...
+```
+
+The non-CI `TestPlaintextPerformanceGuard` threshold is too tight for the
+current tiger VM state and failed both before and after this change. The
+previous commit `a04c4f8` produced 47,706-49,214 req/s across repeated targeted
+runs, and `2f0f728` produced 47,674-49,093 req/s. That failure is pre-existing
+on this host and is not evidence of a regression from this accept re-arm fix.
+
+## Diagnostic A/B
+
+Result directory:
+`/home/tiger/kruda-wing-nonpipelined-io-ef3fb05/bench/reproducible/results/accept-churn-20260604T163105Z`
+
+Command shape:
+
+```bash
+wrk --latency -t4 -c256 -d10s -H "Connection: close" \
+  http://127.0.0.1:<port>/plaintext-handler
+```
+
+| Commit | RPS | Avg latency | Stdev | Max latency | Socket read errors |
+|---|---:|---:|---:|---:|---:|
+| `a04c4f8` before | 127,624.54 | 1.59 ms | 2.07 ms | 12.92 ms | 1,288,983 |
+| `2f0f728` after | 128,204.17 | 1.45 ms | 1.93 ms | 20.75 ms | 1,294,851 |
+
+The diagnostic shows a small connection-churn improvement, but the forced-close
+wrk profile reports socket read errors in both rows. Treat it as directional
+accept-path evidence only. It is not public benchmark claim evidence and does
+not change the CPU-bound handler-route Actix claim gate.

--- a/bench/reproducible/results/2026-06-04-read-buffer-2048-evidence.md
+++ b/bench/reproducible/results/2026-06-04-read-buffer-2048-evidence.md
@@ -1,6 +1,6 @@
 # Read Buffer 2048 Evidence
 
-Date: 2026-06-04
+Date: 2026-06-05
 Host: tiger dev server
 Branch: `perf/wing-nonpipelined-io-profile`
 Commit under test: `7c54694`
@@ -77,11 +77,53 @@ Compared with the clean `4096` resource evidence from
 RSS by roughly 12-17% across the six measured route/profile rows. It still uses
 more RSS than Actix.
 
+## Repeat Cross-Runtime Resource Pass
+
+Result directory:
+`/home/tiger/kruda-wing-nonpipelined-io-ef3fb05/bench/reproducible/results/resource-readbuf2048-repeat-20260604T181840Z`
+
+Command shape:
+
+```bash
+BENCH_FRAMEWORKS="kruda fiber actix" \
+BENCH_DURATION=15s \
+KRUDA_GO_TAGS=kruda_stdjson \
+KRUDA_READ_BUF_SIZE=2048 \
+KRUDA_PORT=3251 \
+FIBER_PORT=3252 \
+ACTIX_PORT=3253 \
+./resource.sh plaintext-handler json-static json-serialize
+```
+
+| Profile | Route | Kruda RPS | Actix RPS | Kruda p99 | Actix p99 | Kruda RSS | Actix RSS | Errors |
+|---|---|---:|---:|---:|---:|---:|---:|---:|
+| latency | `plaintext-handler` | 822,189.28 | 712,321.22 | 1.090 | 3.610 | 14.38 | 7.95 | 0 |
+| latency | `json-static` | 800,095.67 | 700,721.19 | 1.060 | 2.940 | 15.50 | 7.95 | 0 |
+| latency | `json-serialize` | 825,286.03 | 693,787.07 | 0.660 | 3.280 | 16.50 | 7.95 | 0 |
+| throughput | `plaintext-handler` | 824,356.91 | 735,412.99 | 1.130 | 4.100 | 17.88 | 10.20 | 0 |
+| throughput | `json-static` | 809,993.79 | 724,586.98 | 1.140 | 3.250 | 18.25 | 10.45 | 0 |
+| throughput | `json-serialize` | 821,033.81 | 713,632.10 | 1.050 | 3.570 | 18.38 | 10.45 | 0 |
+
+The repeat pass did not reproduce the earlier `latency/json-serialize` p99
+spike. It again preserved zero socket errors and zero non-2xx responses.
+
+Compared with the clean `4096` resource evidence, the repeat `2048` pass reduced
+Kruda max RSS by roughly 12-16% across the six measured route/profile rows:
+
+| Profile | Route | 4096 RSS MB | 2048 repeat RSS MB | RSS delta |
+|---|---|---:|---:|---:|
+| latency | `plaintext-handler` | 16.25 | 14.38 | -11.5% |
+| latency | `json-static` | 17.75 | 15.50 | -12.7% |
+| latency | `json-serialize` | 19.00 | 16.50 | -13.2% |
+| throughput | `plaintext-handler` | 20.38 | 17.88 | -12.3% |
+| throughput | `json-static` | 21.75 | 18.25 | -16.1% |
+| throughput | `json-serialize` | 21.38 | 18.38 | -14.0% |
+
 ## Decision
 
-Keep `KRUDA_READ_BUF_SIZE=4096` as the current published benchmark profile until
-there is repeated evidence. `2048` is a credible follow-up candidate for an
-optional short-header memory profile because it lowered RSS materially while
-preserving zero errors and competitive throughput. Repeat the cross-runtime run
-before updating docs or public benchmark recommendations, because the
-`latency/json-serialize` row had a p99 spike in this single resource pass.
+Keep `KRUDA_READ_BUF_SIZE=4096` as the current published throughput/p99 evidence
+profile. Promote `2048` only as an optional short-header memory profile
+candidate: it repeatedly reduced RSS materially while preserving zero errors,
+zero non-2xx responses, and the Actix throughput/p99 gate, but it also produced
+some higher Kruda p99 rows than the clean `4096` profile. Do not change Kruda's
+framework default from this evidence.

--- a/bench/reproducible/results/2026-06-04-read-buffer-2048-evidence.md
+++ b/bench/reproducible/results/2026-06-04-read-buffer-2048-evidence.md
@@ -1,0 +1,87 @@
+# Read Buffer 2048 Evidence
+
+Date: 2026-06-04
+Host: tiger dev server
+Branch: `perf/wing-nonpipelined-io-profile`
+Commit under test: `7c54694`
+
+## Scope
+
+This evidence checks whether a smaller Wing read buffer is a useful
+workload-specific memory profile for short-header CPU-bound routes. It does not
+change Kruda's framework default. Smaller read buffers can reject requests whose
+request line and headers do not fit the configured buffer, so this remains an
+explicit benchmark/runtime tuning knob, not a general default.
+
+## Directional Sweep
+
+Result directory:
+`/home/tiger/kruda-wing-nonpipelined-io-ef3fb05/bench/reproducible/results/readbuf-sweep-20260604T164728Z`
+
+Command shape:
+
+```bash
+BENCH_FRAMEWORKS=kruda \
+BENCH_DURATION=8s \
+KRUDA_GO_TAGS=kruda_stdjson \
+KRUDA_READ_BUF_SIZE=<1024|2048|4096> \
+./resource.sh plaintext-handler json-static json-serialize
+```
+
+Directional summary:
+
+- `1024` produced the lowest RSS, but p99 was less stable on `json-static` and
+  throughput `plaintext-handler`.
+- `2048` looked like the most balanced candidate in the sweep: lower RSS than
+  `4096`, competitive RPS/core, and no errors.
+- `4096` remained strong on some throughput rows, especially
+  `json-serialize`, but used more RSS.
+
+Selected rows:
+
+| Read buffer | Profile | Route | RPS | p99 ms | Max RSS MB | RPS/core | Errors |
+|---:|---|---|---:|---:|---:|---:|---:|
+| 1024 | throughput | `json-serialize` | 811,117.83 | 0.701 | 18.00 | 210,407 | 0 |
+| 2048 | throughput | `json-serialize` | 818,073.08 | 0.742 | 18.25 | 214,503 | 0 |
+| 4096 | throughput | `json-serialize` | 834,088.56 | 0.761 | 20.38 | 217,636 | 0 |
+
+## Cross-Runtime Resource Pass
+
+Result directory:
+`/home/tiger/kruda-wing-nonpipelined-io-ef3fb05/bench/reproducible/results/resource-readbuf2048-20260604T165355Z`
+
+Command shape:
+
+```bash
+BENCH_FRAMEWORKS="kruda fiber actix" \
+BENCH_DURATION=15s \
+KRUDA_GO_TAGS=kruda_stdjson \
+KRUDA_READ_BUF_SIZE=2048 \
+KRUDA_PORT=3241 \
+FIBER_PORT=3242 \
+ACTIX_PORT=3243 \
+./resource.sh plaintext-handler json-static json-serialize
+```
+
+| Profile | Route | Kruda RPS | Actix RPS | Kruda p99 | Actix p99 | Kruda RSS | Actix RSS | Errors |
+|---|---|---:|---:|---:|---:|---:|---:|---:|
+| latency | `plaintext-handler` | 823,294.73 | 675,087.29 | 0.870 | 3.270 | 14.00 | 7.82 | 0 |
+| latency | `json-static` | 835,733.44 | 632,128.83 | 0.840 | 3.980 | 15.50 | 7.82 | 0 |
+| latency | `json-serialize` | 802,325.97 | 535,287.60 | 2.410 | 4.550 | 16.50 | 7.95 | 0 |
+| throughput | `plaintext-handler` | 833,025.07 | 720,352.52 | 0.816 | 3.430 | 17.62 | 10.32 | 0 |
+| throughput | `json-static` | 833,497.52 | 733,921.77 | 0.837 | 3.340 | 18.12 | 10.32 | 0 |
+| throughput | `json-serialize` | 820,297.69 | 723,568.66 | 1.090 | 3.280 | 18.75 | 10.45 | 0 |
+
+Compared with the clean `4096` resource evidence from
+`2026-06-04-clean-resource-evidence.md`, the `2048` profile reduced Kruda max
+RSS by roughly 12-17% across the six measured route/profile rows. It still uses
+more RSS than Actix.
+
+## Decision
+
+Keep `KRUDA_READ_BUF_SIZE=4096` as the current published benchmark profile until
+there is repeated evidence. `2048` is a credible follow-up candidate for an
+optional short-header memory profile because it lowered RSS materially while
+preserving zero errors and competitive throughput. Repeat the cross-runtime run
+before updating docs or public benchmark recommendations, because the
+`latency/json-serialize` row had a p99 spike in this single resource pass.

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -264,7 +264,13 @@ Rule of thumb: keep total pool goroutines (workers × pool_size) close to your D
 
 ### Env Vars
 
-`KRUDA_READ_BUF_SIZE` is advanced tuning for Wing's per-connection read buffer. Lower values can reduce RSS in short-header CPU-only profiles, but requests whose request line and headers do not fit the buffer are rejected. Keep the default for general APIs unless a workload-specific benchmark proves the smaller buffer is safe.
+`KRUDA_READ_BUF_SIZE` is advanced tuning for Wing's per-connection read buffer.
+Lower values can reduce RSS in short-header CPU-only profiles, but requests
+whose request line and headers do not fit the buffer are rejected. Keep the
+default for general APIs unless a workload-specific benchmark proves the smaller
+buffer is safe. The reproducible CPU-bound benchmark uses `4096` for the current
+balanced throughput/p99 evidence profile; `2048` is only an optional
+short-header memory profile candidate.
 
 | Env Var | Default | Description |
 |---------|---------|-------------|

--- a/wing_engine.go
+++ b/wing_engine.go
@@ -49,6 +49,7 @@ const (
 	opWake
 )
 
-// cqeFMore is set in event.Flags when a multishot operation will produce more completions.
-// On non-Linux backends (kqueue) this is always 0, so re-arm happens every time.
+// cqeFMore is set in event.Flags when the backend will keep producing accept
+// events without a worker-level re-arm. On kqueue this is always 0, so re-arm
+// happens every time.
 const cqeFMore uint32 = 1 << 1

--- a/wing_engine_linux.go
+++ b/wing_engine_linux.go
@@ -187,7 +187,7 @@ func (e *epollEngine) drainAccept(events []event) int {
 			break
 		}
 		e.epollAdd(int32(nfd), 0)
-		events[count] = event{Op: opAccept, Res: int32(nfd)}
+		events[count] = event{Op: opAccept, Res: int32(nfd), Flags: cqeFMore}
 		count++
 	}
 	return count


### PR DESCRIPTION
## Summary
- Skip duplicate worker-level accept re-arms on Linux epoll accept events by marking successful accept completions with the existing `cqeFMore` flag.
- Add clean CPU/resource benchmark evidence plus Linux accept re-arm evidence from the Tiger runs.
- Document `KRUDA_READ_BUF_SIZE=2048` only as an optional short-header memory profile candidate while keeping `4096` as the current published throughput/p99 evidence profile and leaving framework defaults unchanged.

## Validation
- `/usr/bin/env GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go test -count=1 -tags kruda_stdjson ./...`
- `/usr/bin/env GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go test -race -count=1 -tags kruda_stdjson ./...`
- `/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOTOOLCHAIN=local GOWORK=off GOCACHE=/private/tmp/kruda-go-build-cache GOMODCACHE=/private/tmp/kruda-go-mod-cache go test ./...` from `bench/`
- `tiger-linux`: exact pushed branch temp clone, `CI=1 GOWORK=off GOCACHE=/tmp/kruda-go-build-cache GOMODCACHE=/tmp/kruda-go-mod-cache go test -count=1 -tags kruda_stdjson ./...`

## Notes
- This PR intentionally excludes the io_uring, CPU affinity, PGO, and speculative read experiments from the investigation branch.
- It does not claim a broad memory-footprint win or change Kruda's default read buffer size.