### PR TITLE
Wing: shared takeover body budget + pipelined-after-body byte preservation

### DIFF
--- a/wing_body_pipeline_test.go
+++ b/wing_body_pipeline_test.go
@@ -1,0 +1,199 @@
+//go:build linux || darwin
+
+package kruda
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kruda/kruda/transport"
+)
+
+// echoLenHandler replies "METHOD PATH len=N" so pipelined responses can be
+// matched to their requests and the accumulated body length verified.
+func echoLenHandler() transport.Handler {
+	return transport.HandlerFunc(func(w transport.ResponseWriter, r transport.Request) {
+		b, _ := r.Body()
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte(fmt.Sprintf("%s %s len=%d", r.Method(), r.Path(), len(b))))
+	})
+}
+
+// TestWing_EventLoop_PipelinedAfterAccumulatedBody verifies that a request
+// pipelined immediately after a body that required multi-read accumulation is
+// not dropped. The body (16KB) exceeds the 8KB read buffer, forcing the
+// event-loop accumulation path; the trailing GET arrives in the same byte
+// stream and must still be served.
+func TestWing_EventLoop_PipelinedAfterAccumulatedBody(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing integration test in short mode")
+	}
+	cfg := WingConfig{
+		Workers:     1,
+		ReadBufSize: 8192,
+		BodyLimit:   64 * 1024, // body well within limit, but > read buffer
+	}
+	addr, stop := startWingServerWithConfig(t, cfg, echoLenHandler())
+	defer stop()
+
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	body := strings.Repeat("x", 16*1024)
+	pipeline := "POST /upload HTTP/1.1\r\nHost: h\r\nContent-Length: " + strconv.Itoa(len(body)) + "\r\n\r\n" + body +
+		"GET /done HTTP/1.1\r\nHost: h\r\n\r\n"
+	if _, err := conn.Write([]byte(pipeline)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	reader := bufio.NewReader(conn)
+	_, body1, err := readHTTPResponse(reader)
+	if err != nil {
+		t.Fatalf("response 1 (POST): %v", err)
+	}
+	if body1 != "POST /upload len=16384" {
+		t.Fatalf("response 1 body = %q, want POST /upload len=16384", body1)
+	}
+	_, body2, err := readHTTPResponse(reader)
+	if err != nil {
+		t.Fatalf("response 2 (pipelined GET dropped after accumulated body): %v", err)
+	}
+	if body2 != "GET /done len=0" {
+		t.Fatalf("response 2 body = %q, want GET /done len=0", body2)
+	}
+}
+
+// TestWing_Takeover_PipelinedAfterAccumulatedBody verifies the takeover path
+// does not drop a request pipelined after an accumulated body. A first GET on a
+// DB-preset (Takeover dispatch) route hands the connection to takeoverLoop; the
+// following POST (16KB body, > read buffer) accumulates in the takeover loop and
+// the trailing GET must still be served.
+func TestWing_Takeover_PipelinedAfterAccumulatedBody(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing integration test in short mode")
+	}
+	cfg := WingConfig{
+		Workers:       1,
+		ReadBufSize:   8192,
+		BodyLimit:     64 * 1024,
+		DefaultPreset: DB, // Takeover dispatch
+	}
+	addr, stop := startWingServerWithConfig(t, cfg, echoLenHandler())
+	defer stop()
+
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	body := strings.Repeat("y", 16*1024)
+	pipeline := "GET /a HTTP/1.1\r\nHost: h\r\n\r\n" +
+		"POST /upload HTTP/1.1\r\nHost: h\r\nContent-Length: " + strconv.Itoa(len(body)) + "\r\n\r\n" + body +
+		"GET /done HTTP/1.1\r\nHost: h\r\n\r\n"
+	if _, err := conn.Write([]byte(pipeline)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	reader := bufio.NewReader(conn)
+	wants := []string{"GET /a len=0", "POST /upload len=16384", "GET /done len=0"}
+	for i, want := range wants {
+		_, b, err := readHTTPResponse(reader)
+		if err != nil {
+			t.Fatalf("response %d (%s): %v", i, want, err)
+		}
+		if b != want {
+			t.Fatalf("response %d body = %q, want %q", i, b, want)
+		}
+	}
+}
+
+// takeoverStallConn opens a connection, drives the first GET through to the
+// Takeover loop, reads its 200, then sends only the headers of a body POST so
+// the takeover goroutine charges the in-flight body budget and parks waiting for
+// a body that never arrives. Returns the live connection (caller closes it).
+func takeoverStallConn(t *testing.T, addr string, contentLen int) net.Conn {
+	t.Helper()
+	c, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Fatalf("dial stall: %v", err)
+	}
+	c.SetDeadline(time.Now().Add(3 * time.Second))
+	if _, err := c.Write([]byte("GET /a HTTP/1.1\r\nHost: h\r\n\r\n")); err != nil {
+		t.Fatalf("write stall GET: %v", err)
+	}
+	r := bufio.NewReader(c)
+	if st, _, err := readHTTPResponse(r); err != nil || !strings.Contains(st, "200") {
+		t.Fatalf("stall GET response = %q err=%v, want 200", st, err)
+	}
+	// Headers only — withhold the body so the takeover loop stays parked with the
+	// budget charged.
+	fmt.Fprintf(c, "POST /u HTTP/1.1\r\nHost: h\r\nContent-Length: %d\r\n\r\n", contentLen)
+	return c
+}
+
+// TestWing_Takeover_BodyBudget503 verifies that takeover body accumulation
+// charges the shared per-worker in-flight budget (MaxInflightBodyBytes), so a
+// flood of concurrent takeover uploads cannot allocate unbounded memory: once
+// the budget is exhausted, a further upload is rejected with 503.
+func TestWing_Takeover_BodyBudget503(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing integration test in short mode")
+	}
+	const bodyLimit = 16 * 1024
+	cfg := WingConfig{
+		Workers:              1,
+		ReadBufSize:          8192,
+		BodyLimit:            bodyLimit,
+		MaxInflightBodyBytes: 2 * bodyLimit, // room for exactly two concurrent uploads
+		DefaultPreset:        DB,            // Takeover dispatch
+		ReadTimeout:          2 * time.Second,
+	}
+	addr, stop := startWingServerWithConfig(t, cfg, echoLenHandler())
+	defer stop()
+
+	// Two stalled takeover uploads charge the whole budget (2 * 16KB).
+	s1 := takeoverStallConn(t, addr, bodyLimit)
+	defer s1.Close()
+	s2 := takeoverStallConn(t, addr, bodyLimit)
+	defer s2.Close()
+	// Let both takeover goroutines reach parseNeedBody and charge the budget.
+	time.Sleep(300 * time.Millisecond)
+
+	// A third upload exceeds the budget and must be rejected with 503.
+	c := net.Conn(nil)
+	{
+		var err error
+		c, err = net.DialTimeout("tcp", addr, time.Second)
+		if err != nil {
+			t.Fatalf("dial third: %v", err)
+		}
+		defer c.Close()
+		c.SetDeadline(time.Now().Add(3 * time.Second))
+	}
+	if _, err := c.Write([]byte("GET /a HTTP/1.1\r\nHost: h\r\n\r\n")); err != nil {
+		t.Fatalf("write third GET: %v", err)
+	}
+	r := bufio.NewReader(c)
+	if st, _, err := readHTTPResponse(r); err != nil || !strings.Contains(st, "200") {
+		t.Fatalf("third GET response = %q err=%v, want 200", st, err)
+	}
+	fmt.Fprintf(c, "POST /u HTTP/1.1\r\nHost: h\r\nContent-Length: %d\r\n\r\n%s", bodyLimit, strings.Repeat("z", bodyLimit))
+	st, _, err := readHTTPResponse(r)
+	if err != nil {
+		t.Fatalf("third POST: expected 503, got error %v", err)
+	}
+	if !strings.Contains(st, "503") {
+		t.Fatalf("third POST status = %q, want 503 (takeover budget not enforced)", st)
+	}
+}

