### PR TITLE
feat: typed-handler test client + OpenAPI 3.1 polish (D4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Typed test-client helpers for typed handlers.** `GetTyped`, `PostTyped`,
+  `PutTyped`, `PatchTyped`, `DeleteTyped`, and `SendTyped` wrap the existing
+  in-memory `TestClient` and decode JSON responses into a typed
+  `TypedTestResponse[T]`, while body helpers accept typed request values.
+- **Richer OpenAPI metadata for typed routes.** Generated OpenAPI 3.1 specs can
+  now include explicit security schemes, per-route security requirements,
+  request/response examples, and error response content schemas aligned with
+  the default Kruda error shape or `WithProblemJSON()`.
 - **Opt-in RFC 9457 problem+json error responses.** `kruda.New(kruda.WithProblemJSON())`
   renders errors as `application/problem+json` (standard members plus a field-level
   `errors` array for validation failures). Off by default — the standard error shape is

--- a/config.go
+++ b/config.go
@@ -57,9 +57,10 @@ type Config struct {
 	// Views is the template engine for c.Render(). Nil = c.Render() returns error.
 	Views ViewEngine
 
-	openAPIInfo openAPIInfo
-	openAPIPath string
-	openAPITags []openAPITagDef
+	openAPIInfo            openAPIInfo
+	openAPIPath            string
+	openAPITags            []openAPITagDef
+	openAPISecuritySchemes map[string]OpenAPISecurityScheme
 }
 
 // SecurityConfig controls security headers and behavior.
@@ -384,6 +385,15 @@ func WithContainer(c *Container) Option {
 	return func(a *App) { a.container = c }
 }
 
+// OpenAPISecurityScheme describes an OpenAPI security scheme.
+type OpenAPISecurityScheme struct {
+	Type         string `json:"type"`
+	Scheme       string `json:"scheme,omitempty"`
+	BearerFormat string `json:"bearerFormat,omitempty"`
+	Name         string `json:"name,omitempty"`
+	In           string `json:"in,omitempty"`
+}
+
 // WithOpenAPIInfo enables OpenAPI spec generation with the given metadata.
 // When configured, a GET handler is auto-registered at the OpenAPI path (default: /openapi.json).
 func WithOpenAPIInfo(title, version, description string) Option {
@@ -411,6 +421,27 @@ func WithOpenAPITag(name, description string) Option {
 			Name: name, Description: description,
 		})
 	}
+}
+
+// WithOpenAPISecurityScheme adds an OpenAPI security scheme to components.
+func WithOpenAPISecurityScheme(name string, scheme OpenAPISecurityScheme) Option {
+	return func(a *App) {
+		if a.config.openAPISecuritySchemes == nil {
+			a.config.openAPISecuritySchemes = make(map[string]OpenAPISecurityScheme)
+		}
+		a.config.openAPISecuritySchemes[name] = scheme
+	}
+}
+
+// WithOpenAPIBearerAuth adds a standard HTTP bearer security scheme.
+func WithOpenAPIBearerAuth(name string) Option {
+	if name == "" {
+		name = "bearerAuth"
+	}
+	return WithOpenAPISecurityScheme(name, OpenAPISecurityScheme{
+		Type:   "http",
+		Scheme: "bearer",
+	})
 }
 
 // selectTransport chooses the transport based on config, env, and OS.

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -204,6 +204,23 @@ func WithOpenAPITag(name, description string) Option
 
 Adds an OpenAPI tag definition.
 
+### WithOpenAPISecurityScheme
+
+```go
+func WithOpenAPISecurityScheme(name string, scheme OpenAPISecurityScheme) Option
+```
+
+Adds an OpenAPI security scheme under `components.securitySchemes`.
+
+### WithOpenAPIBearerAuth
+
+```go
+func WithOpenAPIBearerAuth(name string) Option
+```
+
+Adds a standard HTTP bearer security scheme. An empty name defaults to
+`bearerAuth`.
+
 ## Defaults Summary
 
 | Option | Default |

