### PR TITLE
ci: share benchmark regression checker

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -137,24 +137,7 @@ jobs:
           set -euo pipefail
 
           benchstat main-benchmark.txt benchmark.txt | tee benchstat.txt
-
-          awk '
-            /^[^[:space:]]/ && $0 ~ /\+[0-9.]+%/ && $0 !~ /~$/ {
-              for (i = 1; i <= NF; i++) {
-                if ($i ~ /^\+[0-9.]+%$/) {
-                  change = $i
-                  gsub(/^\+|%$/, "", change)
-                  if ((change + 0) > 10) bad = 1
-                }
-              }
-            }
-            END {
-              if (bad) {
-                print "::error::Benchmark regression above 10% detected by same-runner benchstat."
-                exit 1
-              }
-            }
-          ' benchstat.txt
+          scripts/check-benchmark-regressions.sh benchstat.txt
 
       - name: Summarize PR benchmark comparison
         if: ${{ always() && github.event_name == 'pull_request' }}
@@ -178,21 +161,7 @@ jobs:
               exit 0
             fi
 
-            regressions="$(
-              awk '
-                /^[^[:space:]]/ && $0 ~ /\+[0-9.]+%/ && $0 !~ /~$/ {
-                  for (i = 1; i <= NF; i++) {
-                    if ($i ~ /^\+[0-9.]+%$/) {
-                      change = $i
-                      gsub(/^\+|%$/, "", change)
-                      if ((change + 0) > 10) {
-                        printf("- `%s` %s\n", $1, $i)
-                      }
-                    }
-                  }
-                }
-              ' benchstat.txt
-            )"
+            regressions="$(scripts/check-benchmark-regressions.sh --list benchstat.txt)"
 
             if [ -n "$regressions" ]; then
               echo "Regressions above 10%:"

--- a/scripts/check-benchmark-regressions.sh
+++ b/scripts/check-benchmark-regressions.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Report same-runner benchstat regressions above a threshold.
+set -euo pipefail
+
+mode="check"
+threshold="${BENCHSTAT_REGRESSION_THRESHOLD:-10}"
+
+usage() {
+  echo "usage: $0 [--list] [--threshold percent] benchstat.txt" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --list)
+      mode="list"
+      shift
+      ;;
+    --threshold)
+      if [[ $# -lt 2 ]]; then
+        usage
+        exit 2
+      fi
+      threshold="$2"
+      shift 2
+      ;;
+    -*)
+      usage
+      exit 2
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 2
+fi
+
+benchstat_file="$1"
+if [[ ! -f "$benchstat_file" ]]; then
+  echo "benchstat file not found: $benchstat_file" >&2
+  exit 2
+fi
+
+regressions_file="$(mktemp)"
+trap 'rm -f "$regressions_file"' EXIT
+
+awk -v threshold="$threshold" '
+  /sec\/op/ {
+    metric = "sec/op"
+  }
+  /B\/op/ {
+    metric = "B/op"
+  }
+  /allocs\/op/ {
+    metric = "allocs/op"
+  }
+  /^[^[:space:]]/ && $0 ~ /\+[0-9.]+%/ {
+    for (i = 1; i <= NF; i++) {
+      if ($i ~ /^\+[0-9.]+%$/) {
+        change = $i
+        gsub(/^\+|%$/, "", change)
+        if ((change + 0) > threshold) {
+          printf("- `%s` %s %s\n", $1, metric, $i)
+        }
+      }
+    }
+  }
+' "$benchstat_file" > "$regressions_file"
+
+if [[ ! -s "$regressions_file" ]]; then
+  exit 0
+fi
+
+cat "$regressions_file"
+
+if [[ "$mode" == "check" ]]; then
+  if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+    echo "::error::Benchmark regression above ${threshold}% detected by same-runner benchstat."
+  else
+    echo "Benchmark regression above ${threshold}% detected by same-runner benchstat." >&2
+  fi
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- move the same-runner benchstat regression parser into `scripts/check-benchmark-regressions.sh`
- reuse the same parser for both the Benchmark gate and the PR summary
- include metric names in the reported regression rows

## Verification
- `git diff --check HEAD~1..HEAD`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/benchmark.yml'); puts 'yaml-ok'"`
- `bash -n scripts/check-benchmark-regressions.sh`
- synthetic clean fixture exits 0
- synthetic regression fixture exits non-zero and reports `sec/op`, `B/op`, and `allocs/op` rows
- PR #109 `benchstat.txt` artifact parses cleanly