### PR TITLE
bench: add Actix worker-count control

### DIFF
--- a/bench/reproducible/README.md
+++ b/bench/reproducible/README.md
@@ -165,6 +165,9 @@ Actix receives the same base PostgreSQL DSN without pgx-only query options.
 Set `KRUDA_DATABASE_URL`, `FIBER_DATABASE_URL`, or `ACTIX_DATABASE_URL` for
 framework-specific overrides. Set `BENCH_DATABASE_BASE_URL` to change the shared
 default base DSN without disabling those framework-specific defaults.
+Set `BENCH_ACTIX_WORKERS` only for methodology controls that intentionally pin
+Actix's worker count. Leave it unset for the default Actix runtime behavior.
+The harness records the effective `actix_workers` value in `environment.txt`.
 
 For Kruda-only DB dispatch experiments, set `BENCH_KRUDA_DB_DISPATCH` to
 `takeover`, `pool`, `spawn`, or `inline`. This affects only the Kruda

--- a/bench/reproducible/actix/src/main.rs
+++ b/bench/reproducible/actix/src/main.rs
@@ -156,6 +156,19 @@ async fn main() -> std::io::Result<()> {
         .unwrap_or(3003);
 
     let enable_db = std::env::var("BENCH_ENABLE_DB").ok().as_deref() == Some("1");
+    let workers = std::env::var("BENCH_ACTIX_WORKERS").ok().and_then(|raw| {
+        if raw.is_empty() {
+            return None;
+        }
+        let value = raw
+            .parse::<usize>()
+            .unwrap_or_else(|_| panic!("BENCH_ACTIX_WORKERS must be a positive integer: {raw}"));
+        assert!(
+            value > 0,
+            "BENCH_ACTIX_WORKERS must be a positive integer: {raw}"
+        );
+        Some(value)
+    });
     let pool_data = if enable_db {
         let dsn = std::env::var("DATABASE_URL").unwrap_or_else(|_| {
             "postgres://benchmarkdbuser:benchmarkdbpass@localhost:5433/hello_world".to_string()
@@ -171,7 +184,7 @@ async fn main() -> std::io::Result<()> {
         None
     };
 
-    HttpServer::new(move || {
+    let server = HttpServer::new(move || {
         let app = App::new()
             .route("/", web::get().to(plaintext))
             .route("/plaintext-handler", web::get().to(plaintext))
@@ -189,8 +202,12 @@ async fn main() -> std::io::Result<()> {
         } else {
             app
         }
-    })
-    .bind(("0.0.0.0", port))?
-    .run()
-    .await
+    });
+    let server = if let Some(workers) = workers {
+        server.workers(workers)
+    } else {
+        server
+    };
+
+    server.bind(("0.0.0.0", port))?.run().await
 }

--- a/bench/reproducible/bench.sh
+++ b/bench/reproducible/bench.sh
@@ -25,6 +25,7 @@ GOMAXPROCS_VALUE="${GOMAXPROCS:-8}"
 # with the active load-generator threads unless the run is explicitly studying
 # worker scaling. This does not change Kruda's framework default.
 KRUDA_WORKERS_VALUE="${KRUDA_WORKERS:-4}"
+ACTIX_WORKERS_VALUE="${BENCH_ACTIX_WORKERS:-}"
 KRUDA_READ_BUF_SIZE_VALUE="${KRUDA_READ_BUF_SIZE:-}"
 KRUDA_POOL_SIZE_VALUE="${KRUDA_POOL_SIZE:-}"
 BENCH_ENABLE_DB_VALUE="${BENCH_ENABLE_DB:-0}"
@@ -168,6 +169,7 @@ write_environment() {
     echo "kruda_go_tags=${KRUDA_GO_TAGS_VALUE:-default}"
     echo "gomaxprocs=$GOMAXPROCS_VALUE"
     echo "kruda_workers=$KRUDA_WORKERS_VALUE"
+    echo "actix_workers=${ACTIX_WORKERS_VALUE:-default}"
     echo "kruda_read_buf_size=${KRUDA_READ_BUF_SIZE_VALUE:-default}"
     echo "kruda_pool_size=${KRUDA_POOL_SIZE_VALUE:-default}"
     echo "bench_rounds=$BENCH_ROUNDS_VALUE"
@@ -232,7 +234,8 @@ start_server() {
     actix)
       (
         cd "$SCRIPT_DIR/actix"
-        env PORT="$port" BENCH_ENABLE_DB="$BENCH_ENABLE_DB_VALUE" DATABASE_URL="$ACTIX_DATABASE_URL_VALUE" \
+        env PORT="$port" BENCH_ENABLE_DB="$BENCH_ENABLE_DB_VALUE" BENCH_ACTIX_WORKERS="$ACTIX_WORKERS_VALUE" \
+          DATABASE_URL="$ACTIX_DATABASE_URL_VALUE" \
           ./target/release/actix-bench
       ) > "$log" 2>&1 &
       ;;

--- a/bench/reproducible/pipeline-syscall.sh
+++ b/bench/reproducible/pipeline-syscall.sh
@@ -22,6 +22,7 @@ CLIENT_BIN="$SCRIPT_DIR/pipeline-client/pipeline-client"
 
 GOMAXPROCS_VALUE="${GOMAXPROCS:-8}"
 KRUDA_WORKERS_VALUE="${KRUDA_WORKERS:-4}"
+ACTIX_WORKERS_VALUE="${BENCH_ACTIX_WORKERS:-}"
 KRUDA_READ_BUF_SIZE_VALUE="${KRUDA_READ_BUF_SIZE:-}"
 KRUDA_POOL_SIZE_VALUE="${KRUDA_POOL_SIZE:-}"
 BENCH_ENABLE_DB_VALUE="${BENCH_ENABLE_DB:-0}"
@@ -160,6 +161,7 @@ write_environment() {
     echo "kruda_go_tags=${KRUDA_GO_TAGS_VALUE:-default}"
     echo "gomaxprocs=$GOMAXPROCS_VALUE"
     echo "kruda_workers=$KRUDA_WORKERS_VALUE"
+    echo "actix_workers=${ACTIX_WORKERS_VALUE:-default}"
     echo "kruda_read_buf_size=${KRUDA_READ_BUF_SIZE_VALUE:-default}"
     echo "kruda_pool_size=${KRUDA_POOL_SIZE_VALUE:-default}"
     echo "pipeline_duration=$PIPELINE_DURATION_VALUE"
@@ -215,7 +217,8 @@ start_server() {
     actix)
       (
         cd "$SCRIPT_DIR/actix"
-        env PORT="$port" BENCH_ENABLE_DB="$BENCH_ENABLE_DB_VALUE" DATABASE_URL="$ACTIX_DATABASE_URL_VALUE" "$bin"
+        env PORT="$port" BENCH_ENABLE_DB="$BENCH_ENABLE_DB_VALUE" BENCH_ACTIX_WORKERS="$ACTIX_WORKERS_VALUE" \
+          DATABASE_URL="$ACTIX_DATABASE_URL_VALUE" "$bin"
       ) > "$log" 2>&1 &
       ;;
   esac

--- a/bench/reproducible/pipeline.sh
+++ b/bench/reproducible/pipeline.sh
@@ -21,6 +21,7 @@ CLIENT_BIN="$SCRIPT_DIR/pipeline-client/pipeline-client"
 
 GOMAXPROCS_VALUE="${GOMAXPROCS:-8}"
 KRUDA_WORKERS_VALUE="${KRUDA_WORKERS:-4}"
+ACTIX_WORKERS_VALUE="${BENCH_ACTIX_WORKERS:-}"
 KRUDA_READ_BUF_SIZE_VALUE="${KRUDA_READ_BUF_SIZE:-}"
 KRUDA_POOL_SIZE_VALUE="${KRUDA_POOL_SIZE:-}"
 BENCH_ENABLE_DB_VALUE="${BENCH_ENABLE_DB:-0}"
@@ -165,6 +166,7 @@ write_environment() {
     echo "kruda_go_tags=${KRUDA_GO_TAGS_VALUE:-default}"
     echo "gomaxprocs=$GOMAXPROCS_VALUE"
     echo "kruda_workers=$KRUDA_WORKERS_VALUE"
+    echo "actix_workers=${ACTIX_WORKERS_VALUE:-default}"
     echo "kruda_read_buf_size=${KRUDA_READ_BUF_SIZE_VALUE:-default}"
     echo "kruda_pool_size=${KRUDA_POOL_SIZE_VALUE:-default}"
     echo "bench_rounds=$BENCH_ROUNDS_VALUE"
@@ -231,7 +233,8 @@ start_server() {
     actix)
       (
         cd "$SCRIPT_DIR/actix"
-        env PORT="$port" BENCH_ENABLE_DB="$BENCH_ENABLE_DB_VALUE" DATABASE_URL="$ACTIX_DATABASE_URL_VALUE" \
+        env PORT="$port" BENCH_ENABLE_DB="$BENCH_ENABLE_DB_VALUE" BENCH_ACTIX_WORKERS="$ACTIX_WORKERS_VALUE" \
+          DATABASE_URL="$ACTIX_DATABASE_URL_VALUE" \
           ./target/release/actix-bench
       ) > "$log" 2>&1 &
       ;;

--- a/bench/reproducible/resource.sh
+++ b/bench/reproducible/resource.sh
@@ -26,6 +26,7 @@ GOMAXPROCS_VALUE="${GOMAXPROCS:-8}"
 # with the active load-generator threads unless the run is explicitly studying
 # worker scaling. This does not change Kruda's framework default.
 KRUDA_WORKERS_VALUE="${KRUDA_WORKERS:-4}"
+ACTIX_WORKERS_VALUE="${BENCH_ACTIX_WORKERS:-}"
 KRUDA_READ_BUF_SIZE_VALUE="${KRUDA_READ_BUF_SIZE:-}"
 KRUDA_POOL_SIZE_VALUE="${KRUDA_POOL_SIZE:-}"
 BENCH_ENABLE_DB_VALUE="${BENCH_ENABLE_DB:-0}"
@@ -173,6 +174,7 @@ write_environment() {
     echo "kruda_go_tags=${KRUDA_GO_TAGS_VALUE:-default}"
     echo "gomaxprocs=$GOMAXPROCS_VALUE"
     echo "kruda_workers=$KRUDA_WORKERS_VALUE"
+    echo "actix_workers=${ACTIX_WORKERS_VALUE:-default}"
     echo "kruda_read_buf_size=${KRUDA_READ_BUF_SIZE_VALUE:-default}"
     echo "kruda_pool_size=${KRUDA_POOL_SIZE_VALUE:-default}"
     echo "bench_duration=$BENCH_DURATION_VALUE"
@@ -249,7 +251,8 @@ start_server() {
     actix)
       (
         cd "$SCRIPT_DIR/actix"
-        env PORT="$port" BENCH_ENABLE_DB="$BENCH_ENABLE_DB_VALUE" DATABASE_URL="$ACTIX_DATABASE_URL_VALUE" \
+        env PORT="$port" BENCH_ENABLE_DB="$BENCH_ENABLE_DB_VALUE" BENCH_ACTIX_WORKERS="$ACTIX_WORKERS_VALUE" \
+          DATABASE_URL="$ACTIX_DATABASE_URL_VALUE" \
           ./target/release/actix-bench
       ) > "$log" 2>&1 &
       ;;

--- a/bench/reproducible/syscall-profile.sh
+++ b/bench/reproducible/syscall-profile.sh
@@ -32,6 +32,7 @@ WRK_THREADS="${WRK_THREADS:-4}"
 WRK_CONNECTIONS="${WRK_CONNECTIONS:-256}"
 GOMAXPROCS_VALUE="${GOMAXPROCS:-8}"
 KRUDA_WORKERS_VALUE="${KRUDA_WORKERS:-4}"
+ACTIX_WORKERS_VALUE="${BENCH_ACTIX_WORKERS:-}"
 KRUDA_READ_BUF_SIZE_VALUE="${KRUDA_READ_BUF_SIZE:-4096}"
 BENCH_ENABLE_DB_VALUE="${BENCH_ENABLE_DB:-0}"
 KRUDA_GO_TAGS_VALUE="${KRUDA_GO_TAGS-kruda_stdjson}"
@@ -146,6 +147,7 @@ write_environment() {
     echo "profile_sudo=$PROFILE_SUDO"
     echo "gomaxprocs=$GOMAXPROCS_VALUE"
     echo "kruda_workers=$KRUDA_WORKERS_VALUE"
+    echo "actix_workers=${ACTIX_WORKERS_VALUE:-default}"
     echo "kruda_read_buf_size=$KRUDA_READ_BUF_SIZE_VALUE"
     echo "bench_enable_db=$BENCH_ENABLE_DB_VALUE"
     echo "kruda_go_tags=${KRUDA_GO_TAGS_VALUE:-default}"
@@ -198,7 +200,7 @@ start_server() {
     actix)
       (
         cd "$SCRIPT_DIR/actix"
-        env PORT="$port" BENCH_ENABLE_DB="$BENCH_ENABLE_DB_VALUE" "$bin"
+        env PORT="$port" BENCH_ENABLE_DB="$BENCH_ENABLE_DB_VALUE" BENCH_ACTIX_WORKERS="$ACTIX_WORKERS_VALUE" "$bin"
       ) > "$log" 2>&1 &
       ;;
   esac


### PR DESCRIPTION
## Summary
- add an optional BENCH_ACTIX_WORKERS control to the reproducible Actix benchmark app
- record actix_workers in throughput, resource, pipeline, and syscall harness environment output
- document the knob as a methodology control while preserving Actix default behavior when unset

## Verification
- bash -n bench/reproducible/bench.sh bench/reproducible/resource.sh bench/reproducible/pipeline.sh bench/reproducible/pipeline-syscall.sh bench/reproducible/syscall-profile.sh
- cargo +stable fmt --check
- cargo +stable build --release --locked
- PORT=3993 BENCH_ACTIX_WORKERS=1 ./target/release/actix-bench smoke tested with /plaintext-handler