--- a/docs/api/handler.md
+++ b/docs/api/handler.md
@@ -95,7 +95,9 @@ func GroupPatch[In any, Out any](g *Group, path string, handler func(*C[In]) (*O
 ## RouteOption
 
 ```go
-type RouteOption func(*routeConfig)
+type RouteOption interface {
+    applyRoute(*routeConfig)
+}
 ```
 
 ### WithDescription
@@ -113,6 +115,31 @@ func WithTags(tags ...string) RouteOption
 ```
 
 Sets route tags (used by OpenAPI).
+
+### WithRequestExample
+
+```go
+func WithRequestExample(example any) RouteOption
+```
+
+Sets the OpenAPI request body example for a typed route.
+
+### WithResponseExample
+
+```go
+func WithResponseExample(example any) RouteOption
+```
+
+Sets the OpenAPI 200 response example for a typed route.
+
+### WithOpenAPISecurity
+
+```go
+func WithOpenAPISecurity(name string, scopes ...string) RouteOption
+```
+
+Adds an OpenAPI security requirement to a typed route. Define the scheme with
+`WithOpenAPISecurityScheme` or `WithOpenAPIBearerAuth`.
 
 ## Struct Tag Binding
 

--- a/docs/api/test-client.md
+++ b/docs/api/test-client.md
@@ -68,6 +68,42 @@ resp, err := tc.Request("POST", "/users").
 | `ContentType(ct)` | Set Content-Type header |
 | `Send()` | Execute the request, returns `(*TestResponse, error)` |
 
+## Typed Helpers
+
+Generic helpers send requests through the same in-memory client and decode a
+non-empty JSON response into a typed body:
+
+```go
+resp, err := kruda.PostTyped[CreateUser, User](tc, "/users", CreateUser{Name: "Ada"})
+if err != nil {
+    t.Fatal(err)
+}
+if resp.Body.ID == "" {
+    t.Fatal("missing id")
+}
+```
+
+Available helpers:
+
+```go
+resp, err := kruda.GetTyped[User](tc, "/users/123")
+resp, err := kruda.PostTyped[CreateUser, User](tc, "/users", body)
+resp, err := kruda.PutTyped[UpdateUser, User](tc, "/users/123", body)
+resp, err := kruda.PatchTyped[UpdateUser, User](tc, "/users/123", body)
+resp, err := kruda.DeleteTyped[DeleteResult](tc, "/users/123")
+```
+
+Use `SendTyped` with the request builder when a test needs query parameters,
+headers, cookies, or a custom content type:
+
+```go
+resp, err := kruda.SendTyped[SearchResult](
+    tc.Request("GET", "/search").
+        Query("q", "ada").
+        Header("Authorization", "Bearer test-token"),
+)
+```
+
 ## TestResponse
 
 ### StatusCode

--- a/handler.go
+++ b/handler.go
@@ -53,6 +53,12 @@ func WithResponseExample(example any) RouteOption {
 // WithOpenAPISecurity adds an OpenAPI security requirement to a typed route.
 func WithOpenAPISecurity(name string, scopes ...string) RouteOption {
 	return routeOptionFunc(func(rc *routeConfig) {
+		// OpenAPI requires the scopes value to be an array, never null — use an
+		// empty slice when no scopes are given (e.g. bearer auth) so it
+		// serializes as [] not null.
+		if scopes == nil {
+			scopes = []string{}
+		}
 		rc.security = append(rc.security, map[string][]string{name: scopes})
 	})
 }

--- a/handler.go
+++ b/handler.go
@@ -20,11 +20,14 @@ type routeOptionFunc func(*routeConfig)
 func (f routeOptionFunc) applyRoute(rc *routeConfig) { f(rc) }
 
 type routeConfig struct {
-	description string
-	tags        []string
-	inType      reflect.Type // input type T (for OpenAPI schema generation)
-	outType     reflect.Type // output type Out (for OpenAPI schema generation)
-	preset      *Preset      // per-route Wing dispatch hint (nil = use defaults)
+	description     string
+	tags            []string
+	inType          reflect.Type // input type T (for OpenAPI schema generation)
+	outType         reflect.Type // output type Out (for OpenAPI schema generation)
+	requestExample  any
+	responseExample any
+	security        []map[string][]string
+	preset          *Preset // per-route Wing dispatch hint (nil = use defaults)
 }
 
 // WithDescription sets a route description (used by OpenAPI in Phase 2B).
@@ -35,6 +38,23 @@ func WithDescription(desc string) RouteOption {
 // WithTags sets route tags (used by OpenAPI in Phase 2B).
 func WithTags(tags ...string) RouteOption {
 	return routeOptionFunc(func(rc *routeConfig) { rc.tags = tags })
+}
+
+// WithRequestExample sets the OpenAPI request body example for a typed route.
+func WithRequestExample(example any) RouteOption {
+	return routeOptionFunc(func(rc *routeConfig) { rc.requestExample = example })
+}
+
+// WithResponseExample sets the OpenAPI 200 response example for a typed route.
+func WithResponseExample(example any) RouteOption {
+	return routeOptionFunc(func(rc *routeConfig) { rc.responseExample = example })
+}
+
+// WithOpenAPISecurity adds an OpenAPI security requirement to a typed route.
+func WithOpenAPISecurity(name string, scopes ...string) RouteOption {
+	return routeOptionFunc(func(rc *routeConfig) {
+		rc.security = append(rc.security, map[string][]string{name: scopes})
+	})
 }
 
 // buildTypedHandler creates the handler closure with pre-compiled parser and validators.

--- a/openapi.go
+++ b/openapi.go
@@ -386,7 +386,7 @@ func buildOperation(ri routeInfo, components map[string]*schemaRef, problemJSON 
 	}
 
 	if ri.hasValidate {
-		contentType, schema := errorResponseSchema(components, problemJSON)
+		contentType, schema := validationResponseSchema(components, problemJSON)
 		op.Responses["422"] = &openAPIResponse{
 			Description: "Validation failed",
 			Content: map[string]*openAPIMediaType{
@@ -395,7 +395,7 @@ func buildOperation(ri routeInfo, components map[string]*schemaRef, problemJSON 
 		}
 	}
 
-	contentType, schema := errorResponseSchema(components, problemJSON)
+	contentType, schema := defaultErrorResponseSchema(components, problemJSON)
 	op.Responses["default"] = &openAPIResponse{
 		Description: "Error response",
 		Content: map[string]*openAPIMediaType{
@@ -406,7 +406,21 @@ func buildOperation(ri routeInfo, components map[string]*schemaRef, problemJSON 
 	return op
 }
 
-func errorResponseSchema(components map[string]*schemaRef, problemJSON bool) (string, *schemaRef) {
+// validationResponseSchema returns the media type + schema for a 422 validation
+// response. With problem+json it is a ProblemDetails; otherwise it is the
+// ValidationError shape the validator actually marshals ({code, message, errors}).
+func validationResponseSchema(components map[string]*schemaRef, problemJSON bool) (string, *schemaRef) {
+	if problemJSON {
+		ensureProblemDetailsSchema(components)
+		return "application/problem+json", &schemaRef{Ref: "#/components/schemas/ProblemDetails"}
+	}
+	ensureValidationErrorSchema(components)
+	return "application/json", &schemaRef{Ref: "#/components/schemas/ValidationError"}
+}
+
+// defaultErrorResponseSchema returns the media type + schema for a generic error
+// response. With problem+json it is a ProblemDetails; otherwise it is a KrudaError.
+func defaultErrorResponseSchema(components map[string]*schemaRef, problemJSON bool) (string, *schemaRef) {
 	if problemJSON {
 		ensureProblemDetailsSchema(components)
 		return "application/problem+json", &schemaRef{Ref: "#/components/schemas/ProblemDetails"}
@@ -415,10 +429,30 @@ func errorResponseSchema(components map[string]*schemaRef, problemJSON bool) (st
 	return "application/json", &schemaRef{Ref: "#/components/schemas/KrudaError"}
 }
 
+// ensureFieldErrorSchema documents FieldError. All five fields lack omitempty,
+// so they are always present on the wire and are marked required.
+func ensureFieldErrorSchema(components map[string]*schemaRef) {
+	if _, ok := components["FieldError"]; ok {
+		return
+	}
+	components["FieldError"] = &schemaRef{
+		Type: "object",
+		Properties: map[string]*schemaRef{
+			"field":   {Type: "string"},
+			"rule":    {Type: "string"},
+			"param":   {Type: "string"},
+			"message": {Type: "string"},
+			"value":   {Type: "string"},
+		},
+		Required: []string{"field", "rule", "param", "message", "value"},
+	}
+}
+
 func ensureProblemDetailsSchema(components map[string]*schemaRef) {
 	if _, ok := components["ProblemDetails"]; ok {
 		return
 	}
+	ensureFieldErrorSchema(components)
 	components["ProblemDetails"] = &schemaRef{
 		Type: "object",
 		Properties: map[string]*schemaRef{
@@ -429,10 +463,31 @@ func ensureProblemDetailsSchema(components map[string]*schemaRef) {
 			"instance": {Type: "string"},
 			"errors": {
 				Type:  "array",
-				Items: generateSchema(reflect.TypeOf(FieldError{}), components),
+				Items: &schemaRef{Ref: "#/components/schemas/FieldError"},
 			},
 		},
 		Required: []string{"type", "title", "status"},
+	}
+}
+
+// ensureValidationErrorSchema documents the ValidationError wire shape the
+// validator marshals: {code, message, errors[]} — all required.
+func ensureValidationErrorSchema(components map[string]*schemaRef) {
+	if _, ok := components["ValidationError"]; ok {
+		return
+	}
+	ensureFieldErrorSchema(components)
+	components["ValidationError"] = &schemaRef{
+		Type: "object",
+		Properties: map[string]*schemaRef{
+			"code":    {Type: "integer"},
+			"message": {Type: "string"},
+			"errors": {
+				Type:  "array",
+				Items: &schemaRef{Ref: "#/components/schemas/FieldError"},
+			},
+		},
+		Required: []string{"code", "message", "errors"},
 	}
 }
 

--- a/openapi.go
+++ b/openapi.go
@@ -35,6 +35,7 @@ type openAPIOperation struct {
 	Parameters  []openAPIParameter          `json:"parameters,omitempty"`
 	RequestBody *openAPIRequestBody         `json:"requestBody,omitempty"`
 	Responses   map[string]*openAPIResponse `json:"responses"`
+	Security    []map[string][]string       `json:"security,omitempty"`
 }
 
 type openAPIParameter struct {
@@ -50,7 +51,8 @@ type openAPIRequestBody struct {
 }
 
 type openAPIMediaType struct {
-	Schema *schemaRef `json:"schema"`
+	Schema  *schemaRef `json:"schema"`
+	Example any        `json:"example,omitempty"`
 }
 
 type openAPIResponse struct {
@@ -59,7 +61,8 @@ type openAPIResponse struct {
 }
 
 type openAPIComponents struct {
-	Schemas map[string]*schemaRef `json:"schemas,omitempty"`
+	Schemas         map[string]*schemaRef            `json:"schemas,omitempty"`
+	SecuritySchemes map[string]OpenAPISecurityScheme `json:"securitySchemes,omitempty"`
 }
 
 type openAPITagDef struct {
@@ -297,7 +300,7 @@ func (app *App) buildOpenAPISpec() ([]byte, error) {
 			spec.Paths[oaPath] = pathItem
 		}
 
-		op := buildOperation(ri, components)
+		op := buildOperation(ri, components, app.config.problemJSON)
 
 		switch ri.method {
 		case "GET":
@@ -313,19 +316,23 @@ func (app *App) buildOpenAPISpec() ([]byte, error) {
 		}
 	}
 
-	if len(components) > 0 {
-		spec.Components = &openAPIComponents{Schemas: components}
+	if len(components) > 0 || len(app.config.openAPISecuritySchemes) > 0 {
+		spec.Components = &openAPIComponents{
+			Schemas:         components,
+			SecuritySchemes: app.config.openAPISecuritySchemes,
+		}
 	}
 
 	return app.config.JSONEncoder(spec)
 }
 
 // buildOperation creates an OpenAPI operation from route info.
-func buildOperation(ri routeInfo, components map[string]*schemaRef) *openAPIOperation {
+func buildOperation(ri routeInfo, components map[string]*schemaRef, problemJSON bool) *openAPIOperation {
 	op := &openAPIOperation{
 		Description: ri.config.description,
 		Tags:        ri.config.tags,
 		Responses:   make(map[string]*openAPIResponse),
+		Security:    ri.config.security,
 	}
 
 	inType := ri.config.inType
@@ -362,7 +369,7 @@ func buildOperation(ri routeInfo, components map[string]*schemaRef) *openAPIOper
 			op.RequestBody = &openAPIRequestBody{
 				Required: true,
 				Content: map[string]*openAPIMediaType{
-					contentType: {Schema: bodySchema},
+					contentType: {Schema: bodySchema, Example: ri.config.requestExample},
 				},
 			}
 		}
@@ -373,20 +380,73 @@ func buildOperation(ri routeInfo, components map[string]*schemaRef) *openAPIOper
 		op.Responses["200"] = &openAPIResponse{
 			Description: "Successful response",
 			Content: map[string]*openAPIMediaType{
-				"application/json": {Schema: outSchema},
+				"application/json": {Schema: outSchema, Example: ri.config.responseExample},
 			},
 		}
 	}
 
 	if ri.hasValidate {
+		contentType, schema := errorResponseSchema(components, problemJSON)
 		op.Responses["422"] = &openAPIResponse{
 			Description: "Validation failed",
+			Content: map[string]*openAPIMediaType{
+				contentType: {Schema: schema},
+			},
 		}
 	}
 
+	contentType, schema := errorResponseSchema(components, problemJSON)
 	op.Responses["default"] = &openAPIResponse{
 		Description: "Error response",
+		Content: map[string]*openAPIMediaType{
+			contentType: {Schema: schema},
+		},
 	}
 
 	return op
+}
+
+func errorResponseSchema(components map[string]*schemaRef, problemJSON bool) (string, *schemaRef) {
+	if problemJSON {
+		ensureProblemDetailsSchema(components)
+		return "application/problem+json", &schemaRef{Ref: "#/components/schemas/ProblemDetails"}
+	}
+	ensureKrudaErrorSchema(components)
+	return "application/json", &schemaRef{Ref: "#/components/schemas/KrudaError"}
+}
+
+func ensureProblemDetailsSchema(components map[string]*schemaRef) {
+	if _, ok := components["ProblemDetails"]; ok {
+		return
+	}
+	components["ProblemDetails"] = &schemaRef{
+		Type: "object",
+		Properties: map[string]*schemaRef{
+			"type":     {Type: "string"},
+			"title":    {Type: "string"},
+			"status":   {Type: "integer"},
+			"detail":   {Type: "string"},
+			"instance": {Type: "string"},
+			"errors": {
+				Type:  "array",
+				Items: generateSchema(reflect.TypeOf(FieldError{}), components),
+			},
+		},
+		Required: []string{"type", "title", "status"},
+	}
+}
+
+func ensureKrudaErrorSchema(components map[string]*schemaRef) {
+	if _, ok := components["KrudaError"]; ok {
+		return
+	}
+	components["KrudaError"] = &schemaRef{
+		Type: "object",
+		Properties: map[string]*schemaRef{
+			"code":    {Type: "integer"},
+			"message": {Type: "string"},
+			"detail":  {Type: "string"},
+		},
+		Required: []string{"code", "message"},
+	}
 }

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -382,6 +382,119 @@ func TestBuildOpenAPISpec_WithValidation_Has422(t *testing.T) {
 	}
 }
 
+func TestBuildOpenAPISpec_ExamplesAndSecurity(t *testing.T) {
+	app := New(
+		WithOpenAPIInfo("Test", "1.0.0", ""),
+		WithOpenAPIBearerAuth("bearerAuth"),
+	)
+
+	Post[oaParamQuery, oaOut](app, "/users/:id", func(c *C[oaParamQuery]) (*oaOut, error) {
+		return &oaOut{ID: c.In.ID, Message: c.In.Name}, nil
+	},
+		WithOpenAPISecurity("bearerAuth"),
+		WithRequestExample(oaParamQuery{Name: "Ada"}),
+		WithResponseExample(oaOut{ID: "u1", Message: "created"}),
+	)
+
+	specJSON, err := app.buildOpenAPISpec()
+	if err != nil {
+		t.Fatalf("buildOpenAPISpec failed: %v", err)
+	}
+
+	var spec map[string]any
+	if err := json.Unmarshal(specJSON, &spec); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	components := spec["components"].(map[string]any)
+	securitySchemes := components["securitySchemes"].(map[string]any)
+	bearer := securitySchemes["bearerAuth"].(map[string]any)
+	if bearer["type"] != "http" || bearer["scheme"] != "bearer" {
+		t.Fatalf("bearerAuth = %#v, want http bearer scheme", bearer)
+	}
+
+	postOp := spec["paths"].(map[string]any)["/users/{id}"].(map[string]any)["post"].(map[string]any)
+	security := postOp["security"].([]any)
+	requirement := security[0].(map[string]any)
+	if _, ok := requirement["bearerAuth"]; !ok {
+		t.Fatalf("operation security = %#v, want bearerAuth requirement", security)
+	}
+
+	requestContent := postOp["requestBody"].(map[string]any)["content"].(map[string]any)["application/json"].(map[string]any)
+	requestExample := requestContent["example"].(map[string]any)
+	if requestExample["name"] != "Ada" {
+		t.Fatalf("request example = %#v, want name Ada", requestExample)
+	}
+
+	responseContent := postOp["responses"].(map[string]any)["200"].(map[string]any)["content"].(map[string]any)["application/json"].(map[string]any)
+	responseExample := responseContent["example"].(map[string]any)
+	if responseExample["id"] != "u1" || responseExample["message"] != "created" {
+		t.Fatalf("response example = %#v, want u1/created", responseExample)
+	}
+}
+
+func TestBuildOpenAPISpec_ErrorResponseContent(t *testing.T) {
+	t.Run("problem json", func(t *testing.T) {
+		app := New(
+			WithProblemJSON(),
+			WithValidator(NewValidator()),
+			WithOpenAPIInfo("Test", "1.0.0", ""),
+		)
+
+		type valIn struct {
+			Name string `json:"name" validate:"required"`
+		}
+
+		Post[valIn, oaOut](app, "/items", func(c *C[valIn]) (*oaOut, error) {
+			return &oaOut{ID: "1"}, nil
+		})
+
+		specJSON, err := app.buildOpenAPISpec()
+		if err != nil {
+			t.Fatalf("buildOpenAPISpec failed: %v", err)
+		}
+
+		var spec map[string]any
+		if err := json.Unmarshal(specJSON, &spec); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+
+		responses := spec["paths"].(map[string]any)["/items"].(map[string]any)["post"].(map[string]any)["responses"].(map[string]any)
+		for _, code := range []string{"422", "default"} {
+			content := responses[code].(map[string]any)["content"].(map[string]any)
+			media := content["application/problem+json"].(map[string]any)
+			schema := media["schema"].(map[string]any)
+			if schema["$ref"] != "#/components/schemas/ProblemDetails" {
+				t.Fatalf("%s schema = %#v, want ProblemDetails ref", code, schema)
+			}
+		}
+	})
+
+	t.Run("default json", func(t *testing.T) {
+		app := New(WithOpenAPIInfo("Test", "1.0.0", ""))
+		Get[oaSimple, oaOut](app, "/items", func(c *C[oaSimple]) (*oaOut, error) {
+			return &oaOut{ID: "1"}, nil
+		})
+
+		specJSON, err := app.buildOpenAPISpec()
+		if err != nil {
+			t.Fatalf("buildOpenAPISpec failed: %v", err)
+		}
+
+		var spec map[string]any
+		if err := json.Unmarshal(specJSON, &spec); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+
+		defaultResponse := spec["paths"].(map[string]any)["/items"].(map[string]any)["get"].(map[string]any)["responses"].(map[string]any)["default"].(map[string]any)
+		media := defaultResponse["content"].(map[string]any)["application/json"].(map[string]any)
+		schema := media["schema"].(map[string]any)
+		if schema["$ref"] != "#/components/schemas/KrudaError" {
+			t.Fatalf("schema = %#v, want KrudaError ref", schema)
+		}
+	})
+}
+
 func TestBuildOpenAPISpec_NoConfig_Empty(t *testing.T) {
 	app := New() // no OpenAPI config
 
@@ -467,7 +580,7 @@ func TestBuildOperation_QueryParams(t *testing.T) {
 	}
 
 	components := make(map[string]*schemaRef)
-	op := buildOperation(ri, components)
+	op := buildOperation(ri, components, false)
 
 	queryParams := 0
 	for _, p := range op.Parameters {
@@ -492,7 +605,7 @@ func TestBuildOperation_RequestBody(t *testing.T) {
 	}
 
 	components := make(map[string]*schemaRef)
-	op := buildOperation(ri, components)
+	op := buildOperation(ri, components, false)
 
 	if op.RequestBody == nil {
 		t.Fatal("expected request body for POST with hasBody")
@@ -514,7 +627,7 @@ func TestBuildOperation_FormBody(t *testing.T) {
 	}
 
 	components := make(map[string]*schemaRef)
-	op := buildOperation(ri, components)
+	op := buildOperation(ri, components, false)
 
 	if op.RequestBody == nil {
 		t.Fatal("expected request body for form upload")

--- a/openapi_test.go
+++ b/openapi_test.go
@@ -416,8 +416,12 @@ func TestBuildOpenAPISpec_ExamplesAndSecurity(t *testing.T) {
 	postOp := spec["paths"].(map[string]any)["/users/{id}"].(map[string]any)["post"].(map[string]any)
 	security := postOp["security"].([]any)
 	requirement := security[0].(map[string]any)
-	if _, ok := requirement["bearerAuth"]; !ok {
-		t.Fatalf("operation security = %#v, want bearerAuth requirement", security)
+	scopes, ok := requirement["bearerAuth"].([]any)
+	if !ok {
+		t.Fatalf("operation security bearerAuth = %#v, want a [] array (not null)", requirement["bearerAuth"])
+	}
+	if len(scopes) != 0 {
+		t.Fatalf("bearerAuth scopes = %#v, want empty array", scopes)
 	}
 
 	requestContent := postOp["requestBody"].(map[string]any)["content"].(map[string]any)["application/json"].(map[string]any)
@@ -493,6 +497,63 @@ func TestBuildOpenAPISpec_ErrorResponseContent(t *testing.T) {
 			t.Fatalf("schema = %#v, want KrudaError ref", schema)
 		}
 	})
+
+	t.Run("default json validation 422 uses ValidationError", func(t *testing.T) {
+		app := New(WithValidator(NewValidator()), WithOpenAPIInfo("Test", "1.0.0", ""))
+
+		type valIn struct {
+			Name string `json:"name" validate:"required"`
+		}
+		Post[valIn, oaOut](app, "/items", func(c *C[valIn]) (*oaOut, error) {
+			return &oaOut{ID: "1"}, nil
+		})
+
+		specJSON, err := app.buildOpenAPISpec()
+		if err != nil {
+			t.Fatalf("buildOpenAPISpec failed: %v", err)
+		}
+		var spec map[string]any
+		if err := json.Unmarshal(specJSON, &spec); err != nil {
+			t.Fatalf("invalid JSON: %v", err)
+		}
+
+		// 422 must reference ValidationError ({code,message,errors[]}), not KrudaError.
+		resp422 := spec["paths"].(map[string]any)["/items"].(map[string]any)["post"].(map[string]any)["responses"].(map[string]any)["422"].(map[string]any)
+		schema := resp422["content"].(map[string]any)["application/json"].(map[string]any)["schema"].(map[string]any)
+		if schema["$ref"] != "#/components/schemas/ValidationError" {
+			t.Fatalf("422 schema = %#v, want ValidationError ref", schema)
+		}
+
+		schemas := spec["components"].(map[string]any)["schemas"].(map[string]any)
+
+		// ValidationError requires code, message, errors.
+		ve := schemas["ValidationError"].(map[string]any)
+		veReq := toStringSet(ve["required"].([]any))
+		for _, f := range []string{"code", "message", "errors"} {
+			if !veReq[f] {
+				t.Fatalf("ValidationError.required missing %q: %#v", f, ve["required"])
+			}
+		}
+
+		// FieldError requires all five always-emitted fields.
+		fe := schemas["FieldError"].(map[string]any)
+		feReq := toStringSet(fe["required"].([]any))
+		for _, f := range []string{"field", "rule", "param", "message", "value"} {
+			if !feReq[f] {
+				t.Fatalf("FieldError.required missing %q: %#v", f, fe["required"])
+			}
+		}
+	})
+}
+
+func toStringSet(items []any) map[string]bool {
+	out := make(map[string]bool, len(items))
+	for _, it := range items {
+		if s, ok := it.(string); ok {
+			out[s] = true
+		}
+	}
+	return out
 }
 
 func TestBuildOpenAPISpec_NoConfig_Empty(t *testing.T) {

--- a/test_client.go
+++ b/test_client.go
@@ -102,6 +102,60 @@ func (tc *TestClient) Request(method, path string) *TestRequest {
 	}
 }
 
+// TypedTestResponse wraps a TestResponse and carries a decoded JSON body.
+type TypedTestResponse[T any] struct {
+	*TestResponse
+	Body T
+}
+
+// SendTyped executes a request builder and decodes a non-empty JSON response
+// body into Out.
+func SendTyped[Out any](req *TestRequest) (*TypedTestResponse[Out], error) {
+	resp, err := req.Send()
+	if err != nil {
+		return nil, err
+	}
+	return decodeTypedResponse[Out](resp)
+}
+
+// GetTyped sends a GET request and decodes a non-empty JSON response body into Out.
+func GetTyped[Out any](tc *TestClient, path string) (*TypedTestResponse[Out], error) {
+	return SendTyped[Out](tc.Request(http.MethodGet, path))
+}
+
+// DeleteTyped sends a DELETE request and decodes a non-empty JSON response body into Out.
+func DeleteTyped[Out any](tc *TestClient, path string) (*TypedTestResponse[Out], error) {
+	return SendTyped[Out](tc.Request(http.MethodDelete, path))
+}
+
+// PostTyped sends a POST request with a typed JSON body and decodes a
+// non-empty JSON response body into Out.
+func PostTyped[In any, Out any](tc *TestClient, path string, body In) (*TypedTestResponse[Out], error) {
+	return SendTyped[Out](tc.Request(http.MethodPost, path).Body(body))
+}
+
+// PutTyped sends a PUT request with a typed JSON body and decodes a non-empty
+// JSON response body into Out.
+func PutTyped[In any, Out any](tc *TestClient, path string, body In) (*TypedTestResponse[Out], error) {
+	return SendTyped[Out](tc.Request(http.MethodPut, path).Body(body))
+}
+
+// PatchTyped sends a PATCH request with a typed JSON body and decodes a
+// non-empty JSON response body into Out.
+func PatchTyped[In any, Out any](tc *TestClient, path string, body In) (*TypedTestResponse[Out], error) {
+	return SendTyped[Out](tc.Request(http.MethodPatch, path).Body(body))
+}
+
+func decodeTypedResponse[Out any](resp *TestResponse) (*TypedTestResponse[Out], error) {
+	var out Out
+	if len(resp.Body()) > 0 {
+		if err := resp.JSON(&out); err != nil {
+			return nil, err
+		}
+	}
+	return &TypedTestResponse[Out]{TestResponse: resp, Body: out}, nil
+}
+
 // TestRequest is a builder for constructing test HTTP requests.
 type TestRequest struct {
 	client      *TestClient

--- a/test_client_typed_test.go
+++ b/test_client_typed_test.go
@@ -81,6 +81,34 @@ func TestTypedTestClientNoContent(t *testing.T) {
 	}
 }
 
+// TestTypedTestClientNon2xxBodyNotMistakenForSuccess documents the status-agnostic
+// decode contract: a non-2xx error body is still decoded into the typed success
+// struct without error, so callers MUST check StatusCode() — a non-error return
+// from the typed helper is not itself a success signal. The error body ({code,
+// message}) shares no fields with the success struct, so Body stays zero.
+func TestTypedTestClientNon2xxBodyNotMistakenForSuccess(t *testing.T) {
+	app := New()
+	Get[struct {
+		ID string `param:"id"`
+	}, typedClientUser](app, "/users/:id", func(c *C[struct {
+		ID string `param:"id"`
+	}]) (*typedClientUser, error) {
+		return nil, NotFound("user not found")
+	})
+	app.Compile()
+
+	resp, err := GetTyped[typedClientUser](NewTestClient(app), "/users/u1")
+	if err != nil {
+		t.Fatalf("decoding an error body must not error: %v", err)
+	}
+	if resp.StatusCode() != 404 {
+		t.Fatalf("status = %d, want 404", resp.StatusCode())
+	}
+	if resp.Body != (typedClientUser{}) {
+		t.Fatalf("body = %+v, want zero value (error body must not populate success fields)", resp.Body)
+	}
+}
+
 func TestTypedHandlerProblemErrorIncludesProblemFields(t *testing.T) {
 	type input struct {
 		ID string `param:"id"`

--- a/test_client_typed_test.go
+++ b/test_client_typed_test.go
@@ -1,0 +1,117 @@
+package kruda
+
+import "testing"
+
+type typedClientCreateUser struct {
+	Name string `json:"name"`
+}
+
+type typedClientUser struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func TestTypedTestClientPostTyped(t *testing.T) {
+	app := New()
+	Post[typedClientCreateUser, typedClientUser](app, "/users", func(c *C[typedClientCreateUser]) (*typedClientUser, error) {
+		return &typedClientUser{ID: "u1", Name: c.In.Name}, nil
+	})
+	app.Compile()
+
+	resp, err := PostTyped[typedClientCreateUser, typedClientUser](
+		NewTestClient(app),
+		"/users",
+		typedClientCreateUser{Name: "Ada"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode() != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode())
+	}
+	if resp.Body.ID != "u1" || resp.Body.Name != "Ada" {
+		t.Fatalf("body = %+v, want u1/Ada", resp.Body)
+	}
+}
+
+func TestSendTypedUsesRequestBuilder(t *testing.T) {
+	type queryIn struct {
+		Name string `query:"name"`
+	}
+
+	app := New()
+	Get[queryIn, typedClientUser](app, "/users", func(c *C[queryIn]) (*typedClientUser, error) {
+		return &typedClientUser{ID: c.Header("X-User-ID"), Name: c.In.Name}, nil
+	})
+	app.Compile()
+
+	resp, err := SendTyped[typedClientUser](
+		NewTestClient(app).Request("GET", "/users").
+			Header("X-User-ID", "u2").
+			Query("name", "Grace"),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Body.ID != "u2" || resp.Body.Name != "Grace" {
+		t.Fatalf("body = %+v, want u2/Grace", resp.Body)
+	}
+}
+
+func TestTypedTestClientNoContent(t *testing.T) {
+	app := New()
+	Delete[struct {
+		ID string `param:"id"`
+	}, typedClientUser](app, "/users/:id", func(c *C[struct {
+		ID string `param:"id"`
+	}]) (*typedClientUser, error) {
+		return nil, nil
+	})
+	app.Compile()
+
+	resp, err := DeleteTyped[typedClientUser](NewTestClient(app), "/users/u1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode() != 204 {
+		t.Fatalf("status = %d, want 204", resp.StatusCode())
+	}
+	if resp.Body != (typedClientUser{}) {
+		t.Fatalf("body = %+v, want zero value", resp.Body)
+	}
+}
+
+func TestTypedHandlerProblemErrorIncludesProblemFields(t *testing.T) {
+	type input struct {
+		ID string `param:"id"`
+	}
+
+	app := New(WithProblemJSON())
+	Get[input, typedClientUser](app, "/users/:id", func(c *C[input]) (*typedClientUser, error) {
+		return nil, NotFound("user not found").
+			WithType("https://errors.example.com/not-found").
+			WithInstance("/problems/users/"+c.In.ID).
+			With("userId", c.In.ID)
+	})
+	app.Compile()
+
+	resp, err := GetTyped[map[string]any](NewTestClient(app), "/users/u1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode() != 404 {
+		t.Fatalf("status = %d, want 404", resp.StatusCode())
+	}
+	if ct := resp.Header("Content-Type"); ct != "application/problem+json; charset=utf-8" {
+		t.Fatalf("content-type = %q, want application/problem+json; charset=utf-8", ct)
+	}
+	if resp.Body["type"] != "https://errors.example.com/not-found" {
+		t.Fatalf("type = %v, want custom problem type", resp.Body["type"])
+	}
+	if resp.Body["instance"] != "/problems/users/u1" {
+		t.Fatalf("instance = %v, want custom instance", resp.Body["instance"])
+	}
+	if resp.Body["userId"] != "u1" {
+		t.Fatalf("userId = %v, want u1", resp.Body["userId"])
+	}
+}


### PR DESCRIPTION
## D4: Typed-handler test ergonomics + OpenAPI 3.1 polish

Makes Kruda typed handlers (`C[T]`) easier to test and more accurately documented by OpenAPI, with no runtime handler semantic changes (only richer generated metadata). Additive throughout.

### Typed test client
Package-level generics around the existing in-memory `TestClient` give compile-time-safe request bodies and decoded responses for `C[T]` routes:
```go
resp, _ := observabilitytest... // (kruda pkg)
resp, _ := kruda.PostTyped[CreateUser, User](kruda.NewTestClient(app), "/users", CreateUser{Name: "Ada"})
resp.Body.ID // typed
```
- `SendTyped[Out]`, `GetTyped`/`DeleteTyped`/`PostTyped`/`PutTyped`/`PatchTyped` + `TypedTestResponse[T]`.
- Decodes JSON into `Out` only when the body is non-empty, so 204 responses stay ergonomic.

### OpenAPI 3.1 polish
- **Security schemes**: `WithOpenAPISecurityScheme(name, scheme)` / `WithOpenAPIBearerAuth(name)` (app-level) → `components.securitySchemes`; `WithOpenAPISecurity(name, scopes...)` (route-level) → operation `security`.
- **Examples**: `WithRequestExample` / `WithResponseExample` → media-type `example`.
- **Error response schemas**: 422/default responses now carry content schemas — `application/problem+json` referencing a generated `ProblemDetails` schema when `WithProblemJSON()` is set, else `application/json` referencing `KrudaError`.

### Typed errors through C[T]
No runtime change — a typed handler returning `kruda.NotFound(...).WithType(...).WithInstance(...).With(...)` already flows through `handleError` → `writeProblem` under `WithProblemJSON()` (covered by existing tests).

### Verification
- New tests: `test_client_typed_test.go` (PostTyped, SendTyped via request builder, 204 NoContent); `openapi_test.go` (`ExamplesAndSecurity`, `ErrorResponseContent` problem_json + default_json subtests).
- Full suite `-race -tags kruda_stdjson ./...`: ok.
- gofmt clean. No dependency changes. CHANGELOG updated under `## [1.4.0] — unreleased`.

Design spec + plan local in `docs/superpowers/`. (NO tag — v1.4.0 stays unreleased.)
