### PR TITLE
bench: record v1.2.6 JSON recheck

### DIFF
--- a/bench/reproducible/results/2026-06-07-v126-json-evidence.md
+++ b/bench/reproducible/results/2026-06-07-v126-json-evidence.md
@@ -1,0 +1,56 @@
+# v1.2.6 JSON Serialization Recheck
+
+Date: 2026-06-07
+Host: local Mac
+Commit under test: `095d6df6be28c196f250257ac0a705ddd7ef01b8`
+Scope: local `kruda_stdjson` microbenchmark sanity recheck only. This is not a
+cross-runtime throughput claim and not a release trigger.
+
+## Command
+
+```bash
+/usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin \
+  GOTOOLCHAIN=local \
+  GOWORK=off \
+  GOCACHE=/private/tmp/kruda-go-build-cache-phase6 \
+  GOMODCACHE=/private/tmp/kruda-go-mod-cache-phase6 \
+  go test -run '^$' -tags kruda_stdjson \
+    -bench 'BenchmarkCPU(ResponseJSON|HandlerJSON(Static|StaticBytes|Serialize)Feather)$' \
+    -benchmem -count=10 .
+```
+
+## Environment
+
+- OS/arch: `darwin/arm64`
+- Kernel: `Darwin 25.5.0`
+- CPU reported by `go test`: `Apple M3`
+- Online processors: `8`
+- Go command: `go version go1.26.1 darwin/arm64`
+- Module `go` directive: `1.25.10`
+- Build tags: `kruda_stdjson`
+- Network path: none; in-process Go microbenchmark
+- Coordinated omission: not applicable; no request generator or network client
+
+## Median Results
+
+| Benchmark | Median ns/op | B/op | allocs/op |
+|---|---:|---:|---:|
+| `BenchmarkCPUResponseJSON` | 38.48 | 160 | 1 |
+| `BenchmarkCPUHandlerJSONStaticFeather` | 201.25 | 160 | 1 |
+| `BenchmarkCPUHandlerJSONStaticBytesFeather` | 201.95 | 160 | 1 |
+| `BenchmarkCPUHandlerJSONSerializeFeather` | 266.05 | 160 | 1 |
+
+## Decision
+
+No runtime change.
+
+The current `main` JSON handler-path benchmark remains healthy after the
+previous stdjson stream response work. The targeted serialization benchmark is
+at 160 B/op and 1 alloc/op, matching the intended allocation profile from
+`2026-06-02-wing-json-stream-response-evidence.md`, and the local median
+ns/op is below the earlier kept candidate median. This does not create a new
+optimization target.
+
+Keep the JSON track closed unless a new same-runner baseline-versus-candidate
+proof shows an actionable regression or a narrow improvement that clears the
+roadmap gate without adding bytes or allocations on the static JSON paths.

--- a/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
+++ b/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
@@ -22,6 +22,7 @@ The current evidence says:
 - The v1.2.6 read-only DB revalidation on `tiger-linux` recorded `/db` +166.13% and `/fortunes` +92.47% throughput versus Actix, with lower p99, zero socket errors, zero non-2xx responses, and no manual DB DSN overrides.
 - Pipelined I/O diagnostics show useful architecture behavior and lower p99, but not a blanket +20% public claim.
 - The v1.2.6 HTTP/1.1 pipelined diagnostic recheck on `tiger-linux` recorded zero socket errors and zero non-2xx responses; Kruda had higher median RPS and lower p99 than Actix in all nine profile/route rows, but the claim remains diagnostic and pipelined-only.
+- The v1.2.6 local JSON serialization recheck on `main` recorded `BenchmarkCPUHandlerJSONSerializeFeather` at 266.05 ns/op, 160 B/op, and 1 alloc/op under `kruda_stdjson`; this keeps the JSON track closed and does not justify a new runtime change.
 - `KRUDA_READ_BUF_SIZE=2048` is a short-header memory-profile candidate, not a default-change candidate.
 - The v1.2.6 `KRUDA_READ_BUF_SIZE=2048` recheck on `tiger-linux` reduced Kruda max RSS by 4.64-9.84% versus a same-runner `4096` baseline with zero socket errors and zero non-2xx responses, but failed the strict default-change gate because p99 regressed on every measured row and RPS fell by 0.68-4.37%.
 - Release decision on 2026-06-07: do not cut `v1.2.6` from the current post-`v1.2.5` delta because it is docs and benchmark evidence only. Leave `main` untagged until users receive a runtime, security, compatibility, benchmark-tooling, or upgrade-worthy framework change under `docs/release-process.md`.
