### PR TITLE
Wing: X-Forwarded-For/X-Real-IP dedicated fields + 431 for oversized header line

### DIFF
--- a/wing_bodylimit_test.go
+++ b/wing_bodylimit_test.go
@@ -546,6 +546,93 @@ func TestWing_HeaderLineTooLarge431(t *testing.T) {
 	}
 }
 
+// TestWing_SplitHeadersNotWronglyRejected guards that a header block of small,
+// individually-legal lines is served even when a partial read snapshot exceeds
+// HeaderLimit before the terminating CRLF arrives. The verdict must not depend on
+// TCP segmentation (regression: the classifier's total-bytes early-out 431'd it).
+func TestWing_SplitHeadersNotWronglyRejected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing integration test in short mode")
+	}
+	cfg := WingConfig{Workers: 1, ReadBufSize: 8192, HeaderLimit: 1024}
+	addr, stop := startWingServerWithConfig(t, cfg, transport.HandlerFunc(func(w transport.ResponseWriter, r transport.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	}))
+	defer stop()
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	var b strings.Builder
+	b.WriteString("GET / HTTP/1.1\r\nHost: h\r\n")
+	for i := 0; i < 60; i++ { // ~60 small lines, each well under HeaderLimit 1024
+		fmt.Fprintf(&b, "X-H-%d: vvvvvvvvvv\r\n", i)
+	}
+	full := b.String() // > 1024 bytes total, no terminating CRLF yet
+	// Send a >1024 partial first (snapshot exceeds HeaderLimit), pause, then finish.
+	if _, err := conn.Write([]byte(full[:1100])); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if _, err := conn.Write([]byte(full[1100:] + "\r\n")); err != nil {
+		t.Fatal(err)
+	}
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	line, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(line, "200") {
+		t.Fatalf("split small-header block wrongly rejected: got %q", strings.TrimSpace(line))
+	}
+}
+
+// TestWing_Takeover_HeaderLineTooLarge431 guards that the takeover keep-alive path
+// answers 431 for an oversized header line on a pipelined request, matching the
+// event-loop path (regression: takeover grouped it with malformed and closed silently).
+func TestWing_Takeover_HeaderLineTooLarge431(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing integration test in short mode")
+	}
+	cfg := WingConfig{Workers: 1, ReadBufSize: 8192, HeaderLimit: 1024, DefaultPreset: DB}
+	addr, stop := startWingServerWithConfig(t, cfg, transport.HandlerFunc(func(w transport.ResponseWriter, r transport.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	}))
+	defer stop()
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	// Pipeline req1 (valid → enters takeover) + req2 (oversized header → 431 via takeover).
+	big := strings.Repeat("a", 2048)
+	pipelined := "GET / HTTP/1.1\r\nHost: h\r\n\r\n" +
+		"GET / HTTP/1.1\r\nHost: h\r\nX-Big: " + big + "\r\n\r\n"
+	if _, err := conn.Write([]byte(pipelined)); err != nil {
+		t.Fatal(err)
+	}
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	var resp bytes.Buffer
+	tmp := make([]byte, 4096)
+	for {
+		n, rerr := conn.Read(tmp)
+		resp.Write(tmp[:n])
+		if rerr != nil {
+			break
+		}
+	}
+	s := resp.String()
+	if !strings.Contains(s, " 200 ") {
+		t.Fatalf("expected req1 to be served 200, got: %q", s)
+	}
+	if !strings.Contains(s, " 431 ") {
+		t.Fatalf("expected req2 oversized header to get 431 on takeover path, got: %q", s)
+	}
+}
+
 // TestWing_BodyLimitInBuffer guards the case where a complete request body fits
 // entirely inside the read buffer but exceeds BodyLimit. The over-buffer slow
 // path alone never sees these, so the parser must reject them so the classifier

