### PR TITLE
ci: enforce doc correctness for exported APIs and current guides

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - 'docs/**'
       - '.github/workflows/docs.yml'
+      - 'scripts/check-docs.sh'
   workflow_dispatch:
 
 permissions:
@@ -47,6 +48,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
         working-directory: docs
+
+      - name: Check current docs for removed APIs
+        run: scripts/check-docs.sh
 
       - name: Build VitePress site
         run: npx vitepress build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,16 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
+      - name: Install revive
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25.10'
+        run: |
+          go install github.com/mgechev/revive@v1.12.0
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Check exported API docs
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25.10'
+        run: scripts/check-godoc.sh
+
       - name: Go vet
         run: go vet -tags kruda_stdjson ./...
 

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -17,7 +17,7 @@ When enabled via `WithSecureHeaders()`, normal handler responses include these h
 
 Kruda does not emit a `Server` header by default, so framework identity and version details are not exposed by normal responses.
 
-Prebuilt Wing static responses from `WingStaticText` and `WingStaticJSON` are written directly for maximum throughput and bypass middleware, lifecycle hooks, cookies, CORS, and secure-header injection. Prefer normal handlers when a response needs application behavior or `WithSecureHeaders()`.
+Prebuilt Wing static responses from `StaticText` and `StaticJSON` are written directly for maximum throughput and bypass middleware, lifecycle hooks, cookies, CORS, and secure-header injection. Prefer normal handlers when a response needs application behavior or `WithSecureHeaders()`.
 
 ```go
 // Explicitly enable security headers

--- a/docs/guide/transport.md
+++ b/docs/guide/transport.md
@@ -47,7 +47,7 @@ KRUDA_TRANSPORT=fasthttp ./myapp   # force fasthttp
 
 Wing is optimized for raw throughput. It intentionally skips some HTTP features:
 
-- **Prebuilt static responses bypass middleware** — `WingStaticText` and `WingStaticJSON` write route-level prebuilt responses directly. Use normal handlers when a response needs middleware, lifecycle hooks, CORS, cookies, or `WithSecureHeaders()`.
+- **Prebuilt static responses bypass middleware** — `StaticText` and `StaticJSON` write route-level prebuilt responses directly. Use normal handlers when a response needs middleware, lifecycle hooks, CORS, cookies, or `WithSecureHeaders()`.
 - **No `http.Flusher`** — SSE streaming requires flushing, which Wing doesn't support.
 - **No HTTP/2** — Wing speaks HTTP/1.1 only. Use `kruda.NetHTTP()` with TLS for HTTP/2.
 - **No chunked transfer encoding** — Wing pre-computes Content-Length.

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Checks current user-facing docs for references to removed APIs.
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+
+fail() {
+  printf "\033[31m ✗\033[0m %s\n" "$*" >&2
+  exit 1
+}
+
+ok() { printf "\033[32m ✓\033[0m %s\n" "$*"; }
+
+current_docs=()
+while IFS= read -r file; do
+  current_docs+=("$file")
+done < <(git ls-files 'docs/guide/*.md' 'docs/api/*.md' 'docs/release-process.md' 'README.md')
+
+if [[ ${#current_docs[@]} -eq 0 ]]; then
+  fail "no current docs found to scan"
+fi
+
+removed_api='\<Wing(Plaintext|JSON|Query|Render|StaticText|StaticJSON)\>'
+if hits=$(git grep -nE "$removed_api" -- "${current_docs[@]}" || true); [[ -n "$hits" ]]; then
+  echo "$hits"
+  fail "current docs reference removed Wing helper APIs"
+fi
+
+stale_wing_shim='transport/wing.*(still exists|continues to work|compatibility shim|deprecation alias|re-exports|slated for removal|v2\.0\.0)'
+if hits=$(git grep -nE "$stale_wing_shim" -- "${current_docs[@]}" || true); [[ -n "$hits" ]]; then
+  echo "$hits"
+  fail "current docs describe transport/wing as a live compatibility shim"
+fi
+
+ok "current docs do not reference removed Wing APIs"

--- a/scripts/check-godoc.sh
+++ b/scripts/check-godoc.sh
@@ -1,4 +1,4 @@
-#!env bash
+#!/usr/bin/env bash
 # Checks exported symbol comments in released modules.
 set -euo pipefail
 

--- a/scripts/check-godoc.sh
+++ b/scripts/check-godoc.sh
@@ -1,0 +1,49 @@
+#!env bash
+# Checks exported symbol comments in released modules.
+set -euo pipefail
+
+ROOT=$(git rev-parse --show-toplevel)
+cd "$ROOT"
+
+fail() {
+  printf "\033[31m ✗\033[0m %s\n" "$*" >&2
+  exit 1
+}
+
+ok() { printf "\033[32m ✓\033[0m %s\n" "$*"; }
+
+if ! command -v revive >/dev/null; then
+  fail "revive is required for godoc checks; install with: go install github.com/mgechev/revive@latest"
+fi
+
+config=$(mktemp)
+trap 'rm -f "$config"' EXIT
+printf '[rule.exported]\n' > "$config"
+
+contrib_modules=()
+while IFS= read -r module; do
+  contrib_modules+=("$module")
+done < <(find contrib -mindepth 2 -maxdepth 2 -name go.mod -print | sed 's#/go.mod$##' | sort)
+modules=(".")
+modules+=("${contrib_modules[@]}")
+modules+=("cmd/kruda")
+
+gooses=(linux darwin windows)
+missing=""
+
+for module in "${modules[@]}"; do
+  for goos in "${gooses[@]}"; do
+    output=$(cd "$module" && GOOS="$goos" revive -config "$config" ./... 2>&1 || true)
+    output=$(printf "%s\n" "$output" | grep "should have comment" | grep -vE '^examples/' || true)
+    if [[ -n "$output" ]]; then
+      missing+=$'\n'"== $module ($goos) =="$'\n'"$output"
+    fi
+  done
+done
+
+if [[ -n "$missing" ]]; then
+  printf "%s\n" "$missing" | head -40
+  fail "missing godoc on exported symbols in released code"
+fi
+
+ok "godoc complete on released code"

--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -66,19 +66,13 @@ for fuzz in FuzzRouterPattern FuzzRouterMatch FuzzBindJSON FuzzValidateString; d
   fi
 done
 
+section "current documentation correctness"
+scripts/check-docs.sh
+ok "current docs checked"
+
 section "godoc completeness on exported symbols (released code only)"
-# examples/ packages are runnable demos, not library API — revive noise there
-# is not a release blocker. Check core + contrib + transport.
-if command -v revive >/dev/null; then
-  missing=$(revive -config <(echo '[rule.exported]') ./... 2>&1 | grep "should have comment" | grep -vE '^examples/' || true)
-  if [[ -n "$missing" ]]; then
-    echo "$missing" | head -10
-    fail "missing godoc on exported symbols (released code)"
-  fi
-  ok "godoc complete on released code"
-else
-  echo "  (revive not installed, skipping godoc check)"
-fi
+scripts/check-godoc.sh
+ok "godoc complete on released code"
 
 section "examples build"
 for dir in examples/*/; do


### PR DESCRIPTION
## What

Two release gates that make documentation defects fail the build instead of shipping silently, plus the two stale references they would have caught.

### Gates
- **`scripts/check-godoc.sh`** — fails when an exported symbol in a *released* module lacks a doc comment. Checks the root module, **every contrib module**, and `cmd/kruda` across **linux/darwin/windows**, and **fails hard when revive is missing** (the old inline check silently skipped if revive wasn't installed).
- **`scripts/check-docs.sh`** — fails when current user-facing docs (`docs/guide/*`, `docs/api/*`, `release-process.md`, `README.md`) reference removed Wing helper APIs (`WingPlaintext/JSON/Query/Render/StaticText/StaticJSON`) or describe the deleted `transport/wing` shim as live.

### Wiring
- `pre-release.sh` delegates to both scripts (replacing the old inline, silently-skippable revive block).
- `test.yml` runs the godoc check per-PR (revive **pinned to v1.12.0**).
- `docs.yml` runs the docs check before the VitePress build.

### Fixes
- `docs/guide/transport.md` and `docs/guide/security.md` named the v1.3.0-renamed `WingStaticText`/`WingStaticJSON` instead of `StaticText`/`StaticJSON`.

## Verification (local)
- Both gates pass on the current tree.
- `check-godoc.sh` proven **non-vacuous**: injecting an undocumented exported symbol into a contrib module makes it fail (exit 1); removing it returns green.
- Exported-doc coverage is already complete (0 defects) across root + all 10 contrib + cmd/kruda × 3 GOOS — so this gate locks in a state that's already clean.

## Notes
- This is the first PR to exercise both gates in CI.
- No public API change; docs + CI tooling only.