### PR TITLE
bench: record v1.2.6 pipelined diagnostics

### DIFF
--- a/bench/reproducible/README.md
+++ b/bench/reproducible/README.md
@@ -321,6 +321,15 @@ These are normal handler-path routes. Static bypass route options are intentiona
 
 The corresponding resource evidence is in `results/resource-main-984f0d6-20260524T174429Z/`, with a summary note in `results/2026-05-25-main-984f0d6-tiger-evidence.md`. It uses `GOMAXPROCS=8`, `KRUDA_WORKERS=4`, and a default Kruda benchmark binary without the `bench_pprof` build tag to match the harness `wrk -t4` CPU-bound profiles. The run shows zero socket errors and zero non-2xx responses, with Kruda throughput, p99, and RPS/core ahead of Actix while RSS remains higher than Actix.
 
+The v1.2.6 HTTP/1.1 pipelined diagnostic recheck is in
+`results/2026-06-07-v126-pipeline-evidence.md`. It uses `pipeline.sh` with
+Kruda and Actix, three rounds, 5s measured duration, 2s warmup, and profiles
+`baseline-c128-d1`, `pipeline-c128-d8`, and `pipeline-c256-d8`. Kruda had higher
+median RPS and lower p99 than Actix in all nine profile/route rows with zero
+socket errors and zero non-2xx responses. Keep this labeled as pipelined
+HTTP/1.1 diagnostic evidence; do not mix it into default fair handler-path
+claims.
+
 The optional short-header read-buffer resource profile is in `results/resource-20260524Tphase7-readbuf4k/`, with a summary note in `results/2026-05-24-read-buffer-size-evidence.md`. It uses `KRUDA_READ_BUF_SIZE=4096`; compared with the phase 6 baseline, Kruda max RSS dropped by 10.77%, 17.61%, and 10.85% on the throughput routes. Actix still has lower RSS, so this is RSS reduction evidence, not a memory-footprint win claim.
 
 The repeated `KRUDA_READ_BUF_SIZE=2048` resource candidate is documented in