--- a/wing_bodylimit_test.go
+++ b/wing_bodylimit_test.go
@@ -730,6 +730,43 @@ func TestWingRequest_HeaderXFFCaseInsensitive(t *testing.T) {
 	}
 }
 
+// TestWing_HeaderLineLengthBoundary pins the exact off-by-one contract of the
+// classifyIncomplete per-line check: len(hline) == HeaderLimit is accepted;
+// len(hline) == HeaderLimit+1 is rejected with 431.
+// hline is the header line after \r stripping (e.g. "X-Test: <value>").
+func TestWing_HeaderLineLengthBoundary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing integration test in short mode")
+	}
+	const headerLimit = 512
+	cfg := WingConfig{Workers: 1, ReadBufSize: 8192, HeaderLimit: headerLimit}
+	addr, stop := startWingServerWithConfig(t, cfg, transport.HandlerFunc(func(w transport.ResponseWriter, r transport.Request) {
+		w.WriteHeader(200)
+	}))
+	defer stop()
+
+	prefix := "X-Test: " // 8 bytes; hline = prefix + value
+	baseLen := len(prefix)
+
+	for _, tc := range []struct {
+		name     string
+		valLen   int
+		wantCode string
+	}{
+		{"at_limit", headerLimit - baseLen, "200"},      // len(hline)==headerLimit → OK
+		{"over_limit", headerLimit - baseLen + 1, "431"}, // len(hline)==headerLimit+1 → 431
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			hdr := prefix + strings.Repeat("a", tc.valLen)
+			raw := "GET / HTTP/1.1\r\nHost: h\r\n" + hdr + "\r\n\r\n"
+			st, _ := sendRaw(t, addr, raw)
+			if !strings.Contains(st, " "+tc.wantCode+" ") {
+				t.Fatalf("header line len=%d want %s, got %q", len(hdr), tc.wantCode, st)
+			}
+		})
+	}
+}
+
 // TestWing_BodyLimitInBuffer guards the case where a complete request body fits
 // entirely inside the read buffer but exceeds BodyLimit. The over-buffer slow
 // path alone never sees these, so the parser must reject them so the classifier

--- a/wing_bodylimit_test.go
+++ b/wing_bodylimit_test.go
@@ -633,6 +633,103 @@ func TestWing_Takeover_HeaderLineTooLarge431(t *testing.T) {
 	}
 }
 
