### PR TITLE
feat: opt-in RFC 9457 problem+json error responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to Kruda are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.4.0] — unreleased
+
+### Added
+
+- **Opt-in RFC 9457 problem+json error responses.** `kruda.New(kruda.WithProblemJSON())`
+  renders errors as `application/problem+json` (standard members plus a field-level
+  `errors` array for validation failures). Off by default — the standard error shape is
+  unchanged; `WithErrorHandler` still takes precedence.
+- **Fluent `KrudaError` builders** — `WithType`, `WithDetail`, `WithInstance`, and
+  `With(key, value)` for problem `type`/`detail`/`instance`/extension members, e.g.
+  `kruda.NotFound("…").WithType("https://…").With("userId", id)`.
+
 ## [1.3.1] — 2026-06-13
 
 ### Changed

--- a/app_serve.go
+++ b/app_serve.go
@@ -362,6 +362,14 @@ func (app *App) handleError(c *Ctx, err error) {
 			return
 		}
 
+		if app.config.problemJSON {
+			app.writeProblem(c, ProblemDetails{
+				Title: "Validation failed", Status: 422,
+				Detail: ve.Error(), Instance: c.Path(), Errors: ve.Errors,
+			})
+			return
+		}
+
 		// Default: use ValidationError's own JSON marshaling
 		c.Status(422)
 		data, _ := ve.MarshalJSON()
@@ -423,9 +431,29 @@ func (app *App) handleError(c *Ctx, err error) {
 		return
 	}
 
+	if app.config.problemJSON {
+		p := ProblemDetails{
+			Type: ke.Type, Title: http.StatusText(ke.Code), Status: ke.Code,
+			Detail:   orDefault(ke.Detail, ke.Message),
+			Instance: orDefault(ke.Instance, c.Path()), Extensions: ke.Extensions,
+		}
+		if errors.As(ke.Err, &ve) {
+			p.Errors = ve.Errors
+		}
+		app.writeProblem(c, p)
+		return
+	}
+
 	// Default: set status and send JSON error response
 	c.Status(ke.Code)
 	_ = c.JSON(ke)
+}
+
+func (app *App) writeProblem(c *Ctx, p ProblemDetails) {
+	c.Status(p.Status)
+	data, _ := p.MarshalJSON()
+	c.SetHeader("Content-Type", "application/problem+json; charset=utf-8")
+	_ = c.sendBytes(data)
 }
 
 // buildChain creates a pre-built handler chain from global, group, and route-level handlers.

--- a/app_serve_problem_test.go
+++ b/app_serve_problem_test.go
@@ -1,0 +1,75 @@
+package kruda
+
+import (
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func serveOne(t *testing.T, app *App, method, path string) (int, string, string) {
+	t.Helper()
+	app.Compile()
+	r := httptest.NewRequest(method, path, nil)
+	w := httptest.NewRecorder()
+	app.ServeHTTP(w, r)
+	res := w.Result()
+	defer res.Body.Close()
+	body, _ := io.ReadAll(res.Body)
+	return res.StatusCode, res.Header.Get("Content-Type"), string(body)
+}
+
+func TestHandleError_problemJSON_kruda(t *testing.T) {
+	app := New(WithProblemJSON())
+	app.Get("/x", func(c *Ctx) error {
+		return NotFound("user not found").WithType("https://e/nf").With("userId", "42")
+	})
+	status, ctype, body := serveOne(t, app, "GET", "/x")
+	if status != 404 {
+		t.Fatalf("status=%d", status)
+	}
+	if ctype != "application/problem+json; charset=utf-8" {
+		t.Fatalf("ctype=%q", ctype)
+	}
+	for _, want := range []string{`"type":"https://e/nf"`, `"status":404`, `"userId":"42"`, `"instance":"/x"`} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body %s missing %s", body, want)
+		}
+	}
+}
+
+func TestHandleError_problemJSON_validation(t *testing.T) {
+	app := New(WithProblemJSON())
+	app.Get("/v", func(c *Ctx) error {
+		return &ValidationError{Errors: []FieldError{{Field: "email", Rule: "required", Message: "email is required"}}}
+	})
+	status, ctype, body := serveOne(t, app, "GET", "/v")
+	if status != 422 || ctype != "application/problem+json; charset=utf-8" {
+		t.Fatalf("status=%d ctype=%q", status, ctype)
+	}
+	for _, want := range []string{`"title":"Validation failed"`, `"errors":[`, `"field":"email"`} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body %s missing %s", body, want)
+		}
+	}
+}
+
+func TestHandleError_default_unchanged(t *testing.T) {
+	app := New()
+	app.Get("/x", func(c *Ctx) error { return NotFound("user not found") })
+	_, ctype, _ := serveOne(t, app, "GET", "/x")
+	if strings.Contains(ctype, "problem+json") {
+		t.Fatalf("default path must not emit problem+json, got %q", ctype)
+	}
+}
+
+func TestHandleError_customHandlerWins(t *testing.T) {
+	app := New(WithProblemJSON(), WithErrorHandler(func(c *Ctx, e *KrudaError) {
+		_ = c.Status(e.Code).JSON(Map{"custom": e.Message})
+	}))
+	app.Get("/x", func(c *Ctx) error { return NotFound("nope") })
+	_, ctype, body := serveOne(t, app, "GET", "/x")
+	if strings.Contains(ctype, "problem+json") || !strings.Contains(body, `"custom"`) {
+		t.Fatalf("custom handler must win: ctype=%q body=%s", ctype, body)
+	}
+}