--- a/bench/reproducible/results/2026-06-07-v126-pipeline-evidence.md
+++ b/bench/reproducible/results/2026-06-07-v126-pipeline-evidence.md
@@ -1,0 +1,75 @@
+# v1.2.6 Pipelined I/O Diagnostic Evidence
+
+Date: 2026-06-07
+Host: tiger
+Commit under test: `b57fbeee13ada58148b218500ed87696362b373e`
+Scope: HTTP/1.1 pipelined diagnostic workload only. This is not a default
+fair-handler benchmark claim and not a broad real-world API throughput claim.
+
+## Command
+
+```bash
+cd /home/tiger/kruda-v126-pipeline-20260607/bench/reproducible
+PATH="$HOME/.cargo/bin:$PATH" \
+GOTOOLCHAIN=go1.25.10 \
+RESULT_DIR="$PWD/results/pipeline-v126-20260607T0208Z" \
+BENCH_FRAMEWORKS="kruda actix" \
+BENCH_ROUNDS=3 \
+PIPELINE_DURATION=5s \
+PIPELINE_WARMUP=2s \
+PIPELINE_PROFILES="baseline-c128-d1:128:1 pipeline-c128-d8:128:8 pipeline-c256-d8:256:8" \
+KRUDA_PORT=3281 \
+ACTIX_PORT=3283 \
+./pipeline.sh plaintext-handler json-static json-serialize
+```
+
+## Environment
+
+- Result directory:
+  `/home/tiger/kruda-v126-pipeline-20260607/bench/reproducible/results/pipeline-v126-20260607T0208Z`
+- Workload: `http1_pipelined_diagnostic`
+- `bench_enable_db=0`
+- `bench_enable_pprof=0`
+- `kruda_go_tags=kruda_stdjson`
+- `gomaxprocs=8`
+- `kruda_workers=4`
+- `kruda_read_buf_size=default`
+- `bench_rounds=3`
+- `pipeline_duration=5s`
+- `pipeline_warmup=2s`
+- `pipeline_timeout=5s`
+- `pipeline_profiles=baseline-c128-d1:128:1 pipeline-c128-d8:128:8 pipeline-c256-d8:256:8`
+- `frameworks=kruda actix`
+- `routes=plaintext-handler json-static json-serialize`
+- CPU: `13th Gen Intel(R) Core(TM) i5-13500`, 8 logical CPUs
+- Toolchain: `go version go1.25.10 linux/amd64`
+
+## Median Results
+
+All measured rows had zero socket errors and zero non-2xx responses.
+
+| Profile | Route | Kruda median RPS | Actix median RPS | Kruda RPS delta | Kruda p99 ms | Actix p99 ms | Kruda p99 delta |
+|---|---|---:|---:|---:|---:|---:|---:|
+| `baseline-c128-d1` | `plaintext-handler` | 665024.32 | 587007.57 | +13.29% | 1.355 | 2.254 | -39.88% |
+| `baseline-c128-d1` | `json-static` | 638794.55 | 581794.56 | +9.80% | 1.280 | 2.279 | -43.84% |
+| `baseline-c128-d1` | `json-serialize` | 621279.05 | 575838.51 | +7.89% | 1.340 | 2.239 | -40.15% |
+| `pipeline-c128-d8` | `plaintext-handler` | 2862776.91 | 2600192.01 | +10.10% | 1.880 | 2.881 | -34.74% |
+| `pipeline-c128-d8` | `json-static` | 2840551.65 | 2661386.77 | +6.73% | 1.883 | 2.885 | -34.73% |
+| `pipeline-c128-d8` | `json-serialize` | 2631438.61 | 2553475.43 | +3.05% | 1.727 | 2.967 | -41.79% |
+| `pipeline-c256-d8` | `plaintext-handler` | 2974658.45 | 2591340.85 | +14.79% | 3.413 | 4.322 | -21.03% |
+| `pipeline-c256-d8` | `json-static` | 2976859.05 | 2675088.87 | +11.28% | 3.454 | 4.017 | -14.02% |
+| `pipeline-c256-d8` | `json-serialize` | 2735180.87 | 2614658.31 | +4.61% | 3.470 | 3.967 | -12.53% |
+
+## Decision
+
+Accepted as diagnostic evidence only. The fresh v1.2.6 run shows that the
+HTTP/1.1 pipelined harness remains healthy on current `main`: Kruda and Actix
+completed every measured row with zero socket errors and zero non-2xx responses.
+Kruda had higher median RPS and lower p99 than Actix in all nine
+profile/route rows, but the margins are workload-specific and must remain
+labeled as HTTP/1.1 pipelined diagnostics.
+
+Do not implement extra inline pipelined response batching from this result. The
+existing syscall evidence in `2026-06-02-wing-response-batching-syscall-evidence.md`
+already showed depth-8 `requests_per_write_send` near 8.00 for Kruda, so this
+fresh throughput diagnostic does not create a new syscall-count target.

--- a/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
+++ b/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
@@ -21,6 +21,7 @@ The current evidence says:
 - The read-only DB probe did prove a scoped +20% path: `/db` +160.21% and `/fortunes` +95.05% throughput versus Actix, with lower p99.
 - The v1.2.6 read-only DB revalidation on `tiger-linux` recorded `/db` +166.13% and `/fortunes` +92.47% throughput versus Actix, with lower p99, zero socket errors, zero non-2xx responses, and no manual DB DSN overrides.
 - Pipelined I/O diagnostics show useful architecture behavior and lower p99, but not a blanket +20% public claim.
