### PR TITLE
docs: record v1.2.6 no-release decision

### DIFF
--- a/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
+++ b/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
@@ -19,14 +19,17 @@ The current evidence says:
 - Broad CPU-bound fair-handler +20% versus Actix is not proven.
 - The latest CPU-bound tiger smoke at `c3a17ef` showed +12.70% plaintext, +14.53% static JSON, and +13.73% serialized JSON in the throughput profile.
 - The read-only DB probe did prove a scoped +20% path: `/db` +160.21% and `/fortunes` +95.05% throughput versus Actix, with lower p99.
+- The v1.2.6 read-only DB revalidation on `tiger-linux` recorded `/db` +166.13% and `/fortunes` +92.47% throughput versus Actix, with lower p99, zero socket errors, zero non-2xx responses, and no manual DB DSN overrides.
 - Pipelined I/O diagnostics show useful architecture behavior and lower p99, but not a blanket +20% public claim.
 - `KRUDA_READ_BUF_SIZE=2048` is a short-header memory-profile candidate, not a default-change candidate.
+- Release decision on 2026-06-07: do not cut `v1.2.6` from the current post-`v1.2.5` delta because it is docs and benchmark evidence only. Leave `main` untagged until users receive a runtime, security, compatibility, benchmark-tooling, or upgrade-worthy framework change under `docs/release-process.md`.
 - Rejected probes stay rejected unless fresh evidence changes the decision: event timestamp reuse, temporary PGO, static response bypass for fair-handler claims, Actix worker-count alignment as a win path, Kruda workers=8 scaling, CPU affinity, epoll idle spin, and extra pipelined response batching.
 
 ## File Map
 
 - `docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md`: this execution plan and candidate list.
 - `bench/reproducible/results/2026-06-06-wing-actix-20-follow-up.md`: source evidence for broad +20 rejection and read-only DB acceptance.
+- `bench/reproducible/results/2026-06-06-v126-db-evidence.md`: accepted v1.2.6 read-only DB revalidation evidence; docs/evidence only, not a release tag trigger by itself.
 - `bench/reproducible/results/2026-06-02-wing-json-stream-response-evidence.md`: source evidence for the scoped stdjson JSON serialization track.
 - `bench/reproducible/results/2026-06-02-pipelined-io-diagnostic-tiger.md`: source evidence for pipelined I/O diagnostic behavior.
 - `bench/reproducible/results/2026-06-02-wing-response-batching-syscall-evidence.md`: source evidence rejecting extra inline pipelined response batching.
@@ -41,8 +44,8 @@ The current evidence says:
 
 | Track | Status | v1.2.6 value | Required proof before PR |
 |---|---|---|---|
-| Read-only DB workload | Accepted evidence, needs productization | Scoped performance claim for `db` and `fortunes` with framework-specific DSNs | Fresh tiger run with `BENCH_ENABLE_DB=1`, zero errors, same toolchain, and no manual DSN override |
-| JSON serialization | Candidate | Narrow serialized JSON improvement, especially `kruda_stdjson` and p99 | Same-runner main-vs-branch benchmark showing no static/plaintext regression and clear JSON serialization gain |
+| Read-only DB workload | Accepted and recorded | Scoped performance claim for `db` and `fortunes` with framework-specific DSNs | Done in `2026-06-06-v126-db-evidence.md`; keep claim scoped to read-only DB workloads |
+| JSON serialization | Already merged before v1.2.6 decision | Narrow serialized JSON improvement, especially `kruda_stdjson` and p99 | Do not reopen without a new failing proof and same-runner main-vs-branch benchmark |
 | Pipelined I/O diagnostics | Diagnostic only | Better architecture evidence and optional workload profile language | Fresh pipeline run plus syscall ratio check; public wording must say HTTP/1.1 pipelined |
 | Short-header memory profile | Optional profile | Lower RSS with `KRUDA_READ_BUF_SIZE=2048` for short-header workloads | Repeat resource run proves zero errors, no non-2xx, and p99 tradeoff is documented |
 | Broad CPU-bound +20% | Rejected for now | None until a new measured lever exists | Must beat Actix by >=20% on all default CPU-bound throughput routes with fair handler semantics |
@@ -347,16 +350,22 @@ Expected: accepted commits are user-facing docs, benchmark, or runtime improveme
 
 - [ ] **Step 2: Apply the release decision gate**
 
-Release v1.2.6 only if at least one condition is true:
+Release v1.2.6 only if the public release gate in `docs/release-process.md`
+is satisfied. Do not tag a new Go module version for docs/evidence-only work.
+Use these conditions as release-candidate signals, not automatic tag triggers:
 
 ```text
 Users receive a runtime fix
 Users receive a scoped performance improvement with fresh evidence
 Users receive benchmark tooling that materially improves reproducibility
-Users receive public docs that prevent a misleading performance claim
+Users receive public docs that prevent a misleading performance claim and the
+maintainer explicitly accepts a docs-only release tag
 ```
 
 Do not release if the branch contains only maintainer planning or local-only notes.
+Do not release the current post-`v1.2.5` state: it contains public docs and
+benchmark evidence only, with no runtime/package behavior change that asks Go
+users to upgrade from `v1.2.5`.
 
 - [ ] **Step 3: Prepare changelog only after the gate passes**
 


### PR DESCRIPTION
## Summary
- Record the 2026-06-07 decision not to cut v1.2.6 from the current post-v1.2.5 docs/evidence-only delta.
- Update the candidate roadmap with the accepted read-only DB revalidation evidence from tiger-linux.
- Clarify that docs/evidence-only work is not a Go module tag trigger unless explicitly accepted under the release process.

## Verification
- git diff --check
- git diff --cached --check
- rg -n "not released|do not cut|do not tag|docs/evidence-only|Co-Authored|AI-assisted|generated by|TBD|TODO|placeholder" docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md