### PR TITLE
docs: make v1.2.6 roadmap status stable

### DIFF
--- a/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
+++ b/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
@@ -58,11 +58,13 @@ The current evidence says:
 
 ## Execution Status
 
-Completed through `main` commit `eab700a9ac9b02926877b0aa4aaa20d97f5a7e96`
-after PR #101. PR #100 closed the roadmap as a docs/evidence-only track, and
-PR #101 aligned the public read-only DB benchmark wording with the accepted
-v1.2.6 revalidation evidence. The final post-merge `main` runs for Deploy
-Docs, Tests, and Benchmark passed on that commit. No `v1.2.6` tag was created.
+Closed as a docs/evidence-only track. PR #100 closed the roadmap, PR #101
+aligned the public read-only DB benchmark wording with the accepted v1.2.6
+revalidation evidence, and PR #102 refreshed this closure status after those
+public docs updates landed. The PR #101 post-merge `main` runs for Deploy Docs,
+Tests, and Benchmark passed. The PR #102 post-merge `main` runs for Deploy Docs
+and Tests passed; no Benchmark run was triggered for that docs/superpowers-only
+change. No `v1.2.6` tag was created.
 
 All current post-`v1.2.5` work remains docs and benchmark evidence only:
 candidate-boundary wording, read-only DB evidence, JSON recheck evidence,
@@ -72,6 +74,10 @@ no-release decision. Public DB wording now points at
 to read-style DB workloads. Keep the roadmap closed until a new runtime,
 security, compatibility, benchmark-tooling, or maintainer-approved docs-only
 release change justifies reopening the release gate.
+
+This section is intentionally not a moving pointer to the latest `main` commit.
+Do not refresh it for docs-only status-maintenance changes unless the release
+decision or accepted candidate evidence changes.
 
 ## Task 1: Publish the Candidate Boundary
 


### PR DESCRIPTION
## Summary
- Replace the self-invalidating latest-main commit pointer in the v1.2.6 roadmap status with a stable closure record.
- Record the PR #101 and PR #102 post-merge check boundaries without requiring a status edit after every docs-only maintenance PR.
- Keep the release decision unchanged: no v1.2.6 tag from the current docs/evidence-only delta.

## Verification
- git diff --check
- git diff --cached --check
- rg confirms the stale 'Completed through' wording is gone
- rg confirms there is no AI attribution string