### PR TITLE
bench: record git metadata in harness output

### DIFF
--- a/bench/reproducible/README.md
+++ b/bench/reproducible/README.md
@@ -257,7 +257,7 @@ Results are written to `bench/reproducible/results/<timestamp>/`:
 
 | File | Purpose |
 |------|---------|
-| `environment.txt` | CPU, OS, toolchain, route, profile, and worker metadata |
+| `environment.txt` | Git commit/dirty state, CPU, OS, toolchain, route, profile, and worker metadata |
 | `summary.csv` | Machine-readable per-round RPS, p50, p90, p99, max latency, socket errors, and non-2xx responses |
 | `summary.md` | Markdown table for PR evidence |
 | `raw/*.txt` | Raw `wrk --latency` output and server logs |
@@ -267,7 +267,7 @@ Pipelined diagnostic results are written to
 
 | File | Purpose |
 |------|---------|
-| `environment.txt` | CPU, OS, toolchain, route, profile, worker, and pipeline metadata |
+| `environment.txt` | Git commit/dirty state, CPU, OS, toolchain, route, profile, worker, and pipeline metadata |
 | `summary.csv` | Machine-readable per-round requests, RPS, p50, p90, p99, max latency, socket errors, and non-2xx responses |
 | `summary.md` | Markdown table for diagnostic evidence |
 | `raw/*.txt` | Raw `pipeline-client` output and server logs |
@@ -277,7 +277,7 @@ Pipelined syscall diagnostic results are written to
 
 | File | Purpose |
 |------|---------|
-| `environment.txt` | CPU, OS, toolchain, route, profile, worker, pipeline, and strace metadata |
+| `environment.txt` | Git commit/dirty state, CPU, OS, toolchain, route, profile, worker, pipeline, and strace metadata |
 | `summary.csv` | Machine-readable requests, latency, socket errors, syscall counts, and requests-per-syscall ratios |
 | `summary.md` | Markdown table for diagnostic I/O evidence |
 | `raw/*.txt` | Raw `pipeline-client`, `strace -c`, server, attach, and status logs |
@@ -286,7 +286,7 @@ Resource results are written to `bench/reproducible/results/resource-<timestamp>
 
 | File | Purpose |
 |------|---------|
-| `environment.txt` | CPU, memory, OS, toolchain, route, profile, worker, and `pidstat` metadata |
+| `environment.txt` | Git commit/dirty state, CPU, memory, OS, toolchain, route, profile, worker, and `pidstat` metadata |
 | `resource-summary.csv` | Machine-readable wrk and pidstat output, including CPU, RSS, context switches, and RPS/core |
 | `resource-aggregated.csv` | Smaller table for cross-framework comparison |
 | `summary.md` | Markdown table for PR evidence |

--- a/bench/reproducible/bench.sh
+++ b/bench/reproducible/bench.sh
@@ -12,6 +12,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
 TIMESTAMP="$(date -u '+%Y%m%dT%H%M%SZ')"
 RESULT_DIR="${RESULT_DIR:-"$SCRIPT_DIR/results/$TIMESTAMP"}"
 RAW_DIR="$RESULT_DIR/raw"
@@ -149,6 +150,13 @@ write_environment() {
   {
     echo "timestamp_utc=$TIMESTAMP"
     echo "script_dir=$SCRIPT_DIR"
+    echo "repo_root=$REPO_ROOT"
+    echo "git_commit=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || true)"
+    if git -C "$REPO_ROOT" diff --quiet --ignore-submodules -- && git -C "$REPO_ROOT" diff --cached --quiet --ignore-submodules --; then
+      echo "git_tracked_dirty=0"
+    else
+      echo "git_tracked_dirty=1"
+    fi
     echo "result_dir=$RESULT_DIR"
     echo "bench_enable_db=$BENCH_ENABLE_DB_VALUE"
     echo "bench_enable_pprof=$BENCH_ENABLE_PPROF_VALUE"

--- a/bench/reproducible/pipeline-syscall.sh
+++ b/bench/reproducible/pipeline-syscall.sh
@@ -143,6 +143,11 @@ write_environment() {
     echo "script_dir=$SCRIPT_DIR"
     echo "repo_root=$REPO_ROOT"
     echo "git_commit=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || true)"
+    if git -C "$REPO_ROOT" diff --quiet --ignore-submodules -- && git -C "$REPO_ROOT" diff --cached --quiet --ignore-submodules --; then
+      echo "git_tracked_dirty=0"
+    else
+      echo "git_tracked_dirty=1"
+    fi
     echo "result_dir=$RESULT_DIR"
     echo "workload=http1_pipelined_syscall_diagnostic"
     echo "profile_sudo=$PROFILE_SUDO"

--- a/bench/reproducible/pipeline.sh
+++ b/bench/reproducible/pipeline.sh
@@ -148,6 +148,11 @@ write_environment() {
     echo "script_dir=$SCRIPT_DIR"
     echo "repo_root=$REPO_ROOT"
     echo "git_commit=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || true)"
+    if git -C "$REPO_ROOT" diff --quiet --ignore-submodules -- && git -C "$REPO_ROOT" diff --cached --quiet --ignore-submodules --; then
+      echo "git_tracked_dirty=0"
+    else
+      echo "git_tracked_dirty=1"
+    fi
     echo "result_dir=$RESULT_DIR"
     echo "workload=http1_pipelined_diagnostic"
     echo "bench_enable_db=$BENCH_ENABLE_DB_VALUE"

--- a/bench/reproducible/profile-kruda.sh
+++ b/bench/reproducible/profile-kruda.sh
@@ -16,6 +16,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
 KRUDA_DIR="$SCRIPT_DIR/kruda"
 TIMESTAMP="$(date -u '+%Y%m%dT%H%M%SZ')"
 RESULT_DIR="${RESULT_DIR:-"$SCRIPT_DIR/results/profile-$TIMESTAMP"}"
@@ -98,6 +99,13 @@ write_environment() {
   {
     echo "timestamp_utc=$TIMESTAMP"
     echo "script_dir=$SCRIPT_DIR"
+    echo "repo_root=$REPO_ROOT"
+    echo "git_commit=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || true)"
+    if git -C "$REPO_ROOT" diff --quiet --ignore-submodules -- && git -C "$REPO_ROOT" diff --cached --quiet --ignore-submodules --; then
+      echo "git_tracked_dirty=0"
+    else
+      echo "git_tracked_dirty=1"
+    fi
     echo "result_dir=$RESULT_DIR"
     echo "routes=${ROUTES[*]}"
     echo "port=$PORT_VALUE"

--- a/bench/reproducible/resource.sh
+++ b/bench/reproducible/resource.sh
@@ -12,6 +12,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
 TIMESTAMP="$(date -u '+%Y%m%dT%H%M%SZ')"
 RESULT_DIR="${RESULT_DIR:-"$SCRIPT_DIR/results/resource-$TIMESTAMP"}"
 RAW_DIR="$RESULT_DIR/raw"
@@ -154,6 +155,13 @@ write_environment() {
   {
     echo "timestamp_utc=$TIMESTAMP"
     echo "script_dir=$SCRIPT_DIR"
+    echo "repo_root=$REPO_ROOT"
+    echo "git_commit=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || true)"
+    if git -C "$REPO_ROOT" diff --quiet --ignore-submodules -- && git -C "$REPO_ROOT" diff --cached --quiet --ignore-submodules --; then
+      echo "git_tracked_dirty=0"
+    else
+      echo "git_tracked_dirty=1"
+    fi
     echo "result_dir=$RESULT_DIR"
     echo "bench_enable_db=$BENCH_ENABLE_DB_VALUE"
     echo "bench_enable_pprof=$BENCH_ENABLE_PPROF_VALUE"

--- a/bench/reproducible/syscall-profile.sh
+++ b/bench/reproducible/syscall-profile.sh
@@ -11,6 +11,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
 TIMESTAMP="$(date -u '+%Y%m%dT%H%M%SZ')"
 RESULT_DIR="${RESULT_DIR:-"$SCRIPT_DIR/results/syscall-$TIMESTAMP"}"
 RAW_DIR="$RESULT_DIR/raw"
@@ -129,6 +130,13 @@ write_environment() {
   {
     echo "timestamp_utc=$TIMESTAMP"
     echo "script_dir=$SCRIPT_DIR"
+    echo "repo_root=$REPO_ROOT"
+    echo "git_commit=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || true)"
+    if git -C "$REPO_ROOT" diff --quiet --ignore-submodules -- && git -C "$REPO_ROOT" diff --cached --quiet --ignore-submodules --; then
+      echo "git_tracked_dirty=0"
+    else
+      echo "git_tracked_dirty=1"
+    fi
     echo "result_dir=$RESULT_DIR"
     echo "profile_duration=$PROFILE_DURATION"
     echo "warmup_duration=$WARMUP_DURATION"


### PR DESCRIPTION
## Summary
- add repo root, git commit, and tracked dirty-state metadata to benchmark environment output
- make default, resource, profile, syscall, and pipelined harness output easier to tie back to the exact source tree
- document the new git metadata in the reproducible benchmark README output tables

## Verification
- bash -n bench/reproducible/bench.sh bench/reproducible/resource.sh bench/reproducible/profile-kruda.sh bench/reproducible/syscall-profile.sh bench/reproducible/pipeline.sh bench/reproducible/pipeline-syscall.sh
- git diff --check
- /usr/bin/env PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin GOCACHE=/private/tmp/kruda-go-build-cache-meta BENCH_FRAMEWORKS=kruda BENCH_ROUNDS=1 BENCH_DURATION=1s RESULT_DIR=/private/tmp/kruda-meta-bench-clean ./bench/reproducible/bench.sh plaintext-handler
- sed -n '1,8p' /private/tmp/kruda-meta-bench-clean/environment.txt