### PR TITLE
docs: plan v1.2.6 performance candidates

### DIFF
--- a/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
+++ b/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
@@ -1,0 +1,414 @@
+# Kruda v1.2.6 Candidate Roadmap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the post-v1.2.5 performance evidence into a narrow v1.2.6 candidate list without reviving rejected probes or making an unsupported broad +20% CPU-bound claim.
+
+**Architecture:** Treat v1.2.6 as an evidence-gated patch line. Start with docs, benchmark methodology, and reproducibility work; only accept runtime changes after fresh same-runner benchmark evidence proves a scoped claim. Keep CPU-bound fair-handler work, read-only DB work, pipelined I/O diagnostics, and resource-profile tuning as separate tracks.
+
+**Tech Stack:** Go 1.25+, `kruda_stdjson` build tag, Wing transport, `bench/reproducible` harnesses, `wrk`, `benchstat`, Linux tiger benchmark host, GitHub Actions test and benchmark workflows.
+
+---
+
+## Decision Summary
+
+Do not start v1.2.6 by editing runtime hot paths.
+
+The current evidence says:
+
+- Broad CPU-bound fair-handler +20% versus Actix is not proven.
+- The latest CPU-bound tiger smoke at `c3a17ef` showed +12.70% plaintext, +14.53% static JSON, and +13.73% serialized JSON in the throughput profile.
+- The read-only DB probe did prove a scoped +20% path: `/db` +160.21% and `/fortunes` +95.05% throughput versus Actix, with lower p99.
+- Pipelined I/O diagnostics show useful architecture behavior and lower p99, but not a blanket +20% public claim.
+- `KRUDA_READ_BUF_SIZE=2048` is a short-header memory-profile candidate, not a default-change candidate.
+- Rejected probes stay rejected unless fresh evidence changes the decision: event timestamp reuse, temporary PGO, static response bypass for fair-handler claims, Actix worker-count alignment as a win path, Kruda workers=8 scaling, CPU affinity, epoll idle spin, and extra pipelined response batching.
+
+## File Map
+
+- `docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md`: this execution plan and candidate list.
+- `bench/reproducible/results/2026-06-06-wing-actix-20-follow-up.md`: source evidence for broad +20 rejection and read-only DB acceptance.
+- `bench/reproducible/results/2026-06-02-wing-json-stream-response-evidence.md`: source evidence for the scoped stdjson JSON serialization track.
+- `bench/reproducible/results/2026-06-02-pipelined-io-diagnostic-tiger.md`: source evidence for pipelined I/O diagnostic behavior.
+- `bench/reproducible/results/2026-06-02-wing-response-batching-syscall-evidence.md`: source evidence rejecting extra inline pipelined response batching.
+- `bench/reproducible/results/2026-06-04-read-buffer-2048-evidence.md`: source evidence for optional short-header memory profile work.
+- `bench/reproducible/README.md`: benchmark harness usage and public wording guardrails.
+- `docs/guide/performance.md`: public performance wording if a later task promotes a candidate.
+- `docs/release-process.md`: release gate and benchmark-review checklist.
+- `.github/workflows/benchmark.yml`: same-runner benchmark gate behavior.
+- `CHANGELOG.md`: only modified when an actual v1.2.6 release candidate exists.
+
+## Candidate Table
+
+| Track | Status | v1.2.6 value | Required proof before PR |
+|---|---|---|---|
+| Read-only DB workload | Accepted evidence, needs productization | Scoped performance claim for `db` and `fortunes` with framework-specific DSNs | Fresh tiger run with `BENCH_ENABLE_DB=1`, zero errors, same toolchain, and no manual DSN override |
+| JSON serialization | Candidate | Narrow serialized JSON improvement, especially `kruda_stdjson` and p99 | Same-runner main-vs-branch benchmark showing no static/plaintext regression and clear JSON serialization gain |
+| Pipelined I/O diagnostics | Diagnostic only | Better architecture evidence and optional workload profile language | Fresh pipeline run plus syscall ratio check; public wording must say HTTP/1.1 pipelined |
+| Short-header memory profile | Optional profile | Lower RSS with `KRUDA_READ_BUF_SIZE=2048` for short-header workloads | Repeat resource run proves zero errors, no non-2xx, and p99 tradeoff is documented |
+| Broad CPU-bound +20% | Rejected for now | None until a new measured lever exists | Must beat Actix by >=20% on all default CPU-bound throughput routes with fair handler semantics |
+
+## Task 1: Publish the Candidate Boundary
+
+**Files:**
+- Modify: `bench/reproducible/README.md`
+- Modify: `docs/guide/performance.md`
+- Optional modify: `docs/MAINTAINER_ROADMAP.md`
+
+- [ ] **Step 1: Confirm current branch and clean state**
+
+```bash
+git status --short --branch
+```
+
+Expected: branch is not `main`, and the working tree is clean before edits.
+
+- [ ] **Step 2: Add a short v1.2.6 candidate boundary section**
+
+Add one public-facing paragraph to `bench/reproducible/README.md` near the benchmark route descriptions:
+
+```markdown
+## v1.2.6 Candidate Boundary
+
+The post-v1.2.5 evidence does not support a broad CPU-bound +20% Actix claim on
+the default fair handler path. Treat read-only DB workloads, serialized JSON,
+pipelined HTTP/1.1 diagnostics, and short-header read-buffer tuning as separate
+candidate tracks. Do not mix their results into one public performance claim.
+```
+
+- [ ] **Step 3: Link the boundary from performance docs**
+
+Add one sentence to `docs/guide/performance.md` near the benchmark methodology section:
+
+```markdown
+For post-v1.2.5 candidate work, keep CPU-bound, read-only DB, pipelined HTTP/1.1,
+and read-buffer memory profiles separate; each profile needs its own evidence
+and wording.
+```
+
+- [ ] **Step 4: Verify docs wording does not overclaim**
+
+```bash
+rg -n "\+20|20%|Actix|DB workload|pipelined|read buffer" bench/reproducible/README.md docs/guide/performance.md
+```
+
+Expected: every +20 or Actix reference is scoped to a named workload, profile, or rejected broad claim.
+
+- [ ] **Step 5: Commit the docs boundary**
+
+```bash
+git add bench/reproducible/README.md docs/guide/performance.md
+git commit -m "docs: define v1.2.6 performance candidate boundary"
+```
+
+## Task 2: Revalidate the Read-only DB Track
+
+**Files:**
+- Modify only if the proof exposes drift: `bench/reproducible/bench.sh`
+- Modify only if wording changes are needed: `bench/reproducible/README.md`
+- Create only if fresh evidence is produced: `bench/reproducible/results/2026-06-06-v126-db-evidence.md`
+
+- [ ] **Step 1: Confirm the DB harness has framework-specific DSN support**
+
+```bash
+rg -n "DATABASE_URL|ACTIX_DATABASE_URL|KRUDA_DATABASE_URL|BENCH_ENABLE_DB|BENCH_KRUDA_DB_DISPATCH" bench/reproducible
+```
+
+Expected: `bench.sh`, `resource.sh`, and benchmark app files show separate framework DSN handling or no manual DSN override is needed.
+
+- [ ] **Step 2: Run the DB proof on tiger**
+
+Run on the Linux benchmark host:
+
+```bash
+cd /path/to/kruda
+git fetch origin main
+git switch -c perf/v126-db-evidence origin/main
+cd bench/reproducible
+BENCH_ENABLE_DB=1 \
+BENCH_KRUDA_DB_DISPATCH=takeover \
+BENCH_FRAMEWORKS="kruda actix" \
+BENCH_ROUNDS=3 \
+BENCH_DURATION=8s \
+BENCH_WARMUP=2s \
+GOTOOLCHAIN=go1.25.10 \
+./bench.sh db fortunes
+```
+
+Expected: every measured row has zero socket errors and zero non-2xx responses.
+
+- [ ] **Step 3: Accept or reject the DB claim**
+
+Accept only if both default read-only DB routes clear the gate:
+
+```text
+db throughput delta versus Actix >= +20%
+fortunes throughput delta versus Actix >= +20%
+Kruda p99 lower than Actix on both routes
+No manual framework-specific DSN override was needed
+```
+
+Reject or rerun if any row has socket errors, non-2xx responses, missing DB rows, mixed toolchains, or a manual DSN override.
+
+- [ ] **Step 4: Record fresh DB evidence**
+
+Create `bench/reproducible/results/2026-06-06-v126-db-evidence.md` with this exact structure:
+
+```markdown
+# v1.2.6 Read-only DB Evidence
+
+Date: 2026-06-06
+Host: tiger
+Commit: output of `git rev-parse HEAD`
+Scope: read-only DB workloads only; not a broad CPU-bound fair-handler claim.
+
+## Command
+
+Use the exact command from Step 2.
+
+## Environment
+
+Copy the concrete values from `environment.txt` in the result directory.
+
+## Median Results
+
+Paste only measured rows from `summary.csv` or `summary.md`.
+
+## Decision
+
+Write `Accepted` or `Rejected`, followed by one paragraph tied to the measured values.
+```
+
+Do not commit the evidence file until the command has produced measured rows.
+
+- [ ] **Step 5: Commit DB evidence if accepted**
+
+```bash
+git add bench/reproducible/results/2026-06-06-v126-db-evidence.md bench/reproducible/README.md
+git commit -m "bench: record v1.2.6 read-only DB evidence"
+```
+
+## Task 3: Recheck the JSON Serialization Track
+
+**Files:**
+- Modify only after a failing proof exists: `ctx_response.go`
+- Modify only after a failing proof exists: `wing_http.go`
+- Test: `wing_feather_internal_test.go`, `wing_bench_test.go`
+- Create only if fresh evidence is produced: `bench/reproducible/results/2026-06-06-v126-json-evidence.md`
+
+- [ ] **Step 1: Run the local JSON microbenchmark baseline**
+
+```bash
+go test -run '^$' -tags kruda_stdjson \
+  -bench 'BenchmarkCPU(ResponseJSON|HandlerJSON(Static|StaticBytes|Serialize)Feather)$' \
+  -benchmem -count=10 .
+```
+
+Expected: command exits 0 and prints benchmark rows for response JSON and handler JSON paths.
+
+- [ ] **Step 2: Define the JSON gate before changing code**
+
+Use this gate for any branch:
+
+```text
+BenchmarkCPUHandlerJSONSerializeFeather improves by >=3% median ns/op
+BenchmarkCPUHandlerJSONSerializeFeather does not increase B/op or allocs/op
+Static JSON helper benchmarks stay within +5% ns/op and no allocation increase
+No public claim says this is a broad Actix win
+```
+
+- [ ] **Step 3: Write a failing proof before runtime edits**
+
+If pursuing a runtime change, add or adjust a focused benchmark/test first. Example target:
+
+```bash
+go test -run '^$' -tags kruda_stdjson \
+  -bench 'BenchmarkCPUHandlerJSONSerializeFeather$' \
+  -benchmem -count=10 .
+```
+
+Expected before an accepted optimization: the measured baseline still shows the gap the candidate intends to improve.
+
+- [ ] **Step 4: Implement only the measured JSON path**
+
+Touch only the response path proven by Step 3. Do not change plaintext, static JSON, DB dispatch, event-loop, or read-buffer code in the same commit.
+
+- [ ] **Step 5: Run the narrow JSON proof**
+
+```bash
+go test -run '^$' -tags kruda_stdjson \
+  -bench 'BenchmarkCPU(ResponseJSON|HandlerJSON(Static|StaticBytes|Serialize)Feather)$' \
+  -benchmem -count=10 .
+```
+
+Expected: JSON serialization meets the Step 2 gate.
+
+- [ ] **Step 6: Commit only if the proof passes**
+
+```bash
+git add ctx_response.go wing_http.go wing_feather_internal_test.go wing_bench_test.go
+git commit -m "perf: improve Wing JSON serialization path"
+```
+
+## Task 4: Keep Pipelined I/O as Diagnostic Work
+
+**Files:**
+- Modify only if diagnostics drift: `bench/reproducible/pipeline.sh`
+- Modify only if syscall diagnostics drift: `bench/reproducible/pipeline-syscall.sh`
+- Create only if fresh evidence is produced: `bench/reproducible/results/2026-06-06-v126-pipeline-evidence.md`
+
+- [ ] **Step 1: Run pipeline throughput diagnostics on tiger**
+
+```bash
+cd bench/reproducible
+BENCH_FRAMEWORKS="kruda actix" \
+BENCH_ROUNDS=3 \
+PIPELINE_DURATION=5s \
+PIPELINE_WARMUP=2s \
+PIPELINE_PROFILES="baseline-c128-d1:128:1 pipeline-c128-d8:128:8 pipeline-c256-d8:256:8" \
+./pipeline.sh plaintext-handler json-static json-serialize
+```
+
+Expected: all measured rows have zero socket errors and zero non-2xx responses.
+
+- [ ] **Step 2: Run syscall diagnostics only if batching behavior is questioned**
+
+```bash
+cd bench/reproducible
+PROFILE_SUDO=1 \
+BENCH_FRAMEWORKS="kruda actix" \
+PIPELINE_PROFILES="baseline-c128-d1:128:1 pipeline-c128-d8:128:8 pipeline-c256-d8:256:8" \
+PIPELINE_DURATION=5s \
+PIPELINE_WARMUP=2s \
+./pipeline-syscall.sh plaintext-handler json-static json-serialize
+```
+
+Expected: depth-8 profiles show Kruda `requests_per_write_send` near 8.00. If already near 8.00, do not implement extra inline response batching.
+
+- [ ] **Step 3: Commit diagnostics only, not runtime changes**
+
+```bash
+git add bench/reproducible/results/2026-06-06-v126-pipeline-evidence.md
+git commit -m "bench: record v1.2.6 pipelined I/O diagnostics"
+```
+
+## Task 5: Treat Read-buffer 2048 as an Optional Profile
+
+**Files:**
+- Modify only if docs need clarification: `docs/guide/performance.md`
+- Modify only if harness output needs clarity: `bench/reproducible/resource.sh`
+- Create only if fresh evidence is produced: `bench/reproducible/results/2026-06-06-v126-readbuf2048-evidence.md`
+
+- [ ] **Step 1: Repeat the resource proof on tiger**
+
+```bash
+cd bench/reproducible
+BENCH_FRAMEWORKS="kruda fiber actix" \
+BENCH_DURATION=15s \
+KRUDA_GO_TAGS=kruda_stdjson \
+KRUDA_READ_BUF_SIZE=2048 \
+./resource.sh plaintext-handler json-static json-serialize
+```
+
+Expected: zero socket errors, zero non-2xx responses, and lower Kruda max RSS versus the documented 4096 profile.
+
+- [ ] **Step 2: Reject default change unless the strict gate passes**
+
+Keep the framework default unchanged unless all conditions pass:
+
+```text
+No p99 regression versus 4096 on all six route/profile rows
+No throughput regression versus 4096 on all six route/profile rows
+RSS reduction remains material across all six route/profile rows
+Large-header rejection risk is documented and acceptable
+```
+
+Expected for current evidence: keep `2048` optional and do not change the framework default.
+
+- [ ] **Step 3: Commit optional-profile docs only**
+
+```bash
+git add docs/guide/performance.md bench/reproducible/results/2026-06-06-v126-readbuf2048-evidence.md
+git commit -m "docs: describe Wing short-header read-buffer profile"
+```
+
+## Task 6: Decide Whether v1.2.6 Is Worth Releasing
+
+**Files:**
+- Modify only when release is justified: `CHANGELOG.md`
+- Check: `docs/release-process.md`
+
+- [ ] **Step 1: Review accepted commits**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Expected: accepted commits are user-facing docs, benchmark, or runtime improvements with evidence.
+
+- [ ] **Step 2: Apply the release decision gate**
+
+Release v1.2.6 only if at least one condition is true:
+
+```text
+Users receive a runtime fix
+Users receive a scoped performance improvement with fresh evidence
+Users receive benchmark tooling that materially improves reproducibility
+Users receive public docs that prevent a misleading performance claim
+```
+
+Do not release if the branch contains only maintainer planning or local-only notes.
+
+- [ ] **Step 3: Prepare changelog only after the gate passes**
+
+Add a section like this to `CHANGELOG.md` only when the accepted commits match these scopes:
+
+```markdown
+## [1.2.6] - 2026-06-06
+
+### Added
+- Added scoped v1.2.6 benchmark evidence for read-only DB workloads.
+
+### Changed
+- Clarified that broad CPU-bound +20% Actix claims require separate fair-handler evidence.
+
+### Fixed
+- Fixed benchmark wording that mixed CPU-bound, DB, pipelined, and resource-profile results.
+```
+
+Every bullet must map to a committed change and proof from this plan.
+
+- [ ] **Step 4: Run release proof before PR merge**
+
+```bash
+./scripts/pre-release.sh
+```
+
+Expected: script exits 0. If it fails due network or dependency download, rerun with the repo's approved Go cache/module-cache command shape and record the exact failure and rerun command.
+
+## Final Verification
+
+- [ ] Run markdown sanity checks:
+
+```bash
+git diff --check
+rg -n "broad .*20|blanket .*20" docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md bench/reproducible docs/guide
+```
+
+Expected: `git diff --check` exits 0. The `rg` command exits 0 only for intentional guardrail text that says the broad or blanket claim is rejected.
+
+- [ ] Review scope:
+
+```bash
+git diff --stat origin/main..HEAD
+```
+
+Expected for this roadmap branch: docs-only changes.
+
+- [ ] Prepare PR wording in English:
+
+```text
+Title: docs: plan v1.2.6 performance candidates
+
+Body:
+This PR adds a docs-only v1.2.6 candidate roadmap that separates accepted DB evidence from rejected broad CPU-bound +20% claims. It defines proof gates for DB, JSON serialization, pipelined diagnostics, and read-buffer resource profiling before any runtime work starts.
+```


### PR DESCRIPTION
This PR adds a docs-only v1.2.6 candidate roadmap that separates accepted read-only DB evidence from rejected broad CPU-bound +20% claims.\n\nIt defines proof gates before any runtime work starts for:\n\n- read-only DB workload evidence\n- JSON serialization work\n- pipelined HTTP/1.1 diagnostics\n- short-header read-buffer resource profiling\n- release-worthiness decisions\n\nNo runtime code, benchmark harness behavior, release notes, or public performance claims are changed.