### PR TITLE
bench: record v1.2.6 read-buffer evidence

### DIFF
--- a/bench/reproducible/README.md
+++ b/bench/reproducible/README.md
@@ -324,11 +324,13 @@ The corresponding resource evidence is in `results/resource-main-984f0d6-2026052
 The optional short-header read-buffer resource profile is in `results/resource-20260524Tphase7-readbuf4k/`, with a summary note in `results/2026-05-24-read-buffer-size-evidence.md`. It uses `KRUDA_READ_BUF_SIZE=4096`; compared with the phase 6 baseline, Kruda max RSS dropped by 10.77%, 17.61%, and 10.85% on the throughput routes. Actix still has lower RSS, so this is RSS reduction evidence, not a memory-footprint win claim.
 
 The repeated `KRUDA_READ_BUF_SIZE=2048` resource candidate is documented in
-`results/2026-06-04-read-buffer-2048-evidence.md`. It reduced Kruda max RSS by
-roughly 12-16% versus the clean `4096` resource evidence while preserving zero
-socket errors, zero non-2xx responses, and the Actix throughput/p99 gate. Some
-Kruda p99 rows were higher than the clean `4096` profile, so keep `4096` as the
-published throughput/p99 evidence profile and treat `2048` as an optional
-short-header memory profile candidate.
+`results/2026-06-04-read-buffer-2048-evidence.md` and rechecked in
+`results/2026-06-07-v126-readbuf2048-evidence.md`. The v1.2.6 recheck reduced
+Kruda max RSS by 4.64-9.84% versus a same-runner `4096` baseline while
+preserving zero socket errors and zero non-2xx responses. It did not pass the
+strict default-change gate because p99 regressed on every measured
+route/profile row and RPS fell by 0.68-4.37%, so keep `4096` as the balanced
+throughput/p99 evidence profile and treat `2048` as an optional short-header
+memory profile candidate.
 
 The lazy Wing peer-address lookup evidence is in `results/resource-20260524Tphase8-lazy-remote-addr-final-readbuf4k/`, with a summary note in `results/2026-05-24-lazy-remote-addr-evidence.md`. It shows the same CPU-bound handler routes with zero socket errors and zero non-2xx responses, and a short `strace` check confirms that routes which do not call `RemoteAddr()` no longer pay eager `getpeername` syscalls on accept.

--- a/bench/reproducible/results/2026-06-07-v126-readbuf2048-evidence.md
+++ b/bench/reproducible/results/2026-06-07-v126-readbuf2048-evidence.md
@@ -1,0 +1,111 @@
+# v1.2.6 Read Buffer 2048 Evidence
+
+Date: 2026-06-07
+Host: tiger
+Commit under test: `6e69e25dd9c7e8726e62ba346278ce2afce13ea7`
+Scope: short-header CPU-bound resource profile only; not a broad throughput
+claim and not a framework default change.
+
+## Command
+
+Same-runner baseline:
+
+```bash
+cd /home/tiger/kruda-v126-readbuf2048-20260607/bench/reproducible
+PATH="$HOME/.cargo/bin:$PATH" \
+GOTOOLCHAIN=go1.25.10 \
+RESULT_DIR="$PWD/results/resource-v126-readbuf4096-20260607T0119Z" \
+BENCH_FRAMEWORKS="kruda fiber actix" \
+BENCH_DURATION=15s \
+KRUDA_GO_TAGS=kruda_stdjson \
+KRUDA_READ_BUF_SIZE=4096 \
+KRUDA_PORT=3261 \
+FIBER_PORT=3262 \
+ACTIX_PORT=3263 \
+./resource.sh plaintext-handler json-static json-serialize
+```
+
+Candidate:
+
+```bash
+cd /home/tiger/kruda-v126-readbuf2048-20260607/bench/reproducible
+PATH="$HOME/.cargo/bin:$PATH" \
+GOTOOLCHAIN=go1.25.10 \
+RESULT_DIR="$PWD/results/resource-v126-readbuf2048-20260607T0142Z" \
+BENCH_FRAMEWORKS="kruda fiber actix" \
+BENCH_DURATION=15s \
+KRUDA_GO_TAGS=kruda_stdjson \
+KRUDA_READ_BUF_SIZE=2048 \
+KRUDA_PORT=3271 \
+FIBER_PORT=3272 \
+ACTIX_PORT=3273 \
+./resource.sh plaintext-handler json-static json-serialize
+```
+
+## Environment
+
+Both runs used:
+
+- `bench_enable_db=0`
+- `bench_enable_pprof=0`
+- `kruda_go_tags=kruda_stdjson`
+- `gomaxprocs=8`
+- `kruda_workers=4`
+- `bench_duration=15s`
+- `resource_interval=1`
+- `resource_min_cpu_sample=50`
+- `frameworks=kruda fiber actix`
+- `routes=plaintext-handler json-static json-serialize`
+- `profiles=latency:-t4 -c128 -d15s throughput:-t4 -c256 -d15s`
+- CPU: `13th Gen Intel(R) Core(TM) i5-13500`, 8 logical CPUs
+- Toolchain: `go version go1.25.10 linux/amd64`
+
+Result directories:
+
+- 4096 baseline:
+  `/home/tiger/kruda-v126-readbuf2048-20260607/bench/reproducible/results/resource-v126-readbuf4096-20260607T0119Z`
+- 2048 candidate:
+  `/home/tiger/kruda-v126-readbuf2048-20260607/bench/reproducible/results/resource-v126-readbuf2048-20260607T0142Z`
+
+## 2048 Cross-runtime Rows
+
+| Profile | Framework | Route | RPS | p99 ms | Max RSS MB | Socket errors | Non-2xx |
+|---|---|---|---:|---:|---:|---:|---:|
+| latency | kruda | plaintext-handler | 816367.44 | 1.390 | 14.50 | 0 | 0 |
+| latency | kruda | json-static | 811965.77 | 1.030 | 15.62 | 0 | 0 |
+| latency | kruda | json-serialize | 784925.40 | 0.621 | 16.12 | 0 | 0 |
+| throughput | kruda | plaintext-handler | 802698.88 | 1.210 | 17.88 | 0 | 0 |
+| throughput | kruda | json-static | 813541.34 | 1.110 | 18.38 | 0 | 0 |
+| throughput | kruda | json-serialize | 788570.12 | 1.090 | 18.75 | 0 | 0 |
+| latency | fiber | plaintext-handler | 627107.59 | 2.850 | 11.75 | 0 | 0 |
+| latency | fiber | json-static | 617026.59 | 2.890 | 11.88 | 0 | 0 |
+| latency | fiber | json-serialize | 598172.70 | 3.140 | 17.44 | 0 | 0 |
+| throughput | fiber | plaintext-handler | 639321.50 | 3.580 | 17.28 | 0 | 0 |
+| throughput | fiber | json-static | 629266.20 | 3.510 | 17.28 | 0 | 0 |
+| throughput | fiber | json-serialize | 616093.25 | 3.930 | 21.75 | 0 | 0 |
+| latency | actix | plaintext-handler | 692088.47 | 2.720 | 7.82 | 0 | 0 |
+| latency | actix | json-static | 689879.46 | 2.740 | 7.95 | 0 | 0 |
+| latency | actix | json-serialize | 691364.32 | 2.860 | 8.07 | 0 | 0 |
+| throughput | actix | plaintext-handler | 722103.99 | 3.230 | 10.45 | 0 | 0 |
+| throughput | actix | json-static | 721257.42 | 3.620 | 10.57 | 0 | 0 |
+| throughput | actix | json-serialize | 707787.46 | 3.110 | 10.57 | 0 | 0 |
+
+## 2048 vs 4096 Kruda Same-runner Comparison
+
+| Profile | Route | RPS delta | p99 delta | Max RSS delta |
+|---|---|---:|---:|---:|
+| latency | plaintext-handler | -0.90% | +109.02% | -5.72% |
+| latency | json-static | -0.68% | +25.76% | -4.64% |
+| latency | json-serialize | -4.37% | +8.76% | -9.84% |
+| throughput | plaintext-handler | -2.71% | +51.06% | -4.64% |
+| throughput | json-static | -1.99% | +21.98% | -5.74% |
+| throughput | json-serialize | -4.27% | +34.40% | -8.00% |
+
+## Decision
+
+Accepted as optional profile evidence only. `KRUDA_READ_BUF_SIZE=2048`
+preserved zero socket errors and zero non-2xx responses while reducing Kruda max
+RSS by 4.64-9.84% versus the same-runner `4096` baseline. It fails the strict
+default-change gate because every measured route/profile row regressed p99, and
+RPS fell by 0.68-4.37%. Keep the framework default unchanged and keep `4096` as
+the balanced throughput/p99 evidence profile.

--- a/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
+++ b/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
@@ -22,6 +22,7 @@ The current evidence says:
 - The v1.2.6 read-only DB revalidation on `tiger-linux` recorded `/db` +166.13% and `/fortunes` +92.47% throughput versus Actix, with lower p99, zero socket errors, zero non-2xx responses, and no manual DB DSN overrides.
 - Pipelined I/O diagnostics show useful architecture behavior and lower p99, but not a blanket +20% public claim.
 - `KRUDA_READ_BUF_SIZE=2048` is a short-header memory-profile candidate, not a default-change candidate.
+- The v1.2.6 `KRUDA_READ_BUF_SIZE=2048` recheck on `tiger-linux` reduced Kruda max RSS by 4.64-9.84% versus a same-runner `4096` baseline with zero socket errors and zero non-2xx responses, but failed the strict default-change gate because p99 regressed on every measured row and RPS fell by 0.68-4.37%.
 - Release decision on 2026-06-07: do not cut `v1.2.6` from the current post-`v1.2.5` delta because it is docs and benchmark evidence only. Leave `main` untagged until users receive a runtime, security, compatibility, benchmark-tooling, or upgrade-worthy framework change under `docs/release-process.md`.
 - Rejected probes stay rejected unless fresh evidence changes the decision: event timestamp reuse, temporary PGO, static response bypass for fair-handler claims, Actix worker-count alignment as a win path, Kruda workers=8 scaling, CPU affinity, epoll idle spin, and extra pipelined response batching.
 
@@ -34,6 +35,7 @@ The current evidence says:
 - `bench/reproducible/results/2026-06-02-pipelined-io-diagnostic-tiger.md`: source evidence for pipelined I/O diagnostic behavior.
 - `bench/reproducible/results/2026-06-02-wing-response-batching-syscall-evidence.md`: source evidence rejecting extra inline pipelined response batching.
 - `bench/reproducible/results/2026-06-04-read-buffer-2048-evidence.md`: source evidence for optional short-header memory profile work.
+- `bench/reproducible/results/2026-06-07-v126-readbuf2048-evidence.md`: accepted optional-profile recheck for `KRUDA_READ_BUF_SIZE=2048`; rejects changing the framework default.
 - `bench/reproducible/README.md`: benchmark harness usage and public wording guardrails.
 - `docs/guide/performance.md`: public performance wording if a later task promotes a candidate.
 - `docs/release-process.md`: release gate and benchmark-review checklist.
@@ -47,7 +49,7 @@ The current evidence says:
 | Read-only DB workload | Accepted and recorded | Scoped performance claim for `db` and `fortunes` with framework-specific DSNs | Done in `2026-06-06-v126-db-evidence.md`; keep claim scoped to read-only DB workloads |
 | JSON serialization | Already merged before v1.2.6 decision | Narrow serialized JSON improvement, especially `kruda_stdjson` and p99 | Do not reopen without a new failing proof and same-runner main-vs-branch benchmark |
 | Pipelined I/O diagnostics | Diagnostic only | Better architecture evidence and optional workload profile language | Fresh pipeline run plus syscall ratio check; public wording must say HTTP/1.1 pipelined |
-| Short-header memory profile | Optional profile | Lower RSS with `KRUDA_READ_BUF_SIZE=2048` for short-header workloads | Repeat resource run proves zero errors, no non-2xx, and p99 tradeoff is documented |
+| Short-header memory profile | Accepted as optional profile; default change rejected | Lower RSS with `KRUDA_READ_BUF_SIZE=2048` for short-header workloads | Done in `2026-06-07-v126-readbuf2048-evidence.md`; zero errors/non-2xx, lower RSS, but p99 and RPS regressions keep the default unchanged |
 | Broad CPU-bound +20% | Rejected for now | None until a new measured lever exists | Must beat Actix by >=20% on all default CPU-bound throughput routes with fair handler semantics |
 
 ## Task 1: Publish the Candidate Boundary


### PR DESCRIPTION
## Summary
- Record the v1.2.6 same-runner resource recheck for KRUDA_READ_BUF_SIZE=2048.
- Update reproducible benchmark docs and the candidate roadmap to keep 2048 as an optional short-header memory profile.
- Explicitly reject changing the framework default because the strict p99/RPS gate did not pass.

## Evidence
- Tiger commit: 6e69e25dd9c7e8726e62ba346278ce2afce13ea7
- 4096 baseline: resource-v126-readbuf4096-20260607T0119Z
- 2048 candidate: resource-v126-readbuf2048-20260607T0142Z
- 2048 preserved zero socket errors and zero non-2xx responses.
- 2048 reduced Kruda max RSS by 4.64-9.84% versus 4096, but p99 regressed on every measured row and RPS fell by 0.68-4.37%.

## Release
- Docs/evidence only; do not tag v1.2.6 from this PR.