### PR TITLE
docs: close v1.2.6 performance roadmap

### DIFF
--- a/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
+++ b/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
@@ -56,6 +56,19 @@ The current evidence says:
 | Short-header memory profile | Accepted as optional profile; default change rejected | Lower RSS with `KRUDA_READ_BUF_SIZE=2048` for short-header workloads | Done in `2026-06-07-v126-readbuf2048-evidence.md`; zero errors/non-2xx, lower RSS, but p99 and RPS regressions keep the default unchanged |
 | Broad CPU-bound +20% | Rejected for now | None until a new measured lever exists | Must beat Actix by >=20% on all default CPU-bound throughput routes with fair handler semantics |
 
+## Execution Status
+
+Completed through `main` commit `c816915b2fdacab8b5ca657e07beb3c0737d8e35`
+after PR #99. The final post-merge `main` runs for Deploy Docs, Tests, and
+Benchmark passed on that commit. No `v1.2.6` tag was created.
+
+All current post-`v1.2.5` work remains docs and benchmark evidence only:
+candidate-boundary wording, read-only DB evidence, JSON recheck evidence,
+pipelined diagnostic evidence, read-buffer optional-profile evidence, and the
+no-release decision. Keep the roadmap closed until a new runtime, security,
+compatibility, benchmark-tooling, or maintainer-approved docs-only release
+change justifies reopening the release gate.
+
 ## Task 1: Publish the Candidate Boundary
 
 **Files:**
@@ -63,7 +76,7 @@ The current evidence says:
 - Modify: `docs/guide/performance.md`
 - Optional modify: `docs/MAINTAINER_ROADMAP.md`
 
-- [ ] **Step 1: Confirm current branch and clean state**
+- [x] **Step 1: Confirm current branch and clean state**
 
 ```bash
 git status --short --branch
@@ -71,7 +84,7 @@ git status --short --branch
 
 Expected: branch is not `main`, and the working tree is clean before edits.
 
-- [ ] **Step 2: Add a short v1.2.6 candidate boundary section**
+- [x] **Step 2: Add a short v1.2.6 candidate boundary section**
 
 Add one public-facing paragraph to `bench/reproducible/README.md` near the benchmark route descriptions:
 
@@ -84,7 +97,7 @@ pipelined HTTP/1.1 diagnostics, and short-header read-buffer tuning as separate
 candidate tracks. Do not mix their results into one public performance claim.
 ```
 
-- [ ] **Step 3: Link the boundary from performance docs**
+- [x] **Step 3: Link the boundary from performance docs**
 
 Add one sentence to `docs/guide/performance.md` near the benchmark methodology section:
 
@@ -94,7 +107,7 @@ and read-buffer memory profiles separate; each profile needs its own evidence
 and wording.
 ```
 
-- [ ] **Step 4: Verify docs wording does not overclaim**
+- [x] **Step 4: Verify docs wording does not overclaim**
 
 ```bash
 rg -n "\+20|20%|Actix|DB workload|pipelined|read buffer" bench/reproducible/README.md docs/guide/performance.md
@@ -102,7 +115,7 @@ rg -n "\+20|20%|Actix|DB workload|pipelined|read buffer" bench/reproducible/READ
 
 Expected: every +20 or Actix reference is scoped to a named workload, profile, or rejected broad claim.
 
-- [ ] **Step 5: Commit the docs boundary**
+- [x] **Step 5: Commit the docs boundary**
 
 ```bash
 git add bench/reproducible/README.md docs/guide/performance.md
@@ -116,7 +129,7 @@ git commit -m "docs: define v1.2.6 performance candidate boundary"
 - Modify only if wording changes are needed: `bench/reproducible/README.md`
 - Create only if fresh evidence is produced: `bench/reproducible/results/2026-06-06-v126-db-evidence.md`
 
-- [ ] **Step 1: Confirm the DB harness has framework-specific DSN support**
+- [x] **Step 1: Confirm the DB harness has framework-specific DSN support**
 
 ```bash
 rg -n "DATABASE_URL|ACTIX_DATABASE_URL|KRUDA_DATABASE_URL|BENCH_ENABLE_DB|BENCH_KRUDA_DB_DISPATCH" bench/reproducible
