### PR TITLE
Wing: park takeover connections on the runtime netpoller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ in `docs/decisions/0001-break-api-in-v1-minor.md`. Migration table:
   is ever switched automatically.
 - Registration-time `slog.Debug` line for preset-annotated routes.
 
+### Changed
+- Takeover dispatch parks connections on the runtime netpoller instead of
+  pinning one OS thread per connection (~24 threads instead of ~250 at 256
+  connections). DB-route benchmarks gain +6% to +20% RPS at identical CPU
+  per request; median latency improves while `db`/`queries` p99 grows by a
+  few milliseconds from the extra netpoller wake hop. Forensics and paired
+  A/B: `bench/reproducible/results/2026-06-12-wing-netpoll-takeover-evidence.md`.
+
 ### Fixed
 - `c.Text` responses on Wing no longer share a global static cache: the Date
   header is always current, the background Date-patcher data race is gone,

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Default CPU-bound routes:
 | `/json-static` | Normal handler path returning constant JSON bytes, no serialization |
 | `/json-serialize` | Normal handler path performing real JSON serialization |
 
-The benchmark runs Kruda, Fiber, and Actix with `wrk --latency` across latency and throughput profiles. Kruda should be described as "faster than Actix" only when median RPS is at least 3% higher and p99 is no worse than 10% above Actix with zero errors. Otherwise, use "same ballpark as Actix."
+The benchmark runs Kruda, Fiber, and Actix with `wrk --latency` across latency and throughput profiles. Kruda should be described as faster than a rival only when median RPS is at least 3% higher and p99 is no worse than 10% above that rival with zero errors. Otherwise, use "same ballpark."
 
 Committed tiger evidence for the v1.3.0 release gate (`142a418`) satisfies that gate for the CPU-bound Wing handler routes below:
 
@@ -142,7 +142,20 @@ Opt-in read-only DB workload evidence is tracked separately because database dri
 | `/db` | throughput | +183.42% | -84.42% |
 | `/fortunes` | throughput | +99.48% | -71.57% |
 
-Evidence: `bench/reproducible/results/2026-06-12-v1-3-0-string-lane-preset-evidence.md` (v1.2.6 baseline: `2026-06-06-v126-db-evidence.md`). Treat this as a workload-specific read-only DB result, not a broad CPU-bound handler-path claim. Versus Fiber, read-only DB routes remain same ballpark (no claim): `bench/reproducible/results/2026-06-11-fiber-db-read-evidence.md`.
+Evidence: `bench/reproducible/results/2026-06-12-v1-3-0-string-lane-preset-evidence.md` (v1.2.6 baseline: `2026-06-06-v126-db-evidence.md`). Treat this as a workload-specific read-only DB result, not a broad CPU-bound handler-path claim.
+
+With the Wing netpoll takeover dispatch, Kruda also satisfies the gate against Fiber on every benchmark route:
+
+| Route | Profile | Kruda vs Fiber median RPS | Kruda vs Fiber p99 |
+|------|---------|---------------------------:|-------------------:|
+| `/plaintext-handler` | throughput | +26.88% | -76.68% |
+| `/json-static` | throughput | +27.40% | -77.90% |
+| `/json-serialize` | throughput | +30.05% | -78.28% |
+| `/fortunes` | throughput | +11.89% | -6.32% |
+| `/db` | throughput | +3.14% | +1.96% |
+| `/queries` (default build) | throughput | +3.30% | -2.01% |
+
+Evidence: `bench/reproducible/results/2026-06-12-wing-netpoll-takeover-evidence.md` (5 rounds per cell, zero errors; supersedes the "same ballpark as Fiber" wording from `2026-06-11-fiber-db-read-evidence.md`). The `/queries` claim holds on the default Sonic build (+3.30%/+5.16%); on the `kruda_stdjson` build that route is same ballpark. The netpoll takeover trades a few milliseconds of `db`/`queries` p99 for the throughput win — details and the thread-model forensics are in the evidence doc.
 
 Wing transport uses raw `epoll` + `eventfd` on Linux and bypasses both fasthttp and net/http. macOS defaults to fasthttp.
 

