### PR TITLE
docs: define v1.2.6 performance candidate boundary

### DIFF
--- a/bench/reproducible/README.md
+++ b/bench/reproducible/README.md
@@ -14,6 +14,13 @@ The default benchmark does not require PostgreSQL. It measures framework overhea
 
 DB, queries, fortunes, and updates are out of scope for the default comparison. Enable them explicitly with `BENCH_ENABLE_DB=1` when you want to study database-heavy workloads.
 
+## v1.2.6 Candidate Boundary
+
+The post-v1.2.5 evidence does not support a broad CPU-bound +20% Actix claim on
+the default fair handler path. Treat read-only DB workloads, serialized JSON,
+pipelined HTTP/1.1 diagnostics, and short-header read-buffer tuning as separate
+candidate tracks. Do not mix their results into one public performance claim.
+
 ## Directory Structure
 
 ```

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -81,6 +81,8 @@ That evidence is limited to same-host loopback CPU-bound handler routes. It is n
 
 Opt-in read-only DB workload evidence is tracked separately. The current tiger follow-up run in `bench/reproducible/results/2026-06-06-wing-actix-20-follow-up.md` used `BENCH_ENABLE_DB=1`, `BENCH_KRUDA_DB_DISPATCH=takeover`, framework-specific default DB DSNs, and zero socket errors/non-2xx responses. In that run, throughput-profile median RPS was +160.21% versus Actix for `/db` and +95.05% for `/fortunes`, with materially lower p99 latency. Treat this as a read-style DB workload result, not as a broad CPU-bound handler-path claim.
 
+For post-v1.2.5 candidate work, keep CPU-bound, read-only DB, pipelined HTTP/1.1, and read-buffer memory profiles separate; each profile needs its own evidence and wording.
+
 Run benchmarks locally:
 
 ```bash


### PR DESCRIPTION
## Summary
- Add a v1.2.6 candidate boundary to the reproducible benchmark docs.
- Link the same boundary from the performance guide so CPU-bound, read-only DB, pipelined HTTP/1.1, and read-buffer memory evidence stay separate.

## Verification
- git diff --check origin/main..HEAD
- rg -n "broad .*20|blanket .*20|\+20|Actix|DB workload|pipelined|read buffer" bench/reproducible/README.md docs/guide/performance.md