### PR TITLE
docs: align v1.2.6 roadmap source evidence wording

### DIFF
--- a/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
+++ b/docs/superpowers/plans/2026-06-06-v1.2.6-candidate-roadmap.md
@@ -17,8 +17,8 @@ Do not start v1.2.6 by editing runtime hot paths.
 The current evidence says:
 
 - Broad CPU-bound fair-handler +20% versus Actix is not proven.
-- The latest CPU-bound tiger smoke at `c3a17ef` showed +12.70% plaintext, +14.53% static JSON, and +13.73% serialized JSON in the throughput profile.
-- The read-only DB probe did prove a scoped +20% path: `/db` +160.21% and `/fortunes` +95.05% throughput versus Actix, with lower p99.
+- The post-v1.2.5 CPU-bound tiger source smoke at `c3a17ef` showed +12.70% plaintext, +14.53% static JSON, and +13.73% serialized JSON in the throughput profile.
+- The source read-only DB probe did prove a scoped +20% path: `/db` +160.21% and `/fortunes` +95.05% throughput versus Actix, with lower p99.
 - The v1.2.6 read-only DB revalidation on `tiger-linux` recorded `/db` +166.13% and `/fortunes` +92.47% throughput versus Actix, with lower p99, zero socket errors, zero non-2xx responses, and no manual DB DSN overrides.
 - Pipelined I/O diagnostics show useful architecture behavior and lower p99, but not a blanket +20% public claim.
 - The v1.2.6 HTTP/1.1 pipelined diagnostic recheck on `tiger-linux` recorded zero socket errors and zero non-2xx responses; Kruda had higher median RPS and lower p99 than Actix in all nine profile/route rows, but the claim remains diagnostic and pipelined-only.


### PR DESCRIPTION
## Summary
- replace stale latest CPU-bound wording in the v1.2.6 roadmap with source-evidence wording
- label the older read-only DB probe as source evidence before the accepted v1.2.6 revalidation bullet

## Verification
- git diff --check
- git grep -n 'latest CPU-bound\|latest clean tiger evidence' -- docs/superpowers bench/reproducible README.md docs/guide/performance.md