--- a/wing_body_pipeline_test.go
+++ b/wing_body_pipeline_test.go
@@ -72,21 +72,87 @@ func TestWing_EventLoop_PipelinedAfterAccumulatedBody(t *testing.T) {
 	}
 }
 
-// TestWing_Takeover_PipelinedAfterAccumulatedBody verifies the takeover path
-// does not drop a request pipelined after an accumulated body. A first GET on a
-// DB-preset (Takeover dispatch) route hands the connection to takeoverLoop; the
-// following POST (16KB body, > read buffer) accumulates in the takeover loop and
-// the trailing GET must still be served.
-func TestWing_Takeover_PipelinedAfterAccumulatedBody(t *testing.T) {
+// TestWing_Takeover_BodyAccumulation covers the takeover accumulation path end to
+// end on a single server (to limit takeover server churn): a request pipelined
+// after an accumulated body is preserved (#4), and the in-flight body budget is
+// charged and then refunded on completion (#3) so sequential uploads succeed.
+//
+// A first GET on a DB-preset (Takeover dispatch) route hands the connection to
+// takeoverLoop; the following POST (16KB body, > read buffer) accumulates there.
+// The budget has room for exactly one upload, so the second upload only succeeds
+// if the first's charge was refunded.
+func TestWing_Takeover_BodyAccumulation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping Wing integration test in short mode")
 	}
