### PR TITLE
ci: pin Windows test runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: ['1.25.10', 'stable']
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-2025]
 
     steps:
       - name: Checkout code
@@ -54,7 +54,7 @@ jobs:
           go test -v -race -tags kruda_stdjson $COVER_FLAG ./...
 
       - name: Test Wing alias module (Linux/macOS)
-        if: matrix.os != 'windows-latest'
+        if: runner.os != 'Windows'
         # Wing alias module's go.mod requires kruda at the new tag version, which
         # doesn't exist on the proxy until release. For PR CI we add a local
         # replace so tests can resolve kruda from the working tree. The replace


### PR DESCRIPTION
## Summary
- pin the Windows test matrix to the explicit windows-2025 runner label
- make the Wing alias module skip condition use runner.os instead of a Windows label string
- remove the windows-latest redirect notice from test evidence while keeping Linux/macOS behavior unchanged

## Source
- GitHub-hosted runner reference lists windows-2025 as a standard Windows runner label: https://docs.github.com/en/actions/reference/runners/github-hosted-runners

## Verification
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/test.yml'); puts 'yaml-ok'"
- git diff --check