@@ -124,7 +137,7 @@ rg -n "DATABASE_URL|ACTIX_DATABASE_URL|KRUDA_DATABASE_URL|BENCH_ENABLE_DB|BENCH_
 
 Expected: `bench.sh`, `resource.sh`, and benchmark app files show separate framework DSN handling or no manual DSN override is needed.
 
-- [ ] **Step 2: Run the DB proof on tiger**
+- [x] **Step 2: Run the DB proof on tiger**
 
 Run on the Linux benchmark host:
 
@@ -145,7 +158,7 @@ GOTOOLCHAIN=go1.25.10 \
 
 Expected: every measured row has zero socket errors and zero non-2xx responses.
 
-- [ ] **Step 3: Accept or reject the DB claim**
+- [x] **Step 3: Accept or reject the DB claim**
 
 Accept only if both default read-only DB routes clear the gate:
 
@@ -158,7 +171,7 @@ No manual framework-specific DSN override was needed
 
 Reject or rerun if any row has socket errors, non-2xx responses, missing DB rows, mixed toolchains, or a manual DSN override.
 
-- [ ] **Step 4: Record fresh DB evidence**
+- [x] **Step 4: Record fresh DB evidence**
 
 Create `bench/reproducible/results/2026-06-06-v126-db-evidence.md` with this exact structure:
 
@@ -189,7 +202,7 @@ Write `Accepted` or `Rejected`, followed by one paragraph tied to the measured v
 
 Do not commit the evidence file until the command has produced measured rows.
 
-- [ ] **Step 5: Commit DB evidence if accepted**
+- [x] **Step 5: Commit DB evidence if accepted**
 
 ```bash
 git add bench/reproducible/results/2026-06-06-v126-db-evidence.md bench/reproducible/README.md
@@ -202,9 +215,9 @@ git commit -m "bench: record v1.2.6 read-only DB evidence"
 - Modify only after a failing proof exists: `ctx_response.go`
 - Modify only after a failing proof exists: `wing_http.go`
 - Test: `wing_feather_internal_test.go`, `wing_bench_test.go`
-- Create only if fresh evidence is produced: `bench/reproducible/results/2026-06-06-v126-json-evidence.md`
+- Create only if fresh evidence is produced: `bench/reproducible/results/2026-06-07-v126-json-evidence.md`
 
-- [ ] **Step 1: Run the local JSON microbenchmark baseline**
+- [x] **Step 1: Run the local JSON microbenchmark baseline**
 
 ```bash
 go test -run '^$' -tags kruda_stdjson \
@@ -214,7 +227,7 @@ go test -run '^$' -tags kruda_stdjson \
 
 Expected: command exits 0 and prints benchmark rows for response JSON and handler JSON paths.
 
-- [ ] **Step 2: Define the JSON gate before changing code**
+- [x] **Step 2: Define the JSON gate before changing code**
 
 Use this gate for any branch:
 
@@ -225,7 +238,7 @@ Static JSON helper benchmarks stay within +5% ns/op and no allocation increase
 No public claim says this is a broad Actix win
 ```
 
-- [ ] **Step 3: Write a failing proof before runtime edits**
+- [x] **Step 3: Confirm whether a failing proof exists before runtime edits**
 
 If pursuing a runtime change, add or adjust a focused benchmark/test first. Example target:
 
@@ -237,11 +250,11 @@ go test -run '^$' -tags kruda_stdjson \
 
 Expected before an accepted optimization: the measured baseline still shows the gap the candidate intends to improve.
 
-- [ ] **Step 4: Implement only the measured JSON path**
+- [x] **Step 4: Skip runtime edits because the measured JSON path stayed healthy**
 
 Touch only the response path proven by Step 3. Do not change plaintext, static JSON, DB dispatch, event-loop, or read-buffer code in the same commit.
 
-- [ ] **Step 5: Run the narrow JSON proof**
+- [x] **Step 5: Run the narrow JSON proof**
 
 ```bash
 go test -run '^$' -tags kruda_stdjson \
@@ -251,11 +264,12 @@ go test -run '^$' -tags kruda_stdjson \
 
 Expected: JSON serialization meets the Step 2 gate.
 