+	const bodyLimit = 64 * 1024
 	cfg := WingConfig{
-		Workers:       1,
-		ReadBufSize:   8192,
-		BodyLimit:     64 * 1024,
-		DefaultPreset: DB, // Takeover dispatch
+		Workers:              1,
+		ReadBufSize:          8192,
+		BodyLimit:            bodyLimit,
+		MaxInflightBodyBytes: 16 * 1024, // room for exactly one 16KB upload
+		DefaultPreset:        DB,        // Takeover dispatch
 	}
+	addr, stop := startWingServerWithConfig(t, cfg, echoLenHandler())
+	defer stop()
+
+	conn, r := takeoverEstablish(t, addr)
+	defer conn.Close()
+
+	// POST (accumulated body) immediately followed by a pipelined GET: the GET
+	// must not be dropped (#4 surplus preservation).
+	body := strings.Repeat("y", 16*1024)
+	pipeline := "POST /upload HTTP/1.1\r\nHost: h\r\nContent-Length: " + strconv.Itoa(len(body)) + "\r\n\r\n" + body +
+		"GET /done HTTP/1.1\r\nHost: h\r\n\r\n"
+	if _, err := conn.Write([]byte(pipeline)); err != nil {
+		t.Fatalf("write pipeline: %v", err)
+	}
+	for _, want := range []string{"POST /upload len=16384", "GET /done len=0"} {
+		_, b, err := readHTTPResponse(r)
+		if err != nil {
+			t.Fatalf("response %q: %v", want, err)
+		}
+		if b != want {
+			t.Fatalf("response body = %q, want %q", b, want)
+		}
+	}
+
+	// A second accumulated upload must succeed — proving the first upload's budget
+	// charge was refunded on completion (#3). A leak would reject this with 503.
+	fmt.Fprintf(conn, "POST /upload HTTP/1.1\r\nHost: h\r\nContent-Length: %d\r\n\r\n%s", len(body), body)
+	st, b, err := readHTTPResponse(r)
+	if err != nil {
+		t.Fatalf("second upload: %v", err)
+	}
+	if !strings.Contains(st, "200") || b != "POST /upload len=16384" {
+		t.Fatalf("second upload st=%q body=%q, want 200 / len=16384 (budget leaked?)", st, b)
+	}
+
+	// An upload whose charge exceeds the budget (32KB > 16KB) is rejected with 503
+	// (#3 enforcement). This is the last request on the connection — the reject
+	// closes it. The 32KB body exceeds the read buffer so it takes the takeover
+	// accumulation path where the budget is charged.
+	big := strings.Repeat("z", 32*1024)
+	fmt.Fprintf(conn, "POST /upload HTTP/1.1\r\nHost: h\r\nContent-Length: %d\r\n\r\n%s", len(big), big)
+	st, _, err = readHTTPResponse(r)
+	if err != nil {
+		t.Fatalf("over-budget upload: expected 503, got error %v", err)
+	}
+	if !strings.Contains(st, "503") {
+		t.Fatalf("over-budget upload status = %q, want 503 (takeover budget not enforced)", st)
+	}
+}
+
+// TestWing_EventLoop_PartialPipelinedAfterAccumulatedBody verifies that a
+// request whose header is only partially present behind an accumulated body is
+// preserved (not dropped) and is completed when the remaining bytes arrive on a
+// later read. This is the edge-triggered-epoll case: the partial surplus is held
+// in readBuf and the next socket edge finishes it.
+func TestWing_EventLoop_PartialPipelinedAfterAccumulatedBody(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing integration test in short mode")
+	}
+	cfg := WingConfig{Workers: 1, ReadBufSize: 8192, BodyLimit: 64 * 1024}
 	addr, stop := startWingServerWithConfig(t, cfg, echoLenHandler())
 	defer stop()
 
