### PR TITLE
bench: add non-pipelined syscall ratios

### DIFF
--- a/bench/reproducible/README.md
+++ b/bench/reproducible/README.md
@@ -292,6 +292,16 @@ Pipelined diagnostic results are written to
 | `summary.md` | Markdown table for diagnostic evidence |
 | `raw/*.txt` | Raw `pipeline-client` output and server logs |
 
+Non-pipelined syscall diagnostic results are written to
+`bench/reproducible/results/syscall-<timestamp>/`:
+
+| File | Purpose |
+|------|---------|
+| `environment.txt` | Git commit/dirty state, CPU, OS, toolchain, route, worker, perf, and strace metadata |
+| `summary.csv` | Machine-readable requests, latency, socket errors, perf counters, syscall counts, requests-per-syscall ratios, and per-1k-request syscall ratios |
+| `summary.md` | Markdown table for diagnostic CPU and I/O evidence |
+| `raw/*.txt` | Raw `wrk --latency`, `perf stat`, `strace -c`, server, attach, and status logs |
+
 Pipelined syscall diagnostic results are written to
 `bench/reproducible/results/pipeline-syscall-<timestamp>/`:
 

--- a/bench/reproducible/results/2026-06-07-nonpipelined-syscall-ratio-evidence.md
+++ b/bench/reproducible/results/2026-06-07-nonpipelined-syscall-ratio-evidence.md
@@ -1,0 +1,101 @@
+# Non-Pipelined Syscall Ratio Evidence
+
+Date: 2026-06-07
+Host: tiger Linux dev server (`tiger-linux`)
+Commit: `7d30d7b` (`bench: add non-pipelined syscall ratios`)
+Scope: Diagnostic harness output only. This change does not alter Kruda
+runtime behavior.
+
+## Local Verification
+
+- `bash -n bench/reproducible/syscall-profile.sh`
+- `git diff --check`
+- Extracted the embedded `summarize` Python block and ran it against
+  `bench/reproducible/results/phase5-default-syscall-sudo-20260528T025554Z`.
+  The generated CSV and Markdown included request counts, requests-per-syscall
+  ratios, and per-1k-request syscall ratios.
+
+## Command
+
+```bash
+cd /home/tiger/kruda-nonpipelined-syscall-ratios-20260607T133743Z/bench/reproducible
+export PATH="$HOME/.cargo/bin:/usr/local/go/bin:$PATH"
+GOTOOLCHAIN=go1.25.10 \
+RESULT_DIR=results/nonpipelined-syscall-ratio-json-serialize-20260607T133830Z \
+PROFILE_DURATION=8s \
+WARMUP_DURATION=2s \
+WRK_CONNECTIONS=256 \
+PROFILE_SUDO=1 \
+PERF_EVENTS=task-clock,context-switches,cpu-migrations,page-faults \
+KRUDA_PORT=3261 \
+ACTIX_PORT=3263 \
+./syscall-profile.sh json-serialize
+```
+
+## Environment
+
+- Result directory:
+  `/home/tiger/kruda-nonpipelined-syscall-ratios-20260607T133743Z/bench/reproducible/results/nonpipelined-syscall-ratio-json-serialize-20260607T133830Z`
+- Git commit: `7d30d7b`
+- Git tracked dirty: `0`
+- CPU: `13th Gen Intel(R) Core(TM) i5-13500`, 8 logical CPUs
+- OS/kernel: Linux `6.8.0-117-generic`
+- Go: `go1.25.10 linux/amd64`
+- Rust: `rustc 1.93.1`
+- Cargo: `cargo 1.93.1`
+- wrk: `debian/4.1.0-4build2 [epoll]`
+- perf: `6.8.12`
+- strace: `6.8`
+- `profile_duration=8s`
+- `warmup_duration=2s`
+- `wrk_threads=4`
+- `wrk_connections=256`
+- `profile_sudo=1`
+- `perf_event_paranoid=4`
+- `ptrace_scope=1`
+- `gomaxprocs=8`
+- `kruda_workers=4`
+- `actix_workers=default`
+- `kruda_read_buf_size=4096`
+- `kruda_go_tags=kruda_stdjson`
+- `routes=json-serialize`
+
+## Summary
+
+Perf rows are the comparable wrk pass. Strace rows are intrusive syscall-count
+diagnostics; use their syscall counts and ratios, not their RPS or latency, for
+I/O architecture conclusions.
+
+| Framework | Route | Kind | Requests | RPS | p99 | Socket errors | Non-2xx | read/recv | write/send | req/read | req/write | epoll wait | epoll wait/1k req | epoll_ctl | epoll_ctl/1k req | futex | futex/1k req | context switches |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| actix | json-serialize | perf | 6009861 | 741883.78 | 3.13ms | 0 | 0 |  |  |  |  |  |  |  |  |  |  | 673640 |
+| actix | json-serialize | strace | 722415 | 90106.61 | 3.98ms | 0 | 0 | 722776 | 722948 | 1.00 | 1.00 | 22877 | 31.67 | 362 | 0.50 |  |  |  |
+| kruda | json-serialize | perf | 7016971 | 866299.88 | 698.00us | 0 | 0 |  |  |  |  |  |  |  |  |  |  | 329440 |
+| kruda | json-serialize | strace | 548190 | 68404.26 | 1.29s | 13 | 0 | 552165 | 548441 | 0.99 | 1.00 | 683 | 1.25 | 771 | 1.41 | 12833 | 23.41 |  |
+
+Status files:
+
+- `actix-json-serialize-perf-status.txt`: `wrk_status=0`, `perf_status=0`
+- `actix-json-serialize-strace-status.txt`: `wrk_status=0`, `strace_status=130`
+- `kruda-json-serialize-perf-status.txt`: `wrk_status=0`, `perf_status=0`
+- `kruda-json-serialize-strace-status.txt`: `wrk_status=0`, `strace_status=130`
+
+`strace_status=130` is expected because the harness stops strace with SIGINT
+after the measured wrk run.
+
+## Interpretation
+
+The updated `syscall-profile.sh` emits request counts and syscall-shape ratios
+for the non-pipelined diagnostic harness. This makes future I/O profile
+candidates comparable without manual ratio math.
+
+The comparable perf pass stayed healthy on this smoke route: Kruda completed
+`json-serialize` at 866,299.88 RPS with 698.00us p99 and zero socket errors or
+non-2xx responses; Actix completed the same pass at 741,883.78 RPS with 3.13ms
+p99 and zero socket errors or non-2xx responses.
+
+The intrusive strace pass shows both frameworks near one request per
+write/send syscall on the non-pipelined `json-serialize` route. Kruda showed
+far fewer epoll waits per 1k requests in this diagnostic row, while the strace
+pass itself introduced 13 Kruda socket errors; that straced row should not be
+used for throughput or tail-latency claims.

