### PR TITLE
bench: runtime footprint measurement + finding

### DIFF
--- a/bench/reproducible/footprint.sh
+++ b/bench/reproducible/footprint.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Measure Kruda runtime footprint: binary size, startup time, idle RSS.
+#
+# Profiling-only, not a benchmark claim source. Numbers are dominated by the Go
+# runtime and the app's own deps (e.g. pgx); use this to spot framework-side
+# footprint regressions, not as a cross-runtime claim.
+#
+# Usage:
+#   ./footprint.sh                 # default (Sonic) build for the runtime metrics
+#   KRUDA_GO_TAGS=kruda_stdjson ./footprint.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+KRUDA_DIR="$SCRIPT_DIR/kruda"
+PORT_VALUE="${PORT:-3400}"
+TAGS="${KRUDA_GO_TAGS-}"
+
+filesize() { stat -c%s "$1" 2>/dev/null || stat -f%z "$1"; }
+mb() { awk "BEGIN{printf \"%.2f\", $1/1048576}"; }
+out() { printf '%-26s %s\n' "$1" "$2"; }
+
+cd "$KRUDA_DIR"
+
+# --- binary size, both builds ---
+GOWORK=off go build -tags kruda_stdjson -o /tmp/kruda-fp-stdjson .
+GOWORK=off go build -o /tmp/kruda-fp-default .
+out "binary stdjson (MB)" "$(mb "$(filesize /tmp/kruda-fp-stdjson)")"
+out "binary default/Sonic (MB)" "$(mb "$(filesize /tmp/kruda-fp-default)")"
+
+# --- startup + idle RSS (CPU route only; no DB needed) ---
+BIN=/tmp/kruda-fp-stdjson
+if [ -n "$TAGS" ] && [ "$TAGS" != "kruda_stdjson" ]; then BIN=/tmp/kruda-fp-default; fi
+
+env PORT="$PORT_VALUE" BENCH_ENABLE_DB=0 "$BIN" >/tmp/kruda-fp.log 2>&1 &
+PID=$!
+trap 'kill "$PID" 2>/dev/null || true' EXIT
+
+t0=$(date +%s%N)
+ready=0
+for _ in $(seq 1 1000); do
+  if curl -fsS "http://127.0.0.1:$PORT_VALUE/plaintext-handler" >/dev/null 2>&1; then ready=1; break; fi
+  sleep 0.002
+done
+t1=$(date +%s%N)
+if [ "$ready" != 1 ]; then echo "server did not become ready" >&2; cat /tmp/kruda-fp.log >&2; exit 1; fi
+out "startup to first 200 (ms)" "$(( (t1 - t0) / 1000000 ))"
+
+sleep 0.5
+rss_kb="$(ps -o rss= -p "$PID" | tr -d ' ')"
+out "idle RSS (MB)" "$(mb "$(( rss_kb * 1024 ))")"
+out "build measured (runtime)" "$(basename "$BIN")"

--- a/bench/reproducible/results/2026-06-13-footprint-evidence.md
+++ b/bench/reproducible/results/2026-06-13-footprint-evidence.md
@@ -1,0 +1,46 @@
+# Runtime Footprint (P3)
+
+Date: 2026-06-13
+Host: tiger Linux dev server (`tiger-linux`, the deploy target), Go 1.25.10;
+cross-checked on local macOS. Measured with `bench/reproducible/footprint.sh`.
+Scope: perf-track wave **P3** — measure-first on startup time, binary size, and
+RSS; optimize only where real headroom exists.
+
+## Question
+
+Beyond throughput, is there framework-side headroom in startup time, binary
+size, or memory footprint?
+
+## Results
+
+| Metric | tiger (Linux, deploy target) | macOS (cross-check) |
+|---|---:|---:|
+| startup → first 200 | **5 ms** | 535 ms |
+| idle RSS | **13.79 MB** | 19.33 MB |
+| binary, `kruda_stdjson` | 21.87 MB | 21.39 MB |
+| binary, default (Sonic) | 26.64 MB | 22.56 MB |
+
+The macOS startup (535 ms) is process-spawn / dyld overhead on the dev laptop,
+**not** the framework — on the Linux deploy target the app is serving in **5 ms**
+(route tree is AOT-compiled at `New`/`Compile`, no eager DB connect when
+`BENCH_ENABLE_DB=0`).
+
+## Findings
+
+- **Startup: 5 ms on Linux** — already excellent; nothing to optimize.
+- **Idle RSS: 13.79 MB** — Go-runtime baseline plus the Wing/Ctx pools; lean and
+  Go-runtime-dominated. No framework-specific allocation stands out.
+- **Binary size: 21.9 MB (stdjson) / 26.6 MB (Sonic)** — dominated by the Go
+  runtime and the app's deps (the bench app links pgx). Sonic adds ~4.8 MB on
+  Linux (its amd64 assembly/JIT). The size knob already exists and is documented:
+  the `kruda_stdjson` build drops Sonic for ~4.8 MB smaller binaries.
+
+## Decision
+
+**Document; no optimization.** Footprint on the deploy target is already lean
+(5 ms startup, 13.8 MB idle RSS) and the remaining size is Go-runtime + app-dep
+dominated. The two real knobs already exist and are documented: `kruda_stdjson`
+for binary size, and `GOGC`/`GOMEMLIMIT` for RSS under load (see
+`docs/guide/performance.md`). `footprint.sh` is added as the regression-checking
+tool. No production code changes, so no RPS/p99 regression risk and no tiger A/B
+is required for this wave.


### PR DESCRIPTION
## Summary
Perf-track wave **P3** (→ v1.3.1): measure-first runtime footprint. Adds `bench/reproducible/footprint.sh` and the finding. **No production code change.**

## Finding — footprint already lean on the deploy target
On tiger (Linux): **startup 5 ms**, **idle RSS 13.79 MB**, binary **21.9 MB** (`kruda_stdjson`) / **26.6 MB** (Sonic). The macOS 535 ms startup is laptop process-spawn overhead, not the framework (Linux serves in 5 ms; the route tree is AOT-compiled, no eager DB connect).

No framework-specific headroom: footprint is Go-runtime + app-dep dominated. The real knobs already exist and are documented — `kruda_stdjson` for binary size (−4.8 MB), `GOGC`/`GOMEMLIMIT` for RSS. `footprint.sh` is the regression-checking tool.

Evidence: `bench/reproducible/results/2026-06-13-footprint-evidence.md`.

## Test
No production code changed → no RPS/p99 regression risk. `footprint.sh` validated on tiger and macOS.