-- [ ] **Step 6: Commit only if the proof passes**
+- [x] **Step 6: Commit evidence only because no runtime change was justified**
 
 ```bash
-git add ctx_response.go wing_http.go wing_feather_internal_test.go wing_bench_test.go
-git commit -m "perf: improve Wing JSON serialization path"
+git add bench/reproducible/results/2026-06-07-v126-json-evidence.md \
+  docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
+git commit -m "bench: record v1.2.6 JSON recheck"
 ```
 
 ## Task 4: Keep Pipelined I/O as Diagnostic Work
@@ -263,9 +277,9 @@ git commit -m "perf: improve Wing JSON serialization path"
 **Files:**
 - Modify only if diagnostics drift: `bench/reproducible/pipeline.sh`
 - Modify only if syscall diagnostics drift: `bench/reproducible/pipeline-syscall.sh`
-- Create only if fresh evidence is produced: `bench/reproducible/results/2026-06-06-v126-pipeline-evidence.md`
+- Create only if fresh evidence is produced: `bench/reproducible/results/2026-06-07-v126-pipeline-evidence.md`
 
-- [ ] **Step 1: Run pipeline throughput diagnostics on tiger**
+- [x] **Step 1: Run pipeline throughput diagnostics on tiger**
 
 ```bash
 cd bench/reproducible
@@ -279,7 +293,7 @@ PIPELINE_PROFILES="baseline-c128-d1:128:1 pipeline-c128-d8:128:8 pipeline-c256-d
 
 Expected: all measured rows have zero socket errors and zero non-2xx responses.
 
-- [ ] **Step 2: Run syscall diagnostics only if batching behavior is questioned**
+- [x] **Step 2: Skip syscall diagnostics because batching behavior was already answered**
 
 ```bash
 cd bench/reproducible
@@ -293,11 +307,13 @@ PIPELINE_WARMUP=2s \
 
 Expected: depth-8 profiles show Kruda `requests_per_write_send` near 8.00. If already near 8.00, do not implement extra inline response batching.
 
-- [ ] **Step 3: Commit diagnostics only, not runtime changes**
+- [x] **Step 3: Commit diagnostics only, not runtime changes**
 
 ```bash
-git add bench/reproducible/results/2026-06-06-v126-pipeline-evidence.md
-git commit -m "bench: record v1.2.6 pipelined I/O diagnostics"
+git add bench/reproducible/results/2026-06-07-v126-pipeline-evidence.md \
+  bench/reproducible/README.md \
+  docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
+git commit -m "bench: record v1.2.6 pipelined diagnostics"
 ```
 
 ## Task 5: Treat Read-buffer 2048 as an Optional Profile
@@ -305,9 +321,9 @@ git commit -m "bench: record v1.2.6 pipelined I/O diagnostics"
 **Files:**
 - Modify only if docs need clarification: `docs/guide/performance.md`
 - Modify only if harness output needs clarity: `bench/reproducible/resource.sh`
-- Create only if fresh evidence is produced: `bench/reproducible/results/2026-06-06-v126-readbuf2048-evidence.md`
+- Create only if fresh evidence is produced: `bench/reproducible/results/2026-06-07-v126-readbuf2048-evidence.md`
 
-- [ ] **Step 1: Repeat the resource proof on tiger**
+- [x] **Step 1: Repeat the resource proof on tiger**
 
 ```bash
 cd bench/reproducible
@@ -320,7 +336,7 @@ KRUDA_READ_BUF_SIZE=2048 \
 
 Expected: zero socket errors, zero non-2xx responses, and lower Kruda max RSS versus the documented 4096 profile.
 
-- [ ] **Step 2: Reject default change unless the strict gate passes**
+- [x] **Step 2: Reject default change unless the strict gate passes**
 
 Keep the framework default unchanged unless all conditions pass:
 
@@ -333,11 +349,13 @@ Large-header rejection risk is documented and acceptable
 
 Expected for current evidence: keep `2048` optional and do not change the framework default.
 
-- [ ] **Step 3: Commit optional-profile docs only**
+- [x] **Step 3: Commit optional-profile evidence only**
 
 ```bash
-git add docs/guide/performance.md bench/reproducible/results/2026-06-06-v126-readbuf2048-evidence.md
-git commit -m "docs: describe Wing short-header read-buffer profile"
+git add bench/reproducible/results/2026-06-07-v126-readbuf2048-evidence.md \
+  bench/reproducible/README.md \
+  docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
+git commit -m "bench: record v1.2.6 read-buffer evidence"
 ```
 
 ## Task 6: Decide Whether v1.2.6 Is Worth Releasing
@@ -346,15 +364,15 @@ git commit -m "docs: describe Wing short-header read-buffer profile"
 - Modify only when release is justified: `CHANGELOG.md`
 - Check: `docs/release-process.md`
 
-- [ ] **Step 1: Review accepted commits**
+- [x] **Step 1: Review accepted commits**
 
 ```bash
-git log --oneline origin/main..HEAD
+git log --oneline v1.2.5..HEAD
 ```
 
 Expected: accepted commits are user-facing docs, benchmark, or runtime improvements with evidence.
 
-- [ ] **Step 2: Apply the release decision gate**
+- [x] **Step 2: Apply the release decision gate**
 
 Release v1.2.6 only if the public release gate in `docs/release-process.md`
 is satisfied. Do not tag a new Go module version for docs/evidence-only work.
@@ -373,7 +391,7 @@ Do not release the current post-`v1.2.5` state: it contains public docs and
 benchmark evidence only, with no runtime/package behavior change that asks Go
 users to upgrade from `v1.2.5`.
 
-- [ ] **Step 3: Prepare changelog only after the gate passes**
+- [x] **Step 3: Skip changelog because the release gate did not pass**
 
 Add a section like this to `CHANGELOG.md` only when the accepted commits match these scopes:
 
@@ -392,17 +410,19 @@ Add a section like this to `CHANGELOG.md` only when the accepted commits match t
 
 Every bullet must map to a committed change and proof from this plan.
 
-- [ ] **Step 4: Run release proof before PR merge**
+- [x] **Step 4: Skip release proof because there is no release candidate**
 
 ```bash
 ./scripts/pre-release.sh
 ```
 
-Expected: script exits 0. If it fails due network or dependency download, rerun with the repo's approved Go cache/module-cache command shape and record the exact failure and rerun command.
+Expected if the release gate passes: script exits 0. This was intentionally
+not run for the closed docs/evidence-only state because there is no release
+candidate, changelog section, or tag path.
 
 ## Final Verification
 
-- [ ] Run markdown sanity checks:
+- [x] Run markdown sanity checks:
 
 ```bash
 git diff --check
@@ -411,7 +431,7 @@ rg -n "broad .*20|blanket .*20" docs/superpowers/plans/2026-06-06-v1.2.6-candida
 
 Expected: `git diff --check` exits 0. The `rg` command exits 0 only for intentional guardrail text that says the broad or blanket claim is rejected.
 
-- [ ] Review scope:
+- [x] Review scope:
 
 ```bash
 git diff --stat origin/main..HEAD
@@ -419,11 +439,14 @@ git diff --stat origin/main..HEAD
 
 Expected for this roadmap branch: docs-only changes.
 
-- [ ] Prepare PR wording in English:
+- [x] Prepare PR wording in English:
 
 ```text
-Title: docs: plan v1.2.6 performance candidates
+Title: docs: close v1.2.6 performance roadmap
 
 Body:
-This PR adds a docs-only v1.2.6 candidate roadmap that separates accepted DB evidence from rejected broad CPU-bound +20% claims. It defines proof gates for DB, JSON serialization, pipelined diagnostics, and read-buffer resource profiling before any runtime work starts.
+This PR marks the docs-only v1.2.6 candidate roadmap as complete after the
+accepted DB, JSON, pipelined, and read-buffer evidence PRs merged. It keeps the
+release decision unchanged: no v1.2.6 tag from the current docs/evidence-only
+delta.
 ```


### PR DESCRIPTION
Marks the docs-only v1.2.6 candidate roadmap as complete after the accepted DB, JSON, pipelined, and read-buffer evidence PRs merged.\n\nThe release decision is unchanged: the current post-v1.2.5 delta remains docs and benchmark evidence only, so this PR does not add a changelog section, does not run release proof, and does not justify a v1.2.6 tag.\n\nVerification:\n- git diff --check\n- rg -n 'broad .*20|blanket .*20' docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md bench/reproducible docs/guide\n- git log --oneline v1.2.5..HEAD