--- a/bench/reproducible/syscall-profile.sh
+++ b/bench/reproducible/syscall-profile.sh
@@ -306,7 +306,9 @@ def parse_wrk(path):
     errors = re.search(r"Socket errors: connect (\d+), read (\d+), write (\d+), timeout (\d+)", text)
     non2xx = re.search(r"Non-2xx or 3xx responses: (\d+)", text)
     rps = re.search(r"Requests/sec:\s+([0-9.]+)", text)
+    requests = re.search(r"(\d+) requests in", text)
     return {
+        "requests": int(requests.group(1)) if requests else 0,
         "rps": float(rps.group(1)) if rps else 0.0,
         "p50": latency_pct("50"),
         "p90": latency_pct("90"),
@@ -338,6 +340,12 @@ def parse_strace(path):
             calls[cols[-1]] = cols[3]
     return calls
 
+def int_value(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
 def sum_calls(calls, names):
     total = 0
     seen = False
@@ -347,6 +355,14 @@ def sum_calls(calls, names):
             total += int(calls[name])
     return str(total) if seen else ""
 
+def requests_per_syscall(requests, calls):
+    calls = int_value(calls)
+    return f"{requests / calls:.2f}" if requests and calls else ""
+
+def calls_per_1k_requests(calls, requests):
+    calls = int_value(calls)
+    return f"{calls / requests * 1000.0:.2f}" if requests and calls else ""
+
 rows = []
 for wrk in sorted((root / "raw").glob("*-wrk.txt")):
     stem = wrk.name[:-len("-wrk.txt")]
@@ -355,6 +371,11 @@ for wrk in sorted((root / "raw").glob("*-wrk.txt")):
     data = parse_wrk(wrk)
     perf = parse_perf(root / "raw" / f"{fw}-{route}-perf-perf.csv") if kind == "perf" else {}
     strace = parse_strace(root / "raw" / f"{fw}-{route}-strace-strace.txt") if kind == "strace" else {}
+    read_recv_calls = sum_calls(strace, ("read", "readv", "recvfrom", "recvmsg"))
+    write_send_calls = sum_calls(strace, ("write", "writev", "sendto", "sendmsg"))
+    epoll_wait_calls = sum_calls(strace, ("epoll_wait", "epoll_pwait", "epoll_pwait2"))
+    epoll_ctl_calls = strace.get("epoll_ctl", "")
+    futex_calls = strace.get("futex", "")
     rows.append({
         "framework": fw,
         "route": route,
@@ -364,18 +385,25 @@ for wrk in sorted((root / "raw").glob("*-wrk.txt")):
         "instructions": perf.get("instructions", ""),
         "task_clock": perf.get("task-clock", ""),
         "context_switches": perf.get("context-switches", ""),
-        "read_recv_calls": sum_calls(strace, ("read", "readv", "recvfrom", "recvmsg")),
-        "write_send_calls": sum_calls(strace, ("write", "writev", "sendto", "sendmsg")),
-        "epoll_wait_calls": sum_calls(strace, ("epoll_wait", "epoll_pwait", "epoll_pwait2")),
-        "epoll_ctl_calls": strace.get("epoll_ctl", ""),
-        "futex_calls": strace.get("futex", ""),
+        "read_recv_calls": read_recv_calls,
+        "write_send_calls": write_send_calls,
+        "requests_per_read_recv": requests_per_syscall(data["requests"], read_recv_calls),
+        "requests_per_write_send": requests_per_syscall(data["requests"], write_send_calls),
+        "epoll_wait_calls": epoll_wait_calls,
+        "epoll_wait_per_1k_requests": calls_per_1k_requests(epoll_wait_calls, data["requests"]),
+        "epoll_ctl_calls": epoll_ctl_calls,
+        "epoll_ctl_per_1k_requests": calls_per_1k_requests(epoll_ctl_calls, data["requests"]),
+        "futex_calls": futex_calls,
+        "futex_per_1k_requests": calls_per_1k_requests(futex_calls, data["requests"]),
     })
 
 headers = [
-    "framework", "route", "kind", "rps", "p50", "p90", "p99", "max",
+    "framework", "route", "kind", "requests", "rps", "p50", "p90", "p99", "max",
     "socket_errors", "non2xx", "cycles", "instructions", "task_clock",
-    "context_switches", "read_recv_calls", "write_send_calls", "epoll_wait_calls",
-    "epoll_ctl_calls", "futex_calls",
+    "context_switches", "read_recv_calls", "write_send_calls",
+    "requests_per_read_recv", "requests_per_write_send", "epoll_wait_calls",
+    "epoll_wait_per_1k_requests", "epoll_ctl_calls", "epoll_ctl_per_1k_requests",
+    "futex_calls", "futex_per_1k_requests",
 ]
 csv_path.write_text(",".join(headers) + "\n" + "\n".join(
     ",".join(str(r.get(h, "")) for h in headers) for r in rows
@@ -386,14 +414,17 @@ lines = [
     "",
     "Perf rows are the comparable wrk pass. Strace rows are intrusive syscall-count diagnostics; use their syscall counts, not their RPS or latency, for performance conclusions. A strace status of 130 is expected because the harness stops strace with SIGINT after the measured wrk run.",
     "",
-    "| Framework | Route | Kind | RPS | p99 | Socket errors | Non-2xx | read/recv | write/send | epoll wait | epoll_ctl | futex | cycles | instructions | context switches |",
-    "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+    "| Framework | Route | Kind | Requests | RPS | p99 | Socket errors | Non-2xx | read/recv | write/send | req/read | req/write | epoll wait | epoll wait/1k req | epoll_ctl | epoll_ctl/1k req | futex | futex/1k req | cycles | instructions | context switches |",
+    "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
 ]
 for r in rows:
     lines.append(
-        f"| {r['framework']} | {r['route']} | {r['kind']} | {r['rps']:.2f} | {r['p99']} | "
+        f"| {r['framework']} | {r['route']} | {r['kind']} | {r['requests']} | {r['rps']:.2f} | {r['p99']} | "
         f"{r['socket_errors']} | {r['non2xx']} | {r['read_recv_calls']} | {r['write_send_calls']} | "
-        f"{r['epoll_wait_calls']} | {r['epoll_ctl_calls']} | {r['futex_calls']} | "
+        f"{r['requests_per_read_recv']} | {r['requests_per_write_send']} | "
+        f"{r['epoll_wait_calls']} | {r['epoll_wait_per_1k_requests']} | "
+        f"{r['epoll_ctl_calls']} | {r['epoll_ctl_per_1k_requests']} | "
+        f"{r['futex_calls']} | {r['futex_per_1k_requests']} | "
         f"{r['cycles']} | {r['instructions']} | {r['context_switches']} |"
     )
 md_path.write_text("\n".join(lines) + "\n")


### PR DESCRIPTION
## Summary

- Add total request counts to `bench/reproducible/syscall-profile.sh` summaries.
- Add non-pipelined syscall-shape ratios: requests per read/recv, requests per write/send, and epoll/futex calls per 1k requests.
- Document the new `results/syscall-*` output shape and add tiger evidence for the updated diagnostic output.

## Evidence

Local:

- `bash -n bench/reproducible/syscall-profile.sh`
- `git diff --check`
- Extracted the embedded `summarize` Python block and ran it against an existing syscall-profile result directory; generated CSV/Markdown included the new columns.

Tiger smoke:

```bash
cd /home/tiger/kruda-nonpipelined-syscall-ratios-20260607T133743Z/bench/reproducible
export PATH="$HOME/.cargo/bin:/usr/local/go/bin:$PATH"
GOTOOLCHAIN=go1.25.10 \
RESULT_DIR=results/nonpipelined-syscall-ratio-json-serialize-20260607T133830Z \
PROFILE_DURATION=8s \
WARMUP_DURATION=2s \
WRK_CONNECTIONS=256 \
PROFILE_SUDO=1 \
PERF_EVENTS=task-clock,context-switches,cpu-migrations,page-faults \
KRUDA_PORT=3261 \
ACTIX_PORT=3263 \
./syscall-profile.sh json-serialize
```

Result:

- `json-serialize`: Kruda perf pass 866,299.88 RPS, p99 698.00us, zero socket errors, zero non-2xx.
- `json-serialize`: Actix perf pass 741,883.78 RPS, p99 3.13ms, zero socket errors, zero non-2xx.
- Strace rows now show the new ratios; both frameworks were near one request per write/send syscall on this non-pipelined route.
- `strace_status=130` was expected because the harness stops strace with SIGINT after wrk completes.

Full note: `bench/reproducible/results/2026-06-07-nonpipelined-syscall-ratio-evidence.md`.