--- a/config.go
+++ b/config.go
@@ -51,6 +51,7 @@ type Config struct {
 
 	Logger       *slog.Logger
 	ErrorHandler func(c *Ctx, err *KrudaError)
+	problemJSON  bool
 	Validator    *Validator
 
 	// Views is the template engine for c.Render(). Nil = c.Render() returns error.
@@ -218,6 +219,13 @@ func WithLogger(l *slog.Logger) Option {
 // WithErrorHandler sets a custom error handler.
 func WithErrorHandler(h func(c *Ctx, err *KrudaError)) Option {
 	return func(a *App) { a.config.ErrorHandler = h }
+}
+
+// WithProblemJSON renders error responses as RFC 9457 application/problem+json.
+// Off by default; the standard error shape is unchanged. WithErrorHandler still
+// takes precedence when both are set.
+func WithProblemJSON() Option {
+	return func(a *App) { a.config.problemJSON = true }
 }
 
 // WithJSONEncoder sets a custom JSON encoder.

--- a/error.go
+++ b/error.go
@@ -13,9 +13,9 @@ type KrudaError struct {
 	Message    string         `json:"message"`
 	Detail     string         `json:"detail,omitempty"`
 	Err        error          `json:"-"`
-	Type       string         `json:"-"` // RFC 9457 type URI; default "about:blank"
-	Instance   string         `json:"-"` // RFC 9457 instance; default = request path
-	Extensions map[string]any `json:"-"` // RFC 9457 extension members
+	Type       string         `json:"-"`
+	Instance   string         `json:"-"`
+	Extensions map[string]any `json:"-"`
 	mapped     bool           // true when error was resolved via MapError/MapErrorFunc/MapErrorType
 }
 
@@ -79,7 +79,7 @@ func InternalError(message string) *KrudaError {
 	return &KrudaError{Code: 500, Message: message}
 }
 
-// WithType sets the RFC 9457 problem "type" URI. Returns the receiver for chaining.
+// WithType sets the RFC 9457 problem "type" URI.
 func (e *KrudaError) WithType(uri string) *KrudaError { e.Type = uri; return e }
 
 // WithDetail sets the RFC 9457 "detail" (human-readable explanation).

--- a/error.go
+++ b/error.go
@@ -9,11 +9,14 @@ import (
 // KrudaError is the standard error type for Kruda.
 // It carries an HTTP status code and is auto-serialized as JSON.
 type KrudaError struct {
-	Code    int    `json:"code"`
-	Message string `json:"message"`
-	Detail  string `json:"detail,omitempty"`
-	Err     error  `json:"-"`
-	mapped  bool   // true when error was resolved via MapError/MapErrorFunc/MapErrorType
+	Code       int            `json:"code"`
+	Message    string         `json:"message"`
+	Detail     string         `json:"detail,omitempty"`
+	Err        error          `json:"-"`
+	Type       string         `json:"-"` // RFC 9457 type URI; default "about:blank"
+	Instance   string         `json:"-"` // RFC 9457 instance; default = request path
+	Extensions map[string]any `json:"-"` // RFC 9457 extension members
+	mapped     bool           // true when error was resolved via MapError/MapErrorFunc/MapErrorType
 }
 
 // Error implements the error interface.
@@ -74,6 +77,25 @@ func TooManyRequests(message string) *KrudaError {
 // InternalError returns a 500 error.
 func InternalError(message string) *KrudaError {
 	return &KrudaError{Code: 500, Message: message}
+}
+
+// WithType sets the RFC 9457 problem "type" URI. Returns the receiver for chaining.
+func (e *KrudaError) WithType(uri string) *KrudaError { e.Type = uri; return e }
+
+// WithDetail sets the RFC 9457 "detail" (human-readable explanation).
+func (e *KrudaError) WithDetail(detail string) *KrudaError { e.Detail = detail; return e }
+
+// WithInstance sets the RFC 9457 "instance" URI (defaults to the request path).
+func (e *KrudaError) WithInstance(instance string) *KrudaError { e.Instance = instance; return e }
+
+// With adds an arbitrary problem extension member. Reserved member names
+// (type/title/status/detail/instance/errors) are ignored at render time.
+func (e *KrudaError) With(key string, value any) *KrudaError {
+	if e.Extensions == nil {
+		e.Extensions = make(map[string]any, 4)
+	}
+	e.Extensions[key] = value
+	return e
 }
 
 // ErrorMapping maps a Go error to an HTTP status code and message.

--- a/example_test.go
+++ b/example_test.go
@@ -80,6 +80,18 @@ func ExamplePreset() {
 	// Output:
 }
 
+// ExampleWithProblemJSON shows opt-in RFC 9457 problem+json error responses.
+func ExampleWithProblemJSON() {
+	app := kruda.New(kruda.WithProblemJSON())
+	app.Get("/users/:id", func(c *kruda.Ctx) error {
+		return kruda.NotFound("user not found").
+			WithType("https://errors.example.com/not-found").
+			With("userId", c.Param("id"))
+	})
+	_ = app
+	// Output:
+}
+
 // Stub handlers used only so the Example* functions compile.
 func listUsersHandler(c *kruda.Ctx) error  { _ = c; return nil }
 func createUserHandler(c *kruda.Ctx) error { _ = c; return nil }

--- a/problem.go
+++ b/problem.go
@@ -2,27 +2,25 @@ package kruda
 
 import "encoding/json"
 
-// ProblemDetails is an RFC 9457 (problem+json) error document. It is rendered for
-// error responses when the app is created with WithProblemJSON(). The non-standard
-// Extensions are flattened to top-level members; reserved member names are ignored.
+// ProblemDetails is an RFC 9457 (problem+json) error document, rendered for error
+// responses when the app is created with WithProblemJSON(). Extensions are flattened
+// to top-level members; reserved member names are ignored.
 type ProblemDetails struct {
-	Type       string         // RFC 9457 "type" URI; defaults to "about:blank"
-	Title      string         // RFC 9457 "title"
-	Status     int            // RFC 9457 "status"
-	Detail     string         // RFC 9457 "detail"; omitted when empty
-	Instance   string         // RFC 9457 "instance"; omitted when empty
-	Errors     []FieldError   // emitted as the "errors" member when non-empty
-	Extensions map[string]any // arbitrary top-level extension members
+	Type       string
+	Title      string
+	Status     int
+	Detail     string
+	Instance   string
+	Errors     []FieldError
+	Extensions map[string]any
 }
 
-// problemReserved holds the standard member names that Extensions may not override.
 var problemReserved = map[string]struct{}{
 	"type": {}, "title": {}, "status": {}, "detail": {}, "instance": {}, "errors": {},
 }
 
-// MarshalJSON renders the document with encoding/json. Error responses are not a hot
-// path, so using the standard library here keeps key order deterministic on every
-// build (Sonic and kruda_stdjson alike).
+// MarshalJSON flattens Extensions alongside the standard members. encoding/json keeps
+// key order deterministic across builds, and error responses are not a hot path.
 func (p ProblemDetails) MarshalJSON() ([]byte, error) {
 	m := make(map[string]any, 6+len(p.Extensions))
 	for k, v := range p.Extensions {
@@ -45,7 +43,6 @@ func (p ProblemDetails) MarshalJSON() ([]byte, error) {
 	return json.Marshal(m)
 }
 
-// orDefault returns s, or def when s is empty.
 func orDefault(s, def string) string {
 	if s == "" {
 		return def

--- a/problem.go
+++ b/problem.go
@@ -1,0 +1,54 @@
+package kruda
+
+import "encoding/json"
+
+// ProblemDetails is an RFC 9457 (problem+json) error document. It is rendered for
+// error responses when the app is created with WithProblemJSON(). The non-standard
+// Extensions are flattened to top-level members; reserved member names are ignored.
+type ProblemDetails struct {
+	Type       string         // RFC 9457 "type" URI; defaults to "about:blank"
+	Title      string         // RFC 9457 "title"
+	Status     int            // RFC 9457 "status"
+	Detail     string         // RFC 9457 "detail"; omitted when empty
+	Instance   string         // RFC 9457 "instance"; omitted when empty
+	Errors     []FieldError   // emitted as the "errors" member when non-empty
+	Extensions map[string]any // arbitrary top-level extension members
+}
+
+// problemReserved holds the standard member names that Extensions may not override.
+var problemReserved = map[string]struct{}{
+	"type": {}, "title": {}, "status": {}, "detail": {}, "instance": {}, "errors": {},
+}
+
+// MarshalJSON renders the document with encoding/json. Error responses are not a hot
+// path, so using the standard library here keeps key order deterministic on every
+// build (Sonic and kruda_stdjson alike).
+func (p ProblemDetails) MarshalJSON() ([]byte, error) {
+	m := make(map[string]any, 6+len(p.Extensions))
+	for k, v := range p.Extensions {
+		if _, reserved := problemReserved[k]; !reserved {
+			m[k] = v
+		}
+	}
+	m["type"] = orDefault(p.Type, "about:blank")
+	m["title"] = p.Title
+	m["status"] = p.Status
+	if p.Detail != "" {
+		m["detail"] = p.Detail
+	}
+	if p.Instance != "" {
+		m["instance"] = p.Instance
+	}
+	if len(p.Errors) > 0 {
+		m["errors"] = p.Errors
+	}
+	return json.Marshal(m)
+}
+
+// orDefault returns s, or def when s is empty.
+func orDefault(s, def string) string {
+	if s == "" {
+		return def
+	}
+	return s
+}

--- a/problem_test.go
+++ b/problem_test.go
@@ -40,7 +40,7 @@ func TestProblemDetailsMarshal_defaultsAndErrors(t *testing.T) {
 func TestProblemDetailsMarshal_reservedExtensionIgnored(t *testing.T) {
 	p := ProblemDetails{
 		Title: "Bad Request", Status: 400,
-		Extensions: map[string]any{"status": 999, "x": "ok"}, // "status" must not override
+		Extensions: map[string]any{"status": 999, "x": "ok"},
 	}
 	got, _ := json.Marshal(p)
 	want := `{"status":400,"title":"Bad Request","type":"about:blank","x":"ok"}`
@@ -55,7 +55,7 @@ func TestKrudaErrorBuilders(t *testing.T) {
 		WithDetail("no such user").
 		WithInstance("/users/42").
 		With("userId", "42").
-		With("type", "ignored-but-stored") // stored; renderer drops reserved keys
+		With("type", "ignored-but-stored")
 
 	if e.Code != 404 || e.Type != "https://errors.example.com/not-found" ||
 		e.Detail != "no such user" || e.Instance != "/users/42" {

--- a/problem_test.go
+++ b/problem_test.go
@@ -48,3 +48,20 @@ func TestProblemDetailsMarshal_reservedExtensionIgnored(t *testing.T) {
 		t.Fatalf("\n got: %s\nwant: %s", got, want)
 	}
 }
+
+func TestKrudaErrorBuilders(t *testing.T) {
+	e := NotFound("user not found").
+		WithType("https://errors.example.com/not-found").
+		WithDetail("no such user").
+		WithInstance("/users/42").
+		With("userId", "42").
+		With("type", "ignored-but-stored") // stored; renderer drops reserved keys
+
+	if e.Code != 404 || e.Type != "https://errors.example.com/not-found" ||
+		e.Detail != "no such user" || e.Instance != "/users/42" {
+		t.Fatalf("builder fields wrong: %+v", e)
+	}
+	if e.Extensions["userId"] != "42" {
+		t.Fatalf("With did not store extension: %+v", e.Extensions)
+	}
+}

--- a/problem_test.go
+++ b/problem_test.go
@@ -1,0 +1,50 @@
+package kruda
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestProblemDetailsMarshal_full(t *testing.T) {
+	p := ProblemDetails{
+		Type: "https://errors.example.com/not-found", Title: "Not Found", Status: 404,
+		Detail: "user not found", Instance: "/users/42",
+		Extensions: map[string]any{"userId": "42"},
+	}
+	got, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// encoding/json sorts map keys → deterministic alphabetical order.
+	want := `{"detail":"user not found","instance":"/users/42","status":404,"title":"Not Found","type":"https://errors.example.com/not-found","userId":"42"}`
+	if string(got) != want {
+		t.Fatalf("\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestProblemDetailsMarshal_defaultsAndErrors(t *testing.T) {
+	p := ProblemDetails{
+		Title: "Validation failed", Status: 422, Detail: "email is required", Instance: "/users",
+		Errors: []FieldError{{Field: "email", Rule: "required", Message: "email is required"}},
+	}
+	got, err := json.Marshal(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `{"detail":"email is required","errors":[{"field":"email","rule":"required","param":"","message":"email is required","value":""}],"instance":"/users","status":422,"title":"Validation failed","type":"about:blank"}`
+	if string(got) != want {
+		t.Fatalf("\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestProblemDetailsMarshal_reservedExtensionIgnored(t *testing.T) {
+	p := ProblemDetails{
+		Title: "Bad Request", Status: 400,
+		Extensions: map[string]any{"status": 999, "x": "ok"}, // "status" must not override
+	}
+	got, _ := json.Marshal(p)
+	want := `{"status":400,"title":"Bad Request","type":"about:blank","x":"ok"}`
+	if string(got) != want {
+		t.Fatalf("\n got: %s\nwant: %s", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Adds one-line opt-in RFC 9457 `application/problem+json` error responses plus fluent `KrudaError` builders. Additive and non-breaking — the default error shape is unchanged and `WithErrorHandler` still takes precedence.

This is the first DX-track bundle (D2) targeting v1.4.0.

## What's new

- **`kruda.New(kruda.WithProblemJSON())`** — renders errors as `application/problem+json` with the standard members, plus a field-level `errors` array for validation failures. Off by default.
- **`ProblemDetails`** (new `problem.go`) — RFC 9457 document with a deterministic `MarshalJSON` (standard library, stable key order on every build); extension members are flattened to the top level and reserved names are ignored.
- **Fluent `KrudaError` builders** — `WithType`, `WithDetail`, `WithInstance`, `With(key, value)`, e.g. `kruda.NotFound("…").WithType("https://…").With("userId", id)`.

## Precedence

`WithErrorHandler` > `WithProblemJSON` > default. The default path is byte-identical to before (regression-guarded).

## Tests

- Golden tests for `ProblemDetails` marshaling (standard members, defaults, `errors[]`, reserved-extension guard) and the builder chain.
- Integration tests through `ServeHTTP`: problem+json for `KrudaError` and `ValidationError`, default-path unchanged, custom handler wins.
- `go vet` clean, `gofmt` clean, full `-race` suite green.

## Not included

No release tag — DX-track release cadence is decided once the bundle set is further along.