+// TestWing_TrustProxy_EmptyFirstHeaderWins guards net/http Get semantics: when a
+// request sends an empty X-Forwarded-For before a non-empty one, the first
+// (empty) header wins and RemoteAddr falls back to the socket peer — a later
+// attacker-supplied value must not override it.
+func TestWing_TrustProxy_EmptyFirstHeaderWins(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing integration test in short mode")
+	}
+	cfg := WingConfig{Workers: 1, ReadBufSize: 8192, TrustProxy: true}
+	addr, stop := startWingServerWithConfig(t, cfg, transport.HandlerFunc(func(w transport.ResponseWriter, r transport.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(r.RemoteAddr()))
+	}))
+	defer stop()
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	fmt.Fprintf(conn, "GET / HTTP/1.1\r\nHost: h\r\nX-Forwarded-For: \r\nX-Forwarded-For: 1.2.3.4\r\n\r\n")
+	body := readHTTPBody(t, conn)
+	if body == "1.2.3.4" {
+		t.Fatalf("empty first XFF must win; second value must not override, got %q", body)
+	}
+	if !strings.HasPrefix(body, "127.0.0.1:") && !strings.HasPrefix(body, "[::1]:") {
+		t.Fatalf("expected loopback fallback, got %q", body)
+	}
+}
+
+// TestWing_Takeover_LargeHeaderWithinLimit guards that the takeover path accepts
+// a header block larger than the 8 KB default pool buffer but within HeaderLimit,
+// matching the event loop (regression: takeover used a fixed 8 KB buffer and
+// wrongly 431'd / truncated large legal headers when HeaderLimit > 8 KB).
+func TestWing_Takeover_LargeHeaderWithinLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing integration test in short mode")
+	}
+	cfg := WingConfig{Workers: 1, ReadBufSize: 16384, HeaderLimit: 16384, DefaultPreset: DB}
+	addr, stop := startWingServerWithConfig(t, cfg, transport.HandlerFunc(func(w transport.ResponseWriter, r transport.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	}))
+	defer stop()
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	// req1 valid (enters takeover) + req2 with a ~12 KB header line (< HeaderLimit,
+	// > 8 KB default pool buffer); req2 closes the conn so the read ends promptly.
+	big := strings.Repeat("a", 12000)
+	pipelined := "GET / HTTP/1.1\r\nHost: h\r\n\r\n" +
+		"GET / HTTP/1.1\r\nHost: h\r\nConnection: close\r\nX-Big: " + big + "\r\n\r\n"
+	if _, err := conn.Write([]byte(pipelined)); err != nil {
+		t.Fatal(err)
+	}
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	var resp bytes.Buffer
+	tmp := make([]byte, 4096)
+	for {
+		n, rerr := conn.Read(tmp)
+		resp.Write(tmp[:n])
+		if rerr != nil {
+			break
+		}
+	}
+	s := resp.String()
+	if strings.Contains(s, " 431 ") {
+		t.Fatalf("legal large header on takeover wrongly 431'd: %q", s)
+	}
+	if strings.Count(s, " 200 ") < 2 {
+		t.Fatalf("expected both requests served 200, got: %q", s)
+	}
+}
+
+// TestWingRequest_HeaderXFFCaseInsensitive guards that the dedicated XFF/X-Real-IP
+// fields are reachable via Header()/RawHeader() regardless of key casing, matching
+// the case-insensitive lookup they had as generic extra headers.
+func TestWingRequest_HeaderXFFCaseInsensitive(t *testing.T) {
+	raw := []byte("GET / HTTP/1.1\r\nHost: h\r\nX-Forwarded-For: 9.9.9.9\r\nX-Real-IP: 8.8.8.8\r\n\r\n")
+	r, _, ok := parseHTTPRequest(raw, parserLimits{maxHeaderCount: 100, maxHeaderSize: 8192})
+	if !ok {
+		t.Fatal("parse failed")
+	}
+	defer releaseRequest(r)
+	for _, k := range []string{"X-Forwarded-For", "x-forwarded-for", "X-FORWARDED-FOR"} {
+		if got := r.Header(k); got != "9.9.9.9" {
+			t.Fatalf("Header(%q) = %q, want 9.9.9.9", k, got)
+		}
+	}
+	for _, k := range []string{"X-Real-IP", "x-real-ip", "X-REAL-IP"} {
+		if got := r.Header(k); got != "8.8.8.8" {
+			t.Fatalf("Header(%q) = %q, want 8.8.8.8", k, got)
+		}
+	}
+}
+
 // TestWing_BodyLimitInBuffer guards the case where a complete request body fits
 // entirely inside the read buffer but exceeds BodyLimit. The over-buffer slow
 // path alone never sees these, so the parser must reject them so the classifier

--- a/wing_bodylimit_test.go
+++ b/wing_bodylimit_test.go
@@ -491,6 +491,61 @@ func TestWing_TrustProxy(t *testing.T) {
 	})
 }
 