@@ -97,103 +163,55 @@ func TestWing_Takeover_PipelinedAfterAccumulatedBody(t *testing.T) {
 	defer conn.Close()
 	conn.SetDeadline(time.Now().Add(5 * time.Second))
 
-	body := strings.Repeat("y", 16*1024)
-	pipeline := "GET /a HTTP/1.1\r\nHost: h\r\n\r\n" +
-		"POST /upload HTTP/1.1\r\nHost: h\r\nContent-Length: " + strconv.Itoa(len(body)) + "\r\n\r\n" + body +
-		"GET /done HTTP/1.1\r\nHost: h\r\n\r\n"
-	if _, err := conn.Write([]byte(pipeline)); err != nil {
-		t.Fatalf("write: %v", err)
+	body := strings.Repeat("x", 16*1024)
+	// Body plus only a partial next request-line — the rest is withheld.
+	first := "POST /upload HTTP/1.1\r\nHost: h\r\nContent-Length: " + strconv.Itoa(len(body)) + "\r\n\r\n" + body +
+		"GET /done HT"
+	if _, err := conn.Write([]byte(first)); err != nil {
+		t.Fatalf("write first: %v", err)
 	}
 
 	reader := bufio.NewReader(conn)
-	wants := []string{"GET /a len=0", "POST /upload len=16384", "GET /done len=0"}
-	for i, want := range wants {
-		_, b, err := readHTTPResponse(reader)
-		if err != nil {
-			t.Fatalf("response %d (%s): %v", i, want, err)
-		}
-		if b != want {
-			t.Fatalf("response %d body = %q, want %q", i, b, want)
-		}
+	_, body1, err := readHTTPResponse(reader)
+	if err != nil {
+		t.Fatalf("response 1 (POST): %v", err)
+	}
+	if body1 != "POST /upload len=16384" {
+		t.Fatalf("response 1 body = %q, want POST /upload len=16384", body1)
+	}
+
+	// Send the rest of the partial request on a later write (a new socket edge).
+	if _, err := conn.Write([]byte("TP/1.1\r\nHost: h\r\n\r\n")); err != nil {
+		t.Fatalf("write rest: %v", err)
+	}
+	_, body2, err := readHTTPResponse(reader)
+	if err != nil {
+		t.Fatalf("response 2 (partial pipelined request lost): %v", err)
+	}
+	if body2 != "GET /done len=0" {
+		t.Fatalf("response 2 body = %q, want GET /done len=0", body2)
 	}
 }
 
-// takeoverStallConn opens a connection, drives the first GET through to the
-// Takeover loop, reads its 200, then sends only the headers of a body POST so
-// the takeover goroutine charges the in-flight body budget and parks waiting for
-// a body that never arrives. Returns the live connection (caller closes it).
-func takeoverStallConn(t *testing.T, addr string, contentLen int) net.Conn {
+// takeoverEstablish dials a connection and drives a first GET through to the
+// Takeover loop, returning the live connection and its response reader. A
+// subsequent body POST on the same connection then exercises the takeover
+// parseNeedBody accumulation path (the first request can never accumulate — it
+// is dispatched complete or inline). Caller closes the connection.
+func takeoverEstablish(t *testing.T, addr string) (net.Conn, *bufio.Reader) {
 	t.Helper()
 	c, err := net.DialTimeout("tcp", addr, time.Second)
 	if err != nil {
-		t.Fatalf("dial stall: %v", err)
+		t.Fatalf("dial: %v", err)
 	}
-	c.SetDeadline(time.Now().Add(3 * time.Second))
+	c.SetDeadline(time.Now().Add(5 * time.Second))
 	if _, err := c.Write([]byte("GET /a HTTP/1.1\r\nHost: h\r\n\r\n")); err != nil {
-		t.Fatalf("write stall GET: %v", err)
+		t.Fatalf("write GET: %v", err)
 	}
 	r := bufio.NewReader(c)
-	if st, _, err := readHTTPResponse(r); err != nil || !strings.Contains(st, "200") {
-		t.Fatalf("stall GET response = %q err=%v, want 200", st, err)
-	}
-	// Headers only — withhold the body so the takeover loop stays parked with the
-	// budget charged.
-	fmt.Fprintf(c, "POST /u HTTP/1.1\r\nHost: h\r\nContent-Length: %d\r\n\r\n", contentLen)
-	return c
-}
-
-// TestWing_Takeover_BodyBudget503 verifies that takeover body accumulation
-// charges the shared per-worker in-flight budget (MaxInflightBodyBytes), so a
-// flood of concurrent takeover uploads cannot allocate unbounded memory: once
-// the budget is exhausted, a further upload is rejected with 503.
-func TestWing_Takeover_BodyBudget503(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping Wing integration test in short mode")
-	}
-	const bodyLimit = 16 * 1024
-	cfg := WingConfig{
-		Workers:              1,
-		ReadBufSize:          8192,
-		BodyLimit:            bodyLimit,
-		MaxInflightBodyBytes: 2 * bodyLimit, // room for exactly two concurrent uploads
-		DefaultPreset:        DB,            // Takeover dispatch
-		ReadTimeout:          2 * time.Second,
-	}
-	addr, stop := startWingServerWithConfig(t, cfg, echoLenHandler())
-	defer stop()
-
-	// Two stalled takeover uploads charge the whole budget (2 * 16KB).
-	s1 := takeoverStallConn(t, addr, bodyLimit)
-	defer s1.Close()
-	s2 := takeoverStallConn(t, addr, bodyLimit)
-	defer s2.Close()
-	// Let both takeover goroutines reach parseNeedBody and charge the budget.
-	time.Sleep(300 * time.Millisecond)
-
-	// A third upload exceeds the budget and must be rejected with 503.
-	c := net.Conn(nil)
-	{
-		var err error
-		c, err = net.DialTimeout("tcp", addr, time.Second)
-		if err != nil {
-			t.Fatalf("dial third: %v", err)
-		}
-		defer c.Close()
-		c.SetDeadline(time.Now().Add(3 * time.Second))
-	}
-	if _, err := c.Write([]byte("GET /a HTTP/1.1\r\nHost: h\r\n\r\n")); err != nil {
-		t.Fatalf("write third GET: %v", err)
-	}
-	r := bufio.NewReader(c)
-	if st, _, err := readHTTPResponse(r); err != nil || !strings.Contains(st, "200") {
-		t.Fatalf("third GET response = %q err=%v, want 200", st, err)
-	}
-	fmt.Fprintf(c, "POST /u HTTP/1.1\r\nHost: h\r\nContent-Length: %d\r\n\r\n%s", bodyLimit, strings.Repeat("z", bodyLimit))
 	st, _, err := readHTTPResponse(r)
-	if err != nil {
-		t.Fatalf("third POST: expected 503, got error %v", err)
+	if err != nil || !strings.Contains(st, "200") {
+		t.Fatalf("GET /a response = %q err=%v, want 200", st, err)
 	}
-	if !strings.Contains(st, "503") {
-		t.Fatalf("third POST status = %q, want 503 (takeover budget not enforced)", st)
-	}
+	return c, r
 }

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -249,14 +249,14 @@ type worker struct {
 	presets  PresetTable
 	// Exact-route MRU cache. Paths stored here must come from Preset.path,
 	// never directly from the read buffer's unsafe request path.
-	lastPreset0  Preset
-	lastPreset1  Preset
-	lastMethod0  string
-	lastMethod1  string
-	lastPath0    string
-	lastPath1    string
-	shutdown     *atomic.Bool
-	hasTimeout   bool
+	lastPreset0     Preset
+	lastPreset1     Preset
+	lastMethod0     string
+	lastMethod1     string
+	lastPath0       string
+	lastPath1       string
+	shutdown        *atomic.Bool
+	hasTimeout      bool
 	readTimeout     int64 // nanoseconds (0 = disabled)
 	writeTimeout    int64
 	idleTimeout     int64
@@ -264,7 +264,7 @@ type worker struct {
 	inflightBody    int64 // current in-flight body bytes (atomic)
 	trustProxy      bool
 	sweepAt         int64 // next sweep unix nano
-	now          int64 // unix nano cached once per event batch
+	now             int64 // unix nano cached once per event batch
 	// dispatchWG tracks Spawn and Takeover goroutines so cleanup() can wait
 	// for in-flight RawSyscall(SYS_WRITE) / blocking syscall.Write calls to
 	// finish before closing fds. Pool goroutines are tracked separately by
@@ -428,11 +428,11 @@ func newWorker(id, listenFd int, cfg WingConfig, handler transport.Handler) (*wo
 	doneCh := make(chan doneMsg, 4096)
 	ft := NewPresetTable(cfg.Presets, cfg.DefaultPreset)
 	w := &worker{
-		id:           id,
-		listenFd:     listenFd,
-		eng:          eng,
-		handler:      handler,
-		config:       cfg,
+		id:              id,
+		listenFd:        listenFd,
+		eng:             eng,
+		handler:         handler,
+		config:          cfg,
 		limits:          parserLimits{maxHeaderCount: cfg.MaxHeaderCount, maxHeaderSize: cfg.MaxHeaderSize, bodyLimit: cfg.BodyLimit},
 		maxConns:        cfg.MaxConnsPerWorker,
 		conns:           make(map[int32]*conn, 1024),
@@ -624,8 +624,15 @@ func (w *worker) handleRecv(ev event) {
 	}
 	// If accumulating a multi-recv body, feed new bytes into the accumulator.
 	if c.bodyNeed > 0 {
-		c.bodyBuf = appendGrow(c.bodyBuf, c.readBuf[:c.readN], c.bodyNeed)
-		c.readN = 0
+		var surplus []byte
+		c.bodyBuf, surplus = accumBody(c.bodyBuf, c.readBuf[:c.readN], c.bodyNeed)
+		if len(surplus) > 0 {
+			// Body completed with trailing pipelined bytes — relocate them to the
+			// front of readBuf so the post-dispatch parse sees the next request.
+			c.readN = copy(c.readBuf, surplus)
+		} else {
+			c.readN = 0
+		}
 		w.drainBodyAccum(c)
 		return
 	}
@@ -654,7 +661,7 @@ func (w *worker) tryParse(c *conn) {
 						// Flush it immediately so the client sends the body.
 						if len(c.sendBuf) > 0 {
 							c.sendN = 0
-							w.directSend(c)  // non-blocking; rest of buf stays queued if partial
+							w.directSend(c) // non-blocking; rest of buf stays queued if partial
 						}
 					}
 					if !w.beginBodyAccum(c, need) {
@@ -682,7 +689,7 @@ func (w *worker) tryParse(c *conn) {
 						// Flush it immediately so the client sends the body.
 						if len(c.sendBuf) > 0 {
 							c.sendN = 0
-							w.directSend(c)  // non-blocking; rest of buf stays queued if partial
+							w.directSend(c) // non-blocking; rest of buf stays queued if partial
 						}
 					}
 					if !w.beginBodyAccum(c, need) {
@@ -918,16 +925,18 @@ func (w *worker) writeAndClose(c *conn, resp []byte) {
 	}
 }
 
-// appendGrow appends src to dst, capping total length at maxCap bytes.
-func appendGrow(dst, src []byte, maxCap int) []byte {
-	avail := maxCap - len(dst)
-	if avail <= 0 {
-		return dst
+// accumBody appends as much of src as the body still needs into bodyBuf (capped
+// at need) and returns the grown buffer plus any surplus — the start of the next
+// pipelined request that arrived in the same read. The surplus aliases src's
+// backing array, so callers must relocate it (to the front of c.readBuf) before
+// reusing that array.
+func accumBody(bodyBuf, src []byte, need int) (out, surplus []byte) {
+	take := need - len(bodyBuf)
+	if take > len(src) {
+		take = len(src)
 	}
-	if len(src) > avail {
-		src = src[:avail]
-	}
-	return append(dst, src...)
+	out = append(bodyBuf, src[:take]...)
+	return out, src[take:]
 }
 
 // beginBodyAccum starts body accumulation for a connection.
@@ -957,10 +966,17 @@ func (w *worker) beginBodyAccum(c *conn, need int) bool {
 	}
 	c.bodyBuf = make([]byte, 0, initCap)
 	// Copy any body bytes already present in the read buffer.
+	var surplus []byte
 	if have := c.readN - headerEnd; have > 0 {
-		c.bodyBuf = appendGrow(c.bodyBuf, c.readBuf[headerEnd:c.readN], need)
+		c.bodyBuf, surplus = accumBody(c.bodyBuf, c.readBuf[headerEnd:c.readN], need)
 	}
-	c.readN = 0
+	if len(surplus) > 0 {
+		// The initial buffer already holds the full body plus the start of the
+		// next pipelined request — preserve that surplus for the post-dispatch parse.
+		c.readN = copy(c.readBuf, surplus)
+	} else {
+		c.readN = 0
+	}
 	w.drainBodyAccum(c)
 	return true
 }
@@ -981,7 +997,14 @@ func (w *worker) drainBodyAccum(c *conn) bool {
 			w.closeConn(c.fd)
 			return true
 		}
-		c.bodyBuf = appendGrow(c.bodyBuf, c.readBuf[:int(rn)], c.bodyNeed)
+		var surplus []byte
+		c.bodyBuf, surplus = accumBody(c.bodyBuf, c.readBuf[:int(rn)], c.bodyNeed)
+		if len(surplus) > 0 {
+			// The read overshot the body — the body is now complete, so this loop
+			// exits. Relocate the trailing pipelined bytes to the front of readBuf
+			// for the post-dispatch parse.
+			c.readN = copy(c.readBuf, surplus)
+		}
 	}
 	if len(c.bodyBuf) >= c.bodyNeed {
 		w.finishBodyAccum(c)
@@ -1277,6 +1300,19 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte) {
 						goto done
 					}
 					headerEnd += 4
+					// Charge the shared per-worker in-flight body budget so a flood
+					// of concurrent takeover uploads cannot allocate unbounded memory
+					// (mirrors the event-loop beginBodyAccum). Refunded on every exit
+					// below — completion, read error — since takeover never reaches
+					// closeConn while accumulating.
+					if w.maxInflightBody > 0 {
+						if atomic.AddInt64(&w.inflightBody, int64(need)) > int64(w.maxInflightBody) {
+							atomic.AddInt64(&w.inflightBody, -int64(need))
+							f.Write(wingStatusClose(503))
+							keepAlive = false
+							goto done
+						}
+					}
 					headerSnapshot := make([]byte, headerEnd)
 					copy(headerSnapshot, buf[:headerEnd])
 					// Seed bodyBuf with already-received body bytes.
@@ -1300,6 +1336,9 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte) {
 							if w.readTimeout > 0 {
 								f.SetReadDeadline(time.Time{})
 							}
+							if w.maxInflightBody > 0 {
+								atomic.AddInt64(&w.inflightBody, -int64(need))
+							}
 							keepAlive = false
 							goto done
 						}
@@ -1307,8 +1346,20 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte) {
 					if w.readTimeout > 0 {
 						f.SetReadDeadline(time.Time{})
 					}
+					// Body fully accumulated — release the budget reservation
+					// (mirrors finishBodyAccum). Any later exit on this iteration is
+					// post-accumulation, so it must not refund again.
+					if w.maxInflightBody > 0 {
+						atomic.AddInt64(&w.inflightBody, -int64(need))
+					}
 					// Reconstruct and re-parse with full body present.
 					full := append(headerSnapshot, bodyBuf[:need]...)
+					// Carry bytes beyond the body (start of the next pipelined
+					// request) back into buf so the next iteration parses them
+					// instead of dropping them.
+					if surplus := len(bodyBuf) - need; surplus > 0 {
+						readN = copy(buf, bodyBuf[need:])
+					}
 					bodyBuf = bodyBuf[:0]
 					r2, _, ok2 := parseHTTPRequest(full, w.limits)
 					if !ok2 {

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -1007,12 +1007,38 @@ func (w *worker) drainBodyAccum(c *conn) bool {
 		}
 	}
 	if len(c.bodyBuf) >= c.bodyNeed {
+		// Capture any pipelined request that already arrived behind the body
+		// before dispatching: edge-triggered epoll will not re-notify for bytes
+		// buffered in the socket before the body completed, so a request split
+		// across the completion boundary would otherwise stall.
+		w.drainPipelinedAfterBody(c)
 		w.finishBodyAccum(c)
 	} else {
 		// Socket drained but body still incomplete — wait for the next recv.
 		submitIdleRecv(w.eng, c.fd, nil, 0)
 	}
 	return false
+}
+
+// drainPipelinedAfterBody appends socket bytes that follow a just-completed body
+// (the start of the next pipelined request) into readBuf after any surplus
+// already relocated to its front. Non-blocking: it stops at EAGAIN or a full
+// buffer, so on the common case where no pipelined request is waiting it costs a
+// single EAGAIN read. A pipelined burst exceeding the read buffer is bounded by
+// the same buffer-size limit as ordinary pipelining.
+func (w *worker) drainPipelinedAfterBody(c *conn) {
+	for c.readN < len(c.readBuf) {
+		rn, _, e := syscall.RawSyscall(syscall.SYS_READ, uintptr(c.fd), uintptr(unsafe.Pointer(&c.readBuf[c.readN])), uintptr(len(c.readBuf)-c.readN))
+		if e == syscall.EAGAIN || e == syscall.EWOULDBLOCK {
+			return
+		}
+		if e != 0 || rn <= 0 {
+			// Error or EOF: the accumulated request is still dispatched; teardown
+			// happens on the post-response keep-alive read.
+			return
+		}
+		c.readN += int(rn)
+	}
 }
 
 // finishBodyAccum re-parses the completed request and dispatches it inline.


### PR DESCRIPTION
## What

Two Wing follow-ups to the body-limit-parity work (#3 + #4):

**#3 — Shared in-flight body budget on the takeover path.** Takeover body
accumulation now charges and refunds the per-worker `MaxInflightBodyBytes`
budget (the same atomic the event-loop path uses), rejecting with **503** when a
charge would exceed it. Previously the takeover path accumulated bodies with no
aggregate cap, so N concurrent takeover uploads could allocate up to
N×BodyLimit. The budget now bounds total in-flight body memory across **both**
read paths. The reservation is refunded on every exit (completion, read error,
over-budget reject) — takeover ends via `doneCh`/file, never `closeConn`, so the
refunds are explicit in the loop.

**#4 — Preserve a request pipelined immediately after an accumulated body.**
Both read paths previously **dropped** bytes that arrived behind a body once the
body was complete. Now:
- Event-loop (`handleRecv` feed / `beginBodyAccum` seed / `drainBodyAccum` read)
  uses a unified `accumBody` helper and relocates the surplus to the front of
  `readBuf` for the post-dispatch parse.
- After completion it drains any already-buffered pipelined bytes
  (`drainPipelinedAfterBody`) — edge-triggered epoll does not re-notify for bytes
  that arrived before the body finished, so a request split across the completion
  boundary would otherwise stall. Non-blocking (single EAGAIN read when nothing
  is pipelined).
- Takeover carries `bodyBuf[need:]` back into its read buffer; its blocking
  `f.Read` + non-blocking spin already pull any trailing bytes.

## Invariants preserved

- Fast/no-body hot path is byte-for-byte unchanged (`parseHTTPRequestFast` and
  the complete-request branch are untouched). Alloc guards
  `TestParseFastPath_AllocBaseline` / `TestStringLaneZeroAlloc` stay green.
- Paired A/B on Linux: plaintext throughput branch ≈ main (no regression).

## Tests

`wing_body_pipeline_test.go` — event-loop pipelined-after-body, event-loop
partial-pipelined (ET edge), and a single takeover server exercising #4 surplus
preservation + #3 charge / refund-on-completion / 503-on-exceed.

## Verification

- Full core suite `-race -tags kruda_stdjson` green on **Linux/epoll** (CI gate)
  and macOS; new tests race-clean (Linux 6×, single takeover server 300×).
- codex adversarial review: **APPROVE**.