### PR TITLE
bench: record dispatch sweep git metadata

### DIFF
--- a/bench/reproducible/README.md
+++ b/bench/reproducible/README.md
@@ -184,7 +184,8 @@ For repeatable Kruda-only DB dispatch sweeps, use:
 
 The sweep runs Kruda only, stores per-run `bench.sh` output under
 `results/kruda-db-dispatch-sweep-<timestamp>/runs/`, and writes aggregate
-median RPS/p99/error summaries to `dispatch-summary.csv` and `summary.md`.
+median RPS/p99/error summaries to `dispatch-summary.csv`, `summary.md`, and an
+`environment.txt` with Git commit/dirty state plus sweep settings.
 
 Current Phase 6 tiger sweep evidence is in
 `results/phase6-profile-inventory-pr79-20260602T031308Z/`. In that run,

--- a/bench/reproducible/sweep-kruda-db-dispatch.sh
+++ b/bench/reproducible/sweep-kruda-db-dispatch.sh
@@ -12,6 +12,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
 TIMESTAMP="$(date -u '+%Y%m%dT%H%M%SZ')"
 RESULT_DIR="${RESULT_DIR:-"$SCRIPT_DIR/results/kruda-db-dispatch-sweep-$TIMESTAMP"}"
 RUN_DIR="$RESULT_DIR/runs"
@@ -36,6 +37,13 @@ write_environment() {
   {
     echo "timestamp_utc=$TIMESTAMP"
     echo "script_dir=$SCRIPT_DIR"
+    echo "repo_root=$REPO_ROOT"
+    echo "git_commit=$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || true)"
+    if git -C "$REPO_ROOT" diff --quiet --ignore-submodules -- && git -C "$REPO_ROOT" diff --cached --quiet --ignore-submodules --; then
+      echo "git_tracked_dirty=0"
+    else
+      echo "git_tracked_dirty=1"
+    fi
     echo "result_dir=$RESULT_DIR"
     echo "routes=${ROUTES[*]}"
     echo "modes=${MODES[*]}"


### PR DESCRIPTION
## Summary
- record repo root, git commit, and tracked dirty state in the Kruda DB dispatch sweep environment output
- document that sweep summaries include environment metadata alongside aggregate CSV and Markdown output

## Verification
- `bash -n bench/reproducible/sweep-kruda-db-dispatch.sh`
- `git diff --check HEAD~1..HEAD`
- `RESULT_DIR=/private/tmp/kruda-sweep-meta-smoke-clean BENCH_KRUDA_DB_DISPATCH_MODES=takeover BENCH_ROUNDS=1 BENCH_DURATION=1s ./bench/reproducible/sweep-kruda-db-dispatch.sh plaintext-handler`
- verified `/private/tmp/kruda-sweep-meta-smoke-clean/environment.txt` contains `git_commit=50ed062` and `git_tracked_dirty=0`