### PR TITLE
bench: record v1.2.6 read-only DB evidence

### DIFF
--- a/bench/reproducible/results/2026-06-06-v126-db-evidence.md
+++ b/bench/reproducible/results/2026-06-06-v126-db-evidence.md
@@ -1,0 +1,80 @@
+# v1.2.6 Read-only DB Evidence
+
+Date: 2026-06-06 UTC
+Host: tiger-linux
+Commit: `7f0fef0fda039aae95e91e871544058e3f0b7419`
+Scope: read-only DB workloads only; not a broad CPU-bound fair-handler claim.
+
+## Command
+
+The first attempt used the default Actix benchmark port `3003` and failed before
+Actix measurement because a host `caddy` service already owned that port. The
+accepted rerun used alternate local benchmark ports only; it did not use manual
+DB DSN overrides.
+
+```bash
+cd /tmp/kruda-v126-db-evidence.E9n74n/kruda/bench/reproducible
+BENCH_ENABLE_DB=1 \
+BENCH_KRUDA_DB_DISPATCH=takeover \
+BENCH_FRAMEWORKS="kruda actix" \
+BENCH_ROUNDS=3 \
+BENCH_DURATION=8s \
+BENCH_WARMUP=2s \
+GOTOOLCHAIN=go1.25.10 \
+KRUDA_PORT=3100 \
+ACTIX_PORT=3103 \
+RESULT_DIR="results/v126-db-evidence-rerun-20260606T172351Z" \
+./bench.sh db fortunes
+```
+
+## Environment
+
+Concrete values from
+`results/v126-db-evidence-rerun-20260606T172351Z/environment.txt`:
+
+```text
+timestamp_utc=20260606T172351Z
+bench_enable_db=1
+bench_enable_pprof=0
+bench_kruda_db_dispatch=takeover
+database_url_common_override=0
+kruda_database_url_override=0
+fiber_database_url_override=0
+actix_database_url_override=0
+kruda_go_tags=kruda_stdjson
+gomaxprocs=8
+kruda_workers=4
+kruda_read_buf_size=default
+kruda_pool_size=default
+bench_rounds=3
+bench_duration=8s
+frameworks=kruda actix
+routes=db fortunes
+profiles=latency:-t4 -c128 -d8s throughput:-t4 -c256 -d8s
+CPU=13th Gen Intel(R) Core(TM) i5-13500, 8 online CPUs
+OS=Linux 6.8.0-117-generic x86_64
+Go=go1.25.10 linux/amd64
+Rust=rustc 1.93.1
+Cargo=cargo 1.93.1
+wrk=debian/4.1.0-4build2
+```
+
+## Median Results
+
+All measured rows had zero socket errors and zero non-2xx responses.
+
+| Profile | Route | Kruda median RPS | Actix median RPS | Kruda vs Actix RPS | Kruda p99 ms | Actix p99 ms | Kruda vs Actix p99 |
+|---|---|---:|---:|---:|---:|---:|---:|
+| latency | `db` | 98672.61 | 35921.25 | +174.69% | 9.07 | 30.61 | -70.37% |
+| latency | `fortunes` | 84224.43 | 43125.46 | +95.30% | 4.47 | 16.31 | -72.59% |
+| throughput | `db` | 98455.81 | 36995.09 | +166.13% | 5.80 | 32.11 | -81.94% |
+| throughput | `fortunes` | 82899.42 | 43071.82 | +92.47% | 5.90 | 18.83 | -68.67% |
+
+## Decision
+
+Accepted. This fresh same-host tiger run supports a scoped read-only DB workload
+claim: both `/db` and `/fortunes` cleared the +20% throughput gate versus Actix
+in the throughput profile, both had lower p99 latency, all rows had zero socket
+errors and zero non-2xx responses, and the run used framework-specific default
+DB DSNs without manual DSN overrides. This does not support a broad CPU-bound
+fair-handler claim.


### PR DESCRIPTION
## Summary
- Record fresh tiger-linux read-only DB benchmark evidence for v1.2.6.
- Accept the scoped DB workload claim for /db and /fortunes while explicitly rejecting any broad CPU-bound fair-handler claim.
- Note the host port conflict on default Actix port 3003 and the accepted rerun on alternate local benchmark ports without DB DSN overrides.

## Evidence
- Commit: 7f0fef0fda039aae95e91e871544058e3f0b7419
- Command: BENCH_ENABLE_DB=1 BENCH_KRUDA_DB_DISPATCH=takeover BENCH_FRAMEWORKS="kruda actix" BENCH_ROUNDS=3 BENCH_DURATION=8s GOTOOLCHAIN=go1.25.10 KRUDA_PORT=3100 ACTIX_PORT=3103 ./bench.sh db fortunes
- Result: zero socket errors and zero non-2xx responses across all rows.
- Throughput profile: /db +166.13% median RPS vs Actix; /fortunes +92.47% median RPS vs Actix, with lower Kruda p99 on both routes.

## Verification
- git diff --cached --check
- rg -n "TBD|TODO|placeholder|Co-Authored|AI-assisted|generated by|broad .*claim|\+20|Actix|DSN|socket errors|non-2xx" bench/reproducible/results/2026-06-06-v126-db-evidence.md