@@ -33,6 +34,7 @@ The current evidence says:
 - `bench/reproducible/results/2026-06-06-wing-actix-20-follow-up.md`: source evidence for broad +20 rejection and read-only DB acceptance.
 - `bench/reproducible/results/2026-06-06-v126-db-evidence.md`: accepted v1.2.6 read-only DB revalidation evidence; docs/evidence only, not a release tag trigger by itself.
 - `bench/reproducible/results/2026-06-02-wing-json-stream-response-evidence.md`: source evidence for the scoped stdjson JSON serialization track.
+- `bench/reproducible/results/2026-06-07-v126-json-evidence.md`: local v1.2.6 JSON serialization recheck; no runtime change and not a cross-runtime claim.
 - `bench/reproducible/results/2026-06-02-pipelined-io-diagnostic-tiger.md`: source evidence for pipelined I/O diagnostic behavior.
 - `bench/reproducible/results/2026-06-02-wing-response-batching-syscall-evidence.md`: source evidence rejecting extra inline pipelined response batching.
 - `bench/reproducible/results/2026-06-07-v126-pipeline-evidence.md`: accepted v1.2.6 HTTP/1.1 pipelined diagnostic recheck; diagnostic only, not a default fair-handler claim.
@@ -49,7 +51,7 @@ The current evidence says:
 | Track | Status | v1.2.6 value | Required proof before PR |
 |---|---|---|---|
 | Read-only DB workload | Accepted and recorded | Scoped performance claim for `db` and `fortunes` with framework-specific DSNs | Done in `2026-06-06-v126-db-evidence.md`; keep claim scoped to read-only DB workloads |
-| JSON serialization | Already merged before v1.2.6 decision | Narrow serialized JSON improvement, especially `kruda_stdjson` and p99 | Do not reopen without a new failing proof and same-runner main-vs-branch benchmark |
+| JSON serialization | Rechecked; closed | Existing narrow serialized JSON improvement remains healthy under `kruda_stdjson`; no new runtime change | Done in `2026-06-07-v126-json-evidence.md`; do not reopen without a new failing proof and same-runner main-vs-branch benchmark |
 | Pipelined I/O diagnostics | Accepted as diagnostic only | Better architecture evidence and optional workload profile language | Done in `2026-06-07-v126-pipeline-evidence.md`; public wording must say HTTP/1.1 pipelined |
 | Short-header memory profile | Accepted as optional profile; default change rejected | Lower RSS with `KRUDA_READ_BUF_SIZE=2048` for short-header workloads | Done in `2026-06-07-v126-readbuf2048-evidence.md`; zero errors/non-2xx, lower RSS, but p99 and RPS regressions keep the default unchanged |
 | Broad CPU-bound +20% | Rejected for now | None until a new measured lever exists | Must beat Actix by >=20% on all default CPU-bound throughput routes with fair handler semantics |


### PR DESCRIPTION
Records the v1.2.6 JSON serialization recheck for the existing stdjson handler-path work. The fresh evidence is a local in-process Go microbenchmark only: it confirms the current allocation profile stays at 160 B/op and 1 alloc/op for the measured Wing JSON paths, keeps the JSON track closed, and makes no cross-runtime throughput claim.\n\nThis is docs/evidence only. It does not change runtime behavior and does not justify a v1.2.6 release tag by itself.\n\nVerification:\n- go test -run '^$' -tags kruda_stdjson -bench 'BenchmarkCPU(ResponseJSON|HandlerJSON(Static|StaticBytes|Serialize)Feather)$' -benchmem -count=10 .\n- git diff --cached --check