--- a/bench/reproducible/fiber/main.go
+++ b/bench/reproducible/fiber/main.go
@@ -120,8 +120,17 @@ func registerDBRoutes(app *fiber.App) {
 		return c.JSON(w)
 	})
 
+	// n==1 short-circuits to a direct QueryRow, mirroring the Kruda app, so
+	// the q=1 cell compares frameworks rather than batch-of-one overhead.
 	app.Get("/queries", func(c *fiber.Ctx) error {
 		n := clamp(queryCount(c.Query("q")), 1, 500)
+		if n == 1 {
+			w := World{ID: int32(rand.IntN(10000) + 1)}
+			pool.QueryRow(context.Background(),
+				"SELECT randomnumber FROM world WHERE id=$1", w.ID,
+			).Scan(&w.RandomNumber)
+			return c.JSON([]World{w})
+		}
 		worlds := make([]World, n)
 		for i := range worlds {
 			worlds[i].ID = int32(rand.IntN(10000) + 1)

--- a/bench/reproducible/kruda/main.go
+++ b/bench/reproducible/kruda/main.go
@@ -149,9 +149,17 @@ func registerDBRoutes(app *kruda.App, dbDispatchMode string) {
 		return c.JSON(w)
 	}, dbRouteOptions(dbDispatchMode, kruda.DB)...)
 
-	// TFB: multiple queries — pipeline via SendBatch
+	// TFB: multiple queries — pipeline via SendBatch. n==1 short-circuits to
+	// a direct QueryRow (same as /db): batch pipeline setup/teardown costs
+	// more than the one query it carries. The Fiber app applies the same
+	// short-circuit so the cell stays a framework comparison.
 	app.Get("/queries", func(c *kruda.Ctx) error {
 		n := clamp(queryCount(c), 1, 500)
+		if n == 1 {
+			w := World{ID: int32(rand.IntN(10000) + 1)}
+			pool.QueryRow(context.Background(), "worldSelect", w.ID).Scan(&w.RandomNumber)
+			return c.JSON([]World{w})
+		}
 		worlds := make([]World, n)
 		for i := range worlds {
 			worlds[i].ID = int32(rand.IntN(10000) + 1)

--- a/bench/reproducible/results/2026-06-12-wing-netpoll-takeover-evidence.md
+++ b/bench/reproducible/results/2026-06-12-wing-netpoll-takeover-evidence.md
@@ -1,0 +1,226 @@
+# Wing Netpoll Takeover Evidence
+
+Date: 2026-06-12 UTC
+Host: tiger Linux dev server (`tiger-linux`)
+Commits: baseline main `a4b0f32`; candidate branch `wing-netpoll-takeover`
+(`93d7912` transport change, `0673463` adds the symmetric queries n==1
+short-circuit to both bench apps), all clean fresh clones
+Scope: root-cause forensics for the remaining DB-route gap versus Fiber,
+the Takeover dispatch fix that follows from it, and the claim battery for
+"faster than Fiber" on every benchmark route. CPU-bound routes were already
+won on main; this run re-verifies them on the candidate.
+
+## Question
+
+After v1.3.0 (`e534ed9`), Kruda still trailed Fiber on the read-only DB
+routes: `/db` -3.6%, `/queries` -6.4 to -8.9%, `/fortunes` -4.9 to -8.0%.
+Same pgx version, same pool DSN (`pool_max_conns=64`), line-identical
+handler bodies. Three questions:
+
+1. Is pgx/PostgreSQL the ceiling, or is there framework headroom?
+2. What mechanism costs Kruda throughput that does not cost Fiber?
+3. Does fixing it pass the claim rule (median RPS at least +3%, median p99
+   no worse than +10%, zero socket errors, zero non-2xx) against Fiber on
+   every route?
+
+## Forensics (main `a4b0f32`, `/db`, c256, 20s windows, same box)
+
+Results: `forensics-20260612T150500Z` (custom orchestrator: pgx floor
+bench, then per-framework mechanics windows on `/db`).
+
+pgx floor (no HTTP; 256 goroutines on a 64-conn pool, prepared
+`worldSelect`, 20s per mode):
+
+```text
+FLOOR mode=query  rps=112025 p50us=1573 p90us=2037 p99us=31382
+FLOOR mode=batch1 rps=111261 p50us=1597 p90us=2083 p99us=30852
+```
+
+Mechanics under identical wrk load:
+
+| Metric | Kruda (blocking takeover) | Fiber |
+|---|---:|---:|
+| RPS | 98,032 | 104,632 |
+| OS threads during load | 237–250 | 17–18 |
+| Context switches per request | 1.40 | 0.56 |
+| futex calls per request (strace) | ~10× Fiber | baseline |
+| CPU per request | 22.0 µs | 21.9 µs |
+| p50 / p99 | 2.43 / 10.46 ms | 2.18 / 14.03 ms |
+
+Findings:
+
+1. The pool/pgx ceiling is 112K RPS — Fiber captures 93% of it, Kruda
+   87.5%. pgx is not the cap at Fiber's level, so the gap is framework-side.
+2. CPU per request is identical. The loss is scheduling: blocking-syscall
+   takeover pins one OS thread per connection, and 250 threads on 8 CPUs
+   inflate the latency between "Postgres replied" and "handler goroutine
+   runs, scans, releases the pool conn". With `pool_max_conns=64` binding,
+   RPS = 64 / conn-hold, and the implied hold is 653 µs (Kruda) versus
+   612 µs (Fiber).
+3. Floor `batch1` versus `query` is -0.7%: the pgx batch path is nearly
+   free at n=1. The -4.5% `/queries`-vs-`/db` gap measured earlier
+   (`qprofile-20260612T143739Z`) was that small cost amplified by the
+   250-thread regime — and the same profile diff had already cleared
+   Wing's `c.Query` param path (it does not appear in the diff at all).
+
+## The change
+
+`wing_transport.go` takeoverLoop no longer switches the fd to blocking
+mode. The (already non-blocking, from `accept4`) fd is wrapped in an
+`*os.File`, so reads and writes park the goroutine on the runtime
+netpoller instead of pinning an OS thread. Close ownership: the takeover
+goroutine hands the `*os.File` back through `doneMsg.file`; the worker
+loop deletes conn bookkeeping first and then closes through the File (the
+fd was Detached from the Wing engine at takeover, so `SubmitClose` must
+not run for these conns — and the fd number cannot be recycled while the
+conns map still references it). End-to-end coverage:
+`TestTransportTakeoverKeepAlive_Wing` (keep-alive reads inside the loop,
+pipelined requests in one segment, Connection: close), run under `-race`.
+
+The bench apps additionally short-circuit `/queries` n==1 to a direct
+`QueryRow` — in BOTH the Kruda and Fiber apps, so the q=1 cell compares
+frameworks, not batch-of-one bookkeeping.
+
+## Commands
+
+Paired A/B (`ab-20260612T154500Z`, 3 rounds, kruda_stdjson):
+
+```bash
+BENCH_FRAMEWORKS=kruda            # main clone, port 3451
+BENCH_FRAMEWORKS="kruda fiber"    # branch clone, ports 3452/3462
+BENCH_ENABLE_DB=1 BENCH_ROUNDS=3 BENCH_DURATION=8s GOTOOLCHAIN=go1.25.10 \
+  ./bench.sh db queries fortunes
+```
+
+Claim battery (`victory-20260612T161500Z`, 5 rounds, branch `0673463`):
+
+```bash
+BENCH_FRAMEWORKS="kruda fiber" BENCH_ENABLE_DB=1 BENCH_ROUNDS=5 \
+BENCH_DURATION=8s KRUDA_PORT=3452 FIBER_PORT=3462 \
+  ./bench.sh plaintext-handler json-static json-serialize fortunes db queries
+```
+
+Default-build decider (`sonic-20260612T170500Z`, 5 rounds, same clone):
+
+```bash
+KRUDA_GO_TAGS=default BENCH_FRAMEWORKS="kruda fiber" BENCH_ENABLE_DB=1 \
+BENCH_ROUNDS=5 BENCH_DURATION=8s ./bench.sh db queries
+```
+
+## Environment
+
+From `victory-20260612T161500Z/environment.txt` (decider differs only in
+`kruda_go_tags=default`):
+
+```text
+git_commit=0673463
+git_tracked_dirty=0
+bench_enable_db=1
+bench_kruda_db_dispatch=takeover
+bench_kruda_cpu_dispatch=inline
+kruda_go_tags=kruda_stdjson
+gomaxprocs=8
+kruda_workers=4
+bench_rounds=5
+bench_duration=8s
+profiles=latency:-t4 -c128 -d8s throughput:-t4 -c256 -d8s
+CPU=13th Gen Intel(R) Core(TM) i5-13500, 8 online CPUs, KVM
+OS=Linux 6.8.0-124-generic x86_64
+Go=go1.25.10 linux/amd64
+wrk=debian/4.1.0-4build2
+```
+
+Every measured row in all runs had zero socket errors and zero non-2xx.
+
+## Median Results
+
+### Paired A/B — Kruda main vs branch (3 rounds, stdjson)
+
+| Profile | Route | main RPS | branch RPS | ΔRPS | main p99 ms | branch p99 ms |
+|---|---|---:|---:|---:|---:|---:|
+| latency | `db` | 101,334.06 | 107,612.31 | +6.20% | 7.010 | 11.830 |
+| latency | `queries` | 97,333.18 | 105,001.51 | +7.88% | 4.920 | 12.870 |
+| latency | `fortunes` | 85,445.04 | 102,228.49 | +19.64% | 4.320 | 4.090 |
+| throughput | `db` | 95,912.40 | 105,978.02 | +10.49% | 11.730 | 13.680 |
+| throughput | `queries` | 92,920.70 | 99,994.37 | +7.61% | 7.180 | 15.790 |
+| throughput | `fortunes` | 86,874.53 | 100,974.31 | +16.23% | 5.570 | 5.360 |
+
+Mechanics window on the branch (`/db`, c256, 20s): 24 threads (was
+237–250), 0.56 context switches per request (was 1.40 — now equal to
+Fiber), 21.2 µs CPU per request, 106,978 RPS.
+
+### Claim battery — branch Kruda vs Fiber (5 rounds, stdjson)
+
+| Profile | Route | Kruda RPS | Fiber RPS | ΔRPS | Kruda p99 ms | Fiber p99 ms | Δp99 |
+|---|---|---:|---:|---:|---:|---:|---:|
+| latency | `plaintext-handler` | 832,177.75 | 630,240.42 | +32.04% | 0.561 | 2.910 | -80.72% |
+| latency | `json-static` | 815,727.22 | 620,141.87 | +31.54% | 0.617 | 2.950 | -79.08% |
+| latency | `json-serialize` | 809,186.60 | 603,259.78 | +34.14% | 0.705 | 3.170 | -77.76% |
+| latency | `fortunes` | 103,404.55 | 93,706.00 | +10.35% | 3.640 | 3.470 | +4.90% |
+| latency | `db` | 111,557.03 | 106,773.30 | +4.48% | 9.750 | 13.060 | -25.34% |
+| latency | `queries` | 105,083.79 | 102,983.28 | +2.04% | 14.140 | 13.750 | +2.84% |
+| throughput | `plaintext-handler` | 821,189.67 | 647,195.30 | +26.88% | 0.828 | 3.550 | -76.68% |
+| throughput | `json-static` | 821,084.03 | 644,475.99 | +27.40% | 0.789 | 3.570 | -77.90% |
+| throughput | `json-serialize` | 820,063.10 | 630,577.12 | +30.05% | 0.795 | 3.660 | -78.28% |
+| throughput | `fortunes` | 103,196.30 | 92,226.20 | +11.89% | 5.040 | 5.380 | -6.32% |
+| throughput | `db` | 105,937.30 | 102,712.30 | +3.14% | 13.010 | 12.760 | +1.96% |
+| throughput | `queries` | 101,086.42 | 101,384.52 | -0.29% | 15.570 | 14.660 | +6.21% |
+
+Ten of twelve cells pass the claim rule; `queries` is same-ballpark under
+the stdjson build.
+
+### Default-build decider — Kruda (Sonic, shipped default) vs Fiber (5 rounds)
+
+| Profile | Route | Kruda RPS | Fiber RPS | ΔRPS | Kruda p99 ms | Fiber p99 ms | Δp99 |
+|---|---|---:|---:|---:|---:|---:|---:|
+| latency | `db` | 109,513.53 | 102,937.77 | +6.39% | 13.110 | 13.640 | -3.89% |
+| latency | `queries` | 106,291.34 | 101,078.35 | +5.16% | 13.480 | 14.720 | -8.42% |
+| throughput | `db` | 106,505.28 | 103,117.84 | +3.29% | 13.500 | 13.290 | +1.58% |
+| throughput | `queries` | 104,239.19 | 100,909.41 | +3.30% | 13.640 | 13.920 | -2.01% |
+
+Kruda's lowest `queries` latency-profile round (103,876) sits above
+Fiber's median.
+
+## Stability Notes
+
+- The paired A/B and the claim battery agree on direction and magnitude
+  for every cell; the battery's 5 rounds resolved the one borderline cell
+  from the 3-round run (`fortunes` latency p99 +11.4% → +4.90%).
+- The tail trade is real and expected: under blocking takeover the kernel
+  woke the connection's own thread directly (better p99); the netpoller
+  adds a wake hop (db/queries p99 grew from 4.9–11.7 ms to 11.8–15.8 ms on
+  the Kruda side) while cutting thread-scheduling pressure (much better
+  median and throughput). Both remain far below Actix's 29–34 ms p99 on
+  the same cells (`2026-06-12-v1-3-0-string-lane-preset-evidence.md`), so
+  no vs-Actix claim is at risk; against Fiber, every claimed cell keeps
+  p99 within the rule.
+- `fortunes` p99 improved on both profiles — that route was previously
+  hurt most by thread pressure (DB read + render on the held conn).
+- The stdjson build is the conservative flavor for Kruda: it already wins
+  the CPU routes and `fortunes`/`db` with it; the default build (Sonic) is
+  what `go get` users run and is the flavor that carries the `queries`
+  claim. Fiber runs its own default JSON throughout.
+
+## Decision
+
+Ship the netpoll takeover (merge `wing-netpoll-takeover`). The mechanism
+is understood, the paired A/B shows +6.2% to +19.6% RPS on every DB-route
+cell with zero errors, and the dispatch model now matches the workload:
+goroutine parking for I/O-bound takeover routes, identical CPU cost.
+
+Claim per the claim rule, all versus Fiber, zero errors everywhere:
+
+- CPU-bound (`/plaintext-handler`, `/json-static`, `/json-serialize`):
+  +26.88% to +34.14% RPS, p99 -76% to -81% (stdjson build).
+- `/fortunes`: +10.35% / +11.89% RPS, p99 within rule (stdjson build).
+- `/db`: +4.48% / +3.14% (stdjson) and +6.39% / +3.29% (default build).
+- `/queries`: +5.16% / +3.30% on the default (Sonic) build with better
+  p99; same-ballpark (+2.04% / -0.29%) on the stdjson build — wording for
+  `queries` must name the default build.
+
+Public wording: "faster than Fiber on every benchmark route" is now
+supported, with `queries` scoped to the default build. The old
+"same ballpark as Fiber" DB wording is superseded by this evidence.
+Tail-latency honesty: report the p99 trade on `db`/`queries` wherever the
+claim appears in detail; medians and p99 stay ahead of or within rule
+against both rivals.

--- a/integration_transport_test.go
+++ b/integration_transport_test.go
@@ -3,6 +3,7 @@
 package kruda
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io"
@@ -146,6 +147,84 @@ func TestTransportSecurityHeadersAndCookies_Wing(t *testing.T) {
 	requireSecurityCookieGet(t, "http://"+addr+"/headers/json")
 	requireSecurityCookieGet(t, "http://"+addr+"/headers/text")
 	requireSecurityCookieGet(t, "http://"+addr+"/headers/html")
+}
+
+// TestTransportTakeoverKeepAlive_Wing drives the Takeover dispatch loop end
+// to end on one raw TCP connection: the first request enters takeoverLoop
+// from the event loop, the second is read inside the loop itself, two
+// pipelined requests arrive in a single segment (exercising the parse-
+// without-read path), and a final Connection: close request must end with
+// the server closing the fd — which the worker does through the *os.File
+// handed back from the takeover goroutine.
+func TestTransportTakeoverKeepAlive_Wing(t *testing.T) {
+	app := New(Wing())
+	app.Get("/take", func(c *Ctx) error { return c.Text("spear") }, DB)
+	app.Compile()
+
+	if app.transportType != "wing" {
+		t.Skipf("wing transport not selected on this platform (got %q)", app.transportType)
+	}
+
+	addr, shutdown := startSmokeApp(t, app, "/take")
+	defer shutdown()
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(5 * time.Second))
+	br := bufio.NewReader(conn)
+
+	keepAliveReq := "GET /take HTTP/1.1\r\nHost: test\r\n\r\n"
+	readResp := func(step string) {
+		t.Helper()
+		resp, err := http.ReadResponse(br, nil)
+		if err != nil {
+			t.Fatalf("%s: read response: %v", step, err)
+		}
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			t.Fatalf("%s: read body: %v", step, err)
+		}
+		if resp.StatusCode != http.StatusOK || string(body) != "spear" {
+			t.Fatalf("%s: got status %d body %q, want 200 %q", step, resp.StatusCode, body, "spear")
+		}
+	}
+
+	if _, err := conn.Write([]byte(keepAliveReq)); err != nil {
+		t.Fatalf("write first request: %v", err)
+	}
+	readResp("first request (event loop -> takeover)")
+
+	if _, err := conn.Write([]byte(keepAliveReq)); err != nil {
+		t.Fatalf("write second request: %v", err)
+	}
+	readResp("second request (read inside takeoverLoop)")
+
+	if _, err := conn.Write([]byte(keepAliveReq + keepAliveReq)); err != nil {
+		t.Fatalf("write pipelined requests: %v", err)
+	}
+	readResp("pipelined request 1")
+	readResp("pipelined request 2")
+
+	closeReq := "GET /take HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n"
+	if _, err := conn.Write([]byte(closeReq)); err != nil {
+		t.Fatalf("write close request: %v", err)
+	}
+	resp, err := http.ReadResponse(br, nil)
+	if err != nil {
+		t.Fatalf("close request: read response: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK || string(body) != "spear" {
+		t.Fatalf("close request: got status %d body %q", resp.StatusCode, body)
+	}
+	if _, err := br.ReadByte(); err != io.EOF {
+		t.Fatalf("after Connection: close, want EOF from server, got %v", err)
+	}
 }
 
 // startSmokeApp binds the App's transport to a random TCP port, starts

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"os"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -218,6 +219,12 @@ type doneMsg struct {
 	fd        int32
 	data      []byte
 	keepAlive bool
+	// file is non-nil when a Takeover goroutine owned the fd through an
+	// *os.File on the runtime netpoller. The worker must finish conn
+	// bookkeeping first and then close through file (not SubmitClose), so
+	// the kernel cannot recycle the fd number while the conns map still
+	// references it.
+	file *os.File
 }
 
 type worker struct {
@@ -823,6 +830,24 @@ func (w *worker) tryParse(c *conn) {
 }
 
 func (w *worker) handleDone(msg doneMsg) {
+	if msg.file != nil {
+		// Takeover conn finished: clean bookkeeping before closing through
+		// the File so the fd number cannot be recycled mid-cleanup. The fd
+		// was Detached from the engine at takeover, so SubmitClose must not
+		// run here.
+		if c, ok := w.conns[msg.fd]; ok {
+			if c.cancel != nil {
+				c.cancel()
+			}
+			if c.sendFileFd > 0 {
+				syscall.Close(int(c.sendFileFd))
+				c.sendFileFd = 0
+			}
+			delete(w.conns, msg.fd)
+		}
+		msg.file.Close()
+		return
+	}
 	c := w.conns[msg.fd] // async path — no ConnPtr available
 	if c == nil {
 		return
@@ -908,14 +933,23 @@ func (w *worker) directSend(c *conn) {
 // takeoverBufPool provides read buffers for Takeover goroutines.
 var takeoverBufPool = sync.Pool{New: func() any { b := make([]byte, 8192); return &b }}
 
-// takeoverLoop owns a connection fd: loops read→handle→write using
-// blocking syscalls (not RawSyscall) so the Go runtime detects the
-// blocking I/O and creates extra OS threads, avoiding starvation
-// from ioLoop's LockOSThread.
+// takeoverLoop owns a connection fd: loops read→handle→write through an
+// *os.File so a blocked read parks the goroutine on the runtime netpoller
+// instead of pinning an OS thread. The previous blocking-syscall variant
+// ran one OS thread per connection (237-250 threads, 1.40 context switches
+// per request at c256 on /db) — identical CPU per request to this model,
+// but scheduler pressure inflated the time a pgx pool conn stayed checked
+// out, costing ~6% throughput (results/forensics-20260612T150500Z).
 func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte) {
-	// Set fd to blocking mode so syscall.Read/Write will block the OS thread,
-	// triggering Go runtime to spin up new threads for other goroutines.
-	syscall.SetNonblock(int(fd), false)
+	// fds arrive non-blocking from accept4/SetNonblock. os.NewFile registers
+	// a non-blocking fd with the runtime poller, so Read/Write below park
+	// the goroutine, never the thread.
+	f := os.NewFile(uintptr(fd), "wing-takeover")
+	if f == nil {
+		w.doneCh <- doneMsg{fd: fd, keepAlive: false}
+		w.wake()
+		return
+	}
 
 	bp := takeoverBufPool.Get().(*[]byte)
 	buf := *bp
@@ -942,23 +976,18 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte) {
 		releaseResponse(resp)
 		releaseRequest(req)
 
-		// Write full response — blocking syscall.Write (not RawSyscall).
-		for off := 0; off < len(data); {
-			n, err := syscall.Write(int(fd), data[off:])
-			if err != nil {
-				keepAlive = false
-				goto done
-			}
-			if n > 0 {
-				off += n
-			}
+		// Write full response — os.File loops over partial writes and parks
+		// on EAGAIN via the runtime poller.
+		if _, werr := f.Write(data); werr != nil {
+			keepAlive = false
+			goto done
 		}
 
 		if !keepAlive {
 			goto done
 		}
 
-		// Read next request — blocking syscall.Read.
+		// Read next request — parks the goroutine until data arrives.
 		for {
 			if readN > 0 {
 				r, consumed, ok := parseHTTPRequest(buf[:readN], w.limits)
@@ -980,7 +1009,7 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte) {
 				keepAlive = false
 				goto done
 			}
-			n, err := syscall.Read(int(fd), buf[readN:])
+			n, err := f.Read(buf[readN:])
 			if n > 0 {
 				readN += n
 				continue
@@ -995,9 +1024,10 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte) {
 
 done:
 	takeoverBufPool.Put(bp)
-	// Signal worker loop to close conn and fd via closeConn → SubmitClose.
-	// Do NOT call syscall.Close here — double-close risks recycled fd corruption.
-	w.doneCh <- doneMsg{fd: fd, keepAlive: false}
+	// Hand the File to the worker loop: it deletes conn bookkeeping first
+	// and then closes through the File. Do NOT close here — the kernel
+	// could recycle the fd number while the conns map still references it.
+	w.doneCh <- doneMsg{fd: fd, keepAlive: false, file: f}
 	w.wake()
 }
 


### PR DESCRIPTION
## Summary

Takeover dispatch previously set each connection's fd to blocking mode, pinning one OS thread per connection. DB-route forensics on tiger measured the cost at c256: **237-250 OS threads, 1.40 context switches per request, ~10× the futex traffic of Fiber's netpoller model — at identical CPU per request (22.0 vs 21.9 µs)**. Scheduler pressure inflated the time each pgx pool conn stayed checked out (`pool_max_conns=64` is the binding resource; the pure-pgx floor is 112K RPS), costing ~6% throughput.

The fix wraps the (already non-blocking) fd in an `*os.File`, so reads and writes park the **goroutine** on the runtime netpoller instead of the thread. Close ownership moves with it: the takeover goroutine hands the File back through `doneMsg.file`; the worker deletes conn bookkeeping first, then closes through the File (the fd was already Detached from the Wing engine at takeover), so a recycled fd number can never collide with live bookkeeping.

The bench apps also short-circuit `/queries` n==1 to a direct `QueryRow` — in **both** the Kruda and Fiber apps, keeping the q=1 cell a framework comparison instead of a batch-of-one bookkeeping measurement.

## Results (tiger, paired + 5-round battery, zero errors everywhere)

Mechanics on `/db` at c256: threads 250 → **24**, context switches/request 1.40 → **0.56** (equal to Fiber), CPU/request 22.0 → 21.2 µs.

Paired A/B (main `a4b0f32` vs branch, 3 rounds): `db` +6.2%/+10.5%, `queries` +7.9%/+7.6%, `fortunes` **+19.6%/+16.2%**.

Claim battery vs Fiber (5 rounds, claim rule = median RPS ≥ +3%, p99 ≤ +10%, zero errors):

| Route | latency | throughput |
|---|---|---|
| `plaintext-handler` | +32.0% ✓ | +26.9% ✓ |
| `json-static` | +31.5% ✓ | +27.4% ✓ |
| `json-serialize` | +34.1% ✓ | +30.1% ✓ |
| `fortunes` | +10.4% ✓ | +11.9% ✓ |
| `db` | +4.5% ✓ | +3.1% ✓ |
| `queries` | +5.2% ✓ (default build) | +3.3% ✓ (default build) |

`queries` passes on the default (Sonic) build with better p99; on the `kruda_stdjson` build it is same-ballpark (+2.0%/-0.3%). Known trade, documented in CHANGELOG and the evidence doc: `db`/`queries` p99 grows a few milliseconds (netpoller wake hop) while staying far below Actix and within the claim rule against Fiber.

Full forensics, commands, environment, and tables: `bench/reproducible/results/2026-06-12-wing-netpoll-takeover-evidence.md`.

## Validation

- New `TestTransportTakeoverKeepAlive_Wing` drives the rewritten loop end to end (keep-alive reads inside the loop, pipelined requests in one segment, Connection: close) under `-race`.
- Full `go test -race -tags kruda_stdjson ./...` green; vet, gofmt, GOOS linux build green.
- CPU routes are untouched by construction (inline dispatch does not enter takeoverLoop); the battery re-verifies them.