### PR TITLE
docs: refresh v1.2.6 roadmap status

### DIFF
--- a/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
+++ b/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
@@ -58,16 +58,20 @@ The current evidence says:
 
 ## Execution Status
 
-Completed through `main` commit `c816915b2fdacab8b5ca657e07beb3c0737d8e35`
-after PR #99. The final post-merge `main` runs for Deploy Docs, Tests, and
-Benchmark passed on that commit. No `v1.2.6` tag was created.
+Completed through `main` commit `eab700a9ac9b02926877b0aa4aaa20d97f5a7e96`
+after PR #101. PR #100 closed the roadmap as a docs/evidence-only track, and
+PR #101 aligned the public read-only DB benchmark wording with the accepted
+v1.2.6 revalidation evidence. The final post-merge `main` runs for Deploy
+Docs, Tests, and Benchmark passed on that commit. No `v1.2.6` tag was created.
 
 All current post-`v1.2.5` work remains docs and benchmark evidence only:
 candidate-boundary wording, read-only DB evidence, JSON recheck evidence,
 pipelined diagnostic evidence, read-buffer optional-profile evidence, and the
-no-release decision. Keep the roadmap closed until a new runtime, security,
-compatibility, benchmark-tooling, or maintainer-approved docs-only release
-change justifies reopening the release gate.
+no-release decision. Public DB wording now points at
+`bench/reproducible/results/2026-06-06-v126-db-evidence.md` and remains scoped
+to read-style DB workloads. Keep the roadmap closed until a new runtime,
+security, compatibility, benchmark-tooling, or maintainer-approved docs-only
+release change justifies reopening the release gate.
 
 ## Task 1: Publish the Candidate Boundary
 


### PR DESCRIPTION
## Summary
- Refresh the v1.2.6 candidate roadmap execution status to the latest merged main commit.
- Record that PR #100 closed the roadmap and PR #101 aligned public read-only DB wording with the accepted v1.2.6 evidence.
- Keep the release decision unchanged: no v1.2.6 tag from the current docs/evidence-only delta.

## Verification
- git diff --check
- git diff --cached --check
- rg confirms the stale c816915/PR #99 execution-status wording is gone