+- The v1.2.6 HTTP/1.1 pipelined diagnostic recheck on `tiger-linux` recorded zero socket errors and zero non-2xx responses; Kruda had higher median RPS and lower p99 than Actix in all nine profile/route rows, but the claim remains diagnostic and pipelined-only.
 - `KRUDA_READ_BUF_SIZE=2048` is a short-header memory-profile candidate, not a default-change candidate.
 - The v1.2.6 `KRUDA_READ_BUF_SIZE=2048` recheck on `tiger-linux` reduced Kruda max RSS by 4.64-9.84% versus a same-runner `4096` baseline with zero socket errors and zero non-2xx responses, but failed the strict default-change gate because p99 regressed on every measured row and RPS fell by 0.68-4.37%.
 - Release decision on 2026-06-07: do not cut `v1.2.6` from the current post-`v1.2.5` delta because it is docs and benchmark evidence only. Leave `main` untagged until users receive a runtime, security, compatibility, benchmark-tooling, or upgrade-worthy framework change under `docs/release-process.md`.
@@ -34,6 +35,7 @@ The current evidence says:
 - `bench/reproducible/results/2026-06-02-wing-json-stream-response-evidence.md`: source evidence for the scoped stdjson JSON serialization track.
 - `bench/reproducible/results/2026-06-02-pipelined-io-diagnostic-tiger.md`: source evidence for pipelined I/O diagnostic behavior.
 - `bench/reproducible/results/2026-06-02-wing-response-batching-syscall-evidence.md`: source evidence rejecting extra inline pipelined response batching.
+- `bench/reproducible/results/2026-06-07-v126-pipeline-evidence.md`: accepted v1.2.6 HTTP/1.1 pipelined diagnostic recheck; diagnostic only, not a default fair-handler claim.
 - `bench/reproducible/results/2026-06-04-read-buffer-2048-evidence.md`: source evidence for optional short-header memory profile work.
 - `bench/reproducible/results/2026-06-07-v126-readbuf2048-evidence.md`: accepted optional-profile recheck for `KRUDA_READ_BUF_SIZE=2048`; rejects changing the framework default.
 - `bench/reproducible/README.md`: benchmark harness usage and public wording guardrails.
@@ -48,7 +50,7 @@ The current evidence says:
 |---|---|---|---|
 | Read-only DB workload | Accepted and recorded | Scoped performance claim for `db` and `fortunes` with framework-specific DSNs | Done in `2026-06-06-v126-db-evidence.md`; keep claim scoped to read-only DB workloads |
 | JSON serialization | Already merged before v1.2.6 decision | Narrow serialized JSON improvement, especially `kruda_stdjson` and p99 | Do not reopen without a new failing proof and same-runner main-vs-branch benchmark |
-| Pipelined I/O diagnostics | Diagnostic only | Better architecture evidence and optional workload profile language | Fresh pipeline run plus syscall ratio check; public wording must say HTTP/1.1 pipelined |
+| Pipelined I/O diagnostics | Accepted as diagnostic only | Better architecture evidence and optional workload profile language | Done in `2026-06-07-v126-pipeline-evidence.md`; public wording must say HTTP/1.1 pipelined |
 | Short-header memory profile | Accepted as optional profile; default change rejected | Lower RSS with `KRUDA_READ_BUF_SIZE=2048` for short-header workloads | Done in `2026-06-07-v126-readbuf2048-evidence.md`; zero errors/non-2xx, lower RSS, but p99 and RPS regressions keep the default unchanged |
 | Broad CPU-bound +20% | Rejected for now | None until a new measured lever exists | Must beat Actix by >=20% on all default CPU-bound throughput routes with fair handler semantics |
 


### PR DESCRIPTION
## Summary
- Record the v1.2.6 HTTP/1.1 pipelined diagnostic recheck from tiger.
- Update reproducible benchmark docs and the candidate roadmap to keep the claim scoped to pipelined diagnostics.
- Confirm this does not reopen extra inline response batching or a broad default fair-handler claim.

## Evidence
- Tiger commit: b57fbeee13ada58148b218500ed87696362b373e
- Result directory: pipeline-v126-20260607T0208Z
- All measured rows had zero socket errors and zero non-2xx responses.
- Kruda had higher median RPS and lower p99 than Actix in all nine profile/route rows.

## Release
- Docs/evidence only; do not tag v1.2.6 from this PR.