+// TestWing_TrustProxy_ManyHeaders guards that X-Forwarded-For is honored even when
+// the request carries more than the 8 generic extra-header slots — XFF is parsed
+// into a dedicated field, so it can no longer be dropped by slot overflow.
+func TestWing_TrustProxy_ManyHeaders(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing integration test in short mode")
+	}
+	cfg := WingConfig{Workers: 1, ReadBufSize: 8192, TrustProxy: true}
+	addr, stop := startWingServerWithConfig(t, cfg, transport.HandlerFunc(func(w transport.ResponseWriter, r transport.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte(r.RemoteAddr()))
+	}))
+	defer stop()
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	var b strings.Builder
+	b.WriteString("GET / HTTP/1.1\r\nHost: h\r\nX-Forwarded-For: 1.2.3.4\r\n")
+	for i := 0; i < 12; i++ { // 12 unknown headers — well past the 8-slot extra store
+		fmt.Fprintf(&b, "X-Custom-%d: v%d\r\n", i, i)
+	}
+	b.WriteString("\r\n")
+	if _, err := conn.Write([]byte(b.String())); err != nil {
+		t.Fatal(err)
+	}
+	body := readHTTPBody(t, conn)
+	if body != "1.2.3.4" {
+		t.Fatalf("XFF must survive >8 extra headers, got %q", body)
+	}
+}
+
+// TestWing_HeaderLineTooLarge431 guards that a single header line over HeaderLimit
+// (but within the read buffer) is rejected with 431, not a silent close.
+func TestWing_HeaderLineTooLarge431(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing integration test in short mode")
+	}
+	cfg := WingConfig{Workers: 1, ReadBufSize: 8192, HeaderLimit: 1024}
+	addr, stop := startWingServerWithConfig(t, cfg, transport.HandlerFunc(func(w transport.ResponseWriter, r transport.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	}))
+	defer stop()
+	// One ~2KB header line exceeds HeaderLimit 1024 but the whole request fits
+	// the 8KB read buffer, so it takes the "buffer has room" classifier path.
+	big := strings.Repeat("a", 2048)
+	raw := "GET / HTTP/1.1\r\nHost: h\r\nX-Big: " + big + "\r\n\r\n"
+	st, _ := sendRaw(t, addr, raw)
+	if !strings.Contains(st, "431") {
+		t.Fatalf("oversized header line want 431, got %q", st)
+	}
+}
+
 // TestWing_BodyLimitInBuffer guards the case where a complete request body fits
 // entirely inside the read buffer but exceeds BodyLimit. The over-buffer slow
 // path alone never sees these, so the parser must reject them so the classifier

--- a/wing_http.go
+++ b/wing_http.go
@@ -114,6 +114,8 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 	accept := ""
 	forwardedFor := ""
 	realIP := ""
+	forwardedForSeen := false // first header wins even if its value is empty (net/http Get)
+	realIPSeen := false
 	hostUnsafe := false
 	acceptUnsafe := false
 	keepAlive := true // HTTP/1.1 default
@@ -206,12 +208,14 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 			acceptUnsafe = unsafePath && len(val) > 0
 			continue
 		case headerForwardedFor:
-			if forwardedFor == "" { // first header wins (net/http Get semantics)
+			if !forwardedForSeen {
+				forwardedForSeen = true
 				forwardedFor = string(val)
 			}
 			continue
 		case headerRealIP:
-			if realIP == "" {
+			if !realIPSeen {
+				realIPSeen = true
 				realIP = string(val)
 			}
 			continue
@@ -255,11 +259,13 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 			accept = copyOrUnsafeString(val, unsafePath)
 			acceptUnsafe = unsafePath && len(val) > 0
 		case headerForwardedFor:
-			if forwardedFor == "" { // first header wins (net/http Get semantics)
+			if !forwardedForSeen {
+				forwardedForSeen = true
 				forwardedFor = string(val)
 			}
 		case headerRealIP:
-			if realIP == "" {
+			if !realIPSeen {
+				realIPSeen = true
 				realIP = string(val)
 			}
 		default:
@@ -825,10 +831,10 @@ func (r *wingRequest) Header(key string) string {
 		}
 		return r.accept
 	}
-	if key == "X-Forwarded-For" || key == "x-forwarded-for" {
+	if strings.EqualFold(key, "x-forwarded-for") {
 		return r.forwardedFor
 	}
-	if key == "X-Real-IP" || key == "x-real-ip" {
+	if strings.EqualFold(key, "x-real-ip") {
 		return r.realIP
 	}
 	lk := strings.ToLower(key)

--- a/wing_http.go
+++ b/wing_http.go
@@ -112,6 +112,8 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 	cookie := ""
 	host := ""
 	accept := ""
+	forwardedFor := ""
+	realIP := ""
 	hostUnsafe := false
 	acceptUnsafe := false
 	keepAlive := true // HTTP/1.1 default
@@ -203,6 +205,12 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 			accept = copyOrUnsafeString(val, unsafePath)
 			acceptUnsafe = unsafePath && len(val) > 0
 			continue
+		case headerForwardedFor:
+			forwardedFor = string(val)
+			continue
+		case headerRealIP:
+			realIP = string(val)
+			continue
 		}
 
 		key = trimHTTPSpaces(key)
@@ -242,6 +250,10 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 		case headerAccept:
 			accept = copyOrUnsafeString(val, unsafePath)
 			acceptUnsafe = unsafePath && len(val) > 0
+		case headerForwardedFor:
+			forwardedFor = string(val)
+		case headerRealIP:
+			realIP = string(val)
 		default:
 			if extraN < len(extraHdrs) {
 				lk := make([]byte, len(key))
@@ -294,6 +306,8 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 		r.cookie = cookie
 		r.host = host
 		r.accept = accept
+		r.forwardedFor = forwardedFor
+		r.realIP = realIP
 		r.hostUnsafe = hostUnsafe
 		r.acceptUnsafe = acceptUnsafe
 		r.extraHdrs = extraHdrs
@@ -311,6 +325,8 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 	r.cookie = cookie
 	r.host = host
 	r.accept = accept
+	r.forwardedFor = forwardedFor
+	r.realIP = realIP
 	r.hostUnsafe = hostUnsafe
 	r.acceptUnsafe = acceptUnsafe
 	r.extraHdrs = extraHdrs
@@ -364,6 +380,8 @@ var (
 	bCookie            = []byte("cookie")
 	bHost              = []byte("host")
 	bAccept            = []byte("accept")
+	bForwardedFor      = []byte("x-forwarded-for")
+	bRealIP            = []byte("x-real-ip")
 	bHTTPVersionPrefix = []byte("HTTP/")
 	bStar              = []byte("*")
 	wing100Continue    = []byte("HTTP/1.1 100 Continue\r\n\r\n")
@@ -378,6 +396,8 @@ const (
 	headerCookie
 	headerHost
 	headerAccept
+	headerForwardedFor
+	headerRealIP
 )
 
 func knownHeader(key []byte) uint8 {
@@ -392,6 +412,14 @@ func knownHeader(key []byte) uint8 {
 		}
 		if asciiEqualFold(key, bAccept) {
 			return headerAccept
+		}
+	case 9:
+		if asciiEqualFold(key, bRealIP) {
+			return headerRealIP
+		}
+	case 15:
+		if asciiEqualFold(key, bForwardedFor) {
+			return headerForwardedFor
 		}
 	case 10:
 		if asciiEqualFold(key, bConnection) {
@@ -464,6 +492,11 @@ func classifyIncomplete(data []byte, limits parserLimits) (status parseStatus, n
 		}
 		if n := len(hline); n > 0 && hline[n-1] == '\r' {
 			hline = hline[:n-1]
+		}
+		// A single over-limit header line is 431, not a silent close — mirror
+		// the parser's per-line check so the client learns why it was rejected.
+		if limits.maxHeaderSize > 0 && len(hline) > limits.maxHeaderSize {
+			return parseHeaderTooLarge, 0, false
 		}
 		colon := bytes.IndexByte(hline, ':')
 		if colon <= 0 {
@@ -641,6 +674,8 @@ func releaseRequest(r *wingRequest) {
 	r.cookie = ""
 	r.host = ""
 	r.accept = ""
+	r.forwardedFor = ""
+	r.realIP = ""
 	r.hostUnsafe = false
 	r.acceptUnsafe = false
 	r.remoteAddr = ""
@@ -683,6 +718,8 @@ type wingRequest struct {
 	cookie        string
 	host          string
 	accept        string
+	forwardedFor  string
+	realIP        string
 	remoteAddr    string
 	remoteAddrRef *string
 	trustProxy    bool
@@ -701,15 +738,15 @@ func (r *wingRequest) Path() string          { return r.path }
 func (r *wingRequest) Body() ([]byte, error) { return r.body, nil }
 func (r *wingRequest) RemoteAddr() string {
 	if r.trustProxy {
-		if xff := r.RawHeader("x-forwarded-for"); len(xff) > 0 {
+		if xff := r.forwardedFor; xff != "" {
 			// Take the first (leftmost) IP — the original client.
-			if i := bytes.IndexByte(xff, ','); i >= 0 {
+			if i := strings.IndexByte(xff, ','); i >= 0 {
 				xff = xff[:i]
 			}
-			return string(bytes.TrimSpace(xff))
+			return strings.TrimSpace(xff)
 		}
-		if xri := r.RawHeader("x-real-ip"); len(xri) > 0 {
-			return string(bytes.TrimSpace(xri))
+		if r.realIP != "" {
+			return strings.TrimSpace(r.realIP)
 		}
 	}
 	if r.remoteAddr != "" {
@@ -776,6 +813,12 @@ func (r *wingRequest) Header(key string) string {
 			r.acceptUnsafe = false
 		}
 		return r.accept
+	}
+	if key == "X-Forwarded-For" || key == "x-forwarded-for" {
+		return r.forwardedFor
+	}
+	if key == "X-Real-IP" || key == "x-real-ip" {
+		return r.realIP
 	}
 	lk := strings.ToLower(key)
 	for i := range r.extraN {

--- a/wing_http.go
+++ b/wing_http.go
@@ -206,10 +206,14 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 			acceptUnsafe = unsafePath && len(val) > 0
 			continue
 		case headerForwardedFor:
-			forwardedFor = string(val)
+			if forwardedFor == "" { // first header wins (net/http Get semantics)
+				forwardedFor = string(val)
+			}
 			continue
 		case headerRealIP:
-			realIP = string(val)
+			if realIP == "" {
+				realIP = string(val)
+			}
 			continue
 		}
 
@@ -251,9 +255,13 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 			accept = copyOrUnsafeString(val, unsafePath)
 			acceptUnsafe = unsafePath && len(val) > 0
 		case headerForwardedFor:
-			forwardedFor = string(val)
+			if forwardedFor == "" { // first header wins (net/http Get semantics)
+				forwardedFor = string(val)
+			}
 		case headerRealIP:
-			realIP = string(val)
+			if realIP == "" {
+				realIP = string(val)
+			}
 		default:
 			if extraN < len(extraHdrs) {
 				lk := make([]byte, len(key))
@@ -466,9 +474,12 @@ func classifyIncomplete(data []byte, limits parserLimits) (status parseStatus, n
 	}
 	headerEnd := bytes.Index(data, crlfcrlf)
 	if headerEnd < 0 {
-		if limits.maxHeaderSize > 0 && len(data) > limits.maxHeaderSize {
-			return parseHeaderTooLarge, 0, false
-		}
+		// Headers still arriving: wait for more. Don't reject on accumulated
+		// bytes here — that made the verdict depend on TCP segmentation (a
+		// small-line/large-total header block was served when it arrived in one
+		// read but 431'd when split). Oversized headers are caught per-line once
+		// the block is complete, or by the buffer-full path (ReadBufSize is the
+		// total backstop).
 		return parseNeedHeaderMore, 0, false
 	}
 	// Request line must be well-formed.

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -1175,6 +1175,13 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte) {
 
 	bp := takeoverBufPool.Get().(*[]byte)
 	buf := *bp
+	// The pool's default buffer is 8 KB; grow it to the configured ReadBufSize so
+	// the takeover path accepts the same header sizes as the event loop (which
+	// sizes readBuf from ReadBufSize/HeaderLimit) and so copy() below never
+	// truncates leftover. The grown buffer is returned to the pool by the defer.
+	if w.config.ReadBufSize > len(buf) {
+		buf = make([]byte, w.config.ReadBufSize)
+	}
 	readN := copy(buf, leftover)
 
 	var bodyBuf []byte

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -1309,8 +1309,12 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte) {
 					req = r2
 					keepAlive = req.keepAlive
 					goto next
+				case parseHeaderTooLarge:
+					f.Write(wingStatusClose(431))
+					keepAlive = false
+					goto done
 				default:
-					// parseMalformed, parseHeaderTooLarge — silent close.
+					// parseMalformed — silent close.
 					keepAlive = false
 					goto done
 				}

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -662,7 +662,10 @@ func (w *worker) tryParse(c *conn) {
 						return
 					}
 					return
-				default: // parseMalformed, parseHeaderTooLarge
+				case parseHeaderTooLarge:
+					w.writeAndClose(c, wingStatusClose(431))
+					return
+				default: // parseMalformed
 					w.closeConn(c.fd)
 					return
 				}

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -1178,15 +1178,21 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte) {
 	// The pool's default buffer is 8 KB; grow it to the configured ReadBufSize so
 	// the takeover path accepts the same header sizes as the event loop (which
 	// sizes readBuf from ReadBufSize/HeaderLimit) and so copy() below never
-	// truncates leftover. The grown buffer is returned to the pool by the defer.
-	if w.config.ReadBufSize > len(buf) {
+	// truncates leftover.
+	grewBuf := w.config.ReadBufSize > len(buf)
+	if grewBuf {
 		buf = make([]byte, w.config.ReadBufSize)
 	}
 	readN := copy(buf, leftover)
 
 	var bodyBuf []byte
 	defer func() {
-		*bp = buf
+		if !grewBuf {
+			*bp = buf
+		}
+		// grewBuf: *bp still holds the original pool-sized buffer; the
+		// grown buf is dropped here and reclaimed by the GC, preventing
+		// oversized-buffer retention in the pool.
 		takeoverBufPool.Put(bp)
 		bodyBuf = nil
 	}()


### PR DESCRIPTION
Two adopter-visible correctness fixes deferred (non-blocking) from the body-limit review (#134).

## 1. TrustProxy: don't drop X-Forwarded-For / X-Real-IP behind the 8-slot extra-header store
Previously XFF/X-Real-IP landed in the generic 8-entry `extraHdrs` array, so a request with more than 8 unknown headers dropped them and `RemoteAddr()` fell back to the socket peer (the proxy IP). They are now parsed into dedicated `wingRequest` fields, recognized via `knownHeader`'s `len(key)` dispatch (`case 15` / `case 9`). `RawHeader("X-Forwarded-For")` / `Header(...)` still return them for user code.

## 2. classifyIncomplete: 431 for an oversized single header line
A single header line over `HeaderLimit` but within the read buffer previously took the classifier's malformed path and was closed silently. It now returns `parseHeaderTooLarge`, and `tryParse` answers **431** so the client learns why.

## Perf
No hot-path impact:
- #2 lives entirely in the slow-path classifier (`parseHTTPRequestFast` success never calls it).
- #1 only adds `case 9` / `case 15` to `knownHeader`'s length-dispatch switch; hot-path header lengths (4/6/10/12/14) never reach those cases, and the value is copied only when the header is present. `TestParseFastPath_AllocBaseline` stays at 0 allocs.

## Testing
- `go test -race -tags kruda_stdjson ./...` — green on macOS and verified on a real Linux/epoll box (tiger).
- New: `TestWing_TrustProxy_ManyHeaders` (XFF survives >8 extra headers), `TestWing_HeaderLineTooLarge431`.