### PR TITLE
docs: point DB benchmark wording at v1.2.6 evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,14 +135,14 @@ Committed tiger evidence captured at commit `984f0d6` satisfies that gate for th
 
 Evidence: `bench/reproducible/results/main-984f0d6-20260524T171346Z/`, `bench/reproducible/results/resource-main-984f0d6-20260524T174429Z/`, and the summary note in `bench/reproducible/results/2026-05-25-main-984f0d6-tiger-evidence.md`. These are normal handler-path routes, not Wing static bypass routes. The resource evidence shows higher RPS/core than Actix while Actix still uses less RSS.
 
-Opt-in read-only DB workload evidence is tracked separately because database driver, pool, and schema behavior can dominate framework overhead. In the current tiger follow-up run with `BENCH_ENABLE_DB=1`, `BENCH_KRUDA_DB_DISPATCH=takeover`, and framework-specific default DB DSNs, Kruda was materially faster than Actix on read-style routes:
+Opt-in read-only DB workload evidence is tracked separately because database driver, pool, and schema behavior can dominate framework overhead. In the accepted v1.2.6 tiger revalidation with `BENCH_ENABLE_DB=1`, `BENCH_KRUDA_DB_DISPATCH=takeover`, framework-specific default DB DSNs, and zero socket errors/non-2xx responses, Kruda was materially faster than Actix on read-style routes:
 
 | Route | Profile | Kruda vs Actix median RPS | Kruda vs Actix p99 |
 |------|---------|---------------------------:|-------------------:|
-| `/db` | throughput | +160.21% | -71.25% |
-| `/fortunes` | throughput | +95.05% | -70.00% |
+| `/db` | throughput | +166.13% | -81.94% |
+| `/fortunes` | throughput | +92.47% | -68.67% |
 
-Evidence: `bench/reproducible/results/2026-06-06-wing-actix-20-follow-up.md`. Treat this as a workload-specific DB result, not a broad CPU-bound handler-path claim.
+Evidence: `bench/reproducible/results/2026-06-06-v126-db-evidence.md`. Treat this as a workload-specific read-only DB result, not a broad CPU-bound handler-path claim.
 
 Wing transport uses raw `epoll` + `eventfd` on Linux and bypasses both fasthttp and net/http. macOS defaults to fasthttp.
 

--- a/bench/reproducible/README.md
+++ b/bench/reproducible/README.md
@@ -321,6 +321,15 @@ These are normal handler-path routes. Static bypass route options are intentiona
 
 The corresponding resource evidence is in `results/resource-main-984f0d6-20260524T174429Z/`, with a summary note in `results/2026-05-25-main-984f0d6-tiger-evidence.md`. It uses `GOMAXPROCS=8`, `KRUDA_WORKERS=4`, and a default Kruda benchmark binary without the `bench_pprof` build tag to match the harness `wrk -t4` CPU-bound profiles. The run shows zero socket errors and zero non-2xx responses, with Kruda throughput, p99, and RPS/core ahead of Actix while RSS remains higher than Actix.
 
+The accepted v1.2.6 read-only DB revalidation is in
+`results/2026-06-06-v126-db-evidence.md`. It uses `BENCH_ENABLE_DB=1`,
+`BENCH_KRUDA_DB_DISPATCH=takeover`, Kruda and Actix only, framework-specific
+default DB DSNs, three measured rounds, 8s measured duration, and 2s warmup.
+Throughput-profile medians were +166.13% versus Actix for `/db` and +92.47%
+for `/fortunes`, with materially lower p99 latency and zero socket errors and
+zero non-2xx responses. Keep this scoped to read-only DB workloads; do not mix
+it into CPU-bound fair handler-path claims.
+
 The v1.2.6 HTTP/1.1 pipelined diagnostic recheck is in
 `results/2026-06-07-v126-pipeline-evidence.md`. It uses `pipeline.sh` with
 Kruda and Actix, three rounds, 5s measured duration, 2s warmup, and profiles

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -79,7 +79,7 @@ For cross-runtime claims, use the reproducible CPU-bound harness in `bench/repro
 
 That evidence is limited to same-host loopback CPU-bound handler routes. It is not a database, TLS, HTTP/2, or production network claim. The resource run also shows that Actix still uses less RSS, while Kruda has higher RPS/core on the measured routes.
 
-Opt-in read-only DB workload evidence is tracked separately. The current tiger follow-up run in `bench/reproducible/results/2026-06-06-wing-actix-20-follow-up.md` used `BENCH_ENABLE_DB=1`, `BENCH_KRUDA_DB_DISPATCH=takeover`, framework-specific default DB DSNs, and zero socket errors/non-2xx responses. In that run, throughput-profile median RPS was +160.21% versus Actix for `/db` and +95.05% for `/fortunes`, with materially lower p99 latency. Treat this as a read-style DB workload result, not as a broad CPU-bound handler-path claim.
+Opt-in read-only DB workload evidence is tracked separately. The accepted v1.2.6 tiger revalidation in `bench/reproducible/results/2026-06-06-v126-db-evidence.md` used `BENCH_ENABLE_DB=1`, `BENCH_KRUDA_DB_DISPATCH=takeover`, framework-specific default DB DSNs, and zero socket errors/non-2xx responses. In that run, throughput-profile median RPS was +166.13% versus Actix for `/db` and +92.47% for `/fortunes`, with materially lower p99 latency. Treat this as a read-style DB workload result, not as a broad CPU-bound handler-path claim.
 
 For post-v1.2.5 candidate work, keep CPU-bound, read-only DB, pipelined HTTP/1.1, and read-buffer memory profiles separate; each profile needs its own evidence and wording.
 
@@ -221,7 +221,7 @@ Read-style I/O routes (DB, Redis) use **Spear** dispatch — handler runs in a b
 
 Phase 6 tiger evidence supports `WingQuery()`/Spear for DB read-style workloads in the reproducible harness: `/db`, `/queries`, and `/fortunes` had much higher median throughput than Inline with zero socket errors and zero non-2xx responses. Write-heavy routes are different. The `/updates` route had zero errors with `WingQuery()` but much higher p99 latency, while Inline produced socket errors in the throughput profile. Treat write-heavy DB routes as workload-specific tuning: benchmark with your real DB pool, p99 target, and error gate before choosing a dispatch hint.
 
-For cross-runtime DB comparisons, keep the claim scoped to read-style routes. The latest tiger follow-up evidence with framework-specific DB DSN defaults measured `/db` at +160.21% median throughput versus Actix and `/fortunes` at +95.05%, with lower p99 latency in both throughput and latency profiles. This supports a workload-specific DB claim only; the default CPU-bound fair-handler benchmark remains a separate claim with lower but still positive Actix deltas.
+For cross-runtime DB comparisons, keep the claim scoped to read-style routes. The accepted v1.2.6 tiger revalidation with framework-specific DB DSN defaults measured throughput-profile `/db` at +166.13% median throughput versus Actix and `/fortunes` at +92.47%, with lower p99 latency in both throughput and latency profiles. This supports a workload-specific DB claim only; the default CPU-bound fair-handler benchmark remains a separate claim with lower but still positive Actix deltas.
 
 ### Handler-Level Static JSON
 


### PR DESCRIPTION
Updates public benchmark wording to reference the accepted v1.2.6 read-only DB revalidation instead of the earlier follow-up investigation.\n\nThe claim remains scoped to read-style DB workloads only: /db +166.13% and /fortunes +92.47% median throughput versus Actix in the throughput profile, with lower p99 and zero socket errors/non-2xx responses. This does not broaden the CPU-bound fair-handler claim and does not justify a release tag by itself.\n\nVerification:\n- git diff --check\n- rg -n 'wing-actix-20-follow-up|\+160\.21|\+95\.05|\+166\.13|\+92\.47|v126-db-evidence|broad CPU-bound|read-only DB|read-style routes' README.md docs/guide/performance.md bench/reproducible/README.md