### PR TITLE
ci: upload benchmark evidence artifacts

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -210,6 +210,20 @@ jobs:
             echo "</details>"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Upload benchmark evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: benchmark-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            output.txt
+            benchmark.txt
+            main-output.txt
+            main-benchmark.txt
+            benchstat.txt
+          if-no-files-found: warn
+          retention-days: 30
+
       - name: Get system information
         uses: kenchan0130/actions-system-info@v1.4.0
         id: system-info


### PR DESCRIPTION
## Summary
- upload raw and normalized Benchmark workflow evidence files as a short-retention artifact
- include PR same-runner `benchstat.txt` when it exists, while keeping summaries and gates unchanged

## Verification
- `git diff --check HEAD~1..HEAD`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/benchmark.yml'); puts 'yaml-ok'"`
- verified `actions/upload-artifact@v7` tag exists with `git ls-remote --tags https://github.com/actions/upload-artifact.git 'refs/tags/v*'`