### PR TITLE
fix(wing): close takeover File on shutdown to prevent fd double-close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the whole request read, and `TrustProxy` reads `X-Forwarded-For`/`X-Real-IP`
   with the same boolean semantics as net/http. The no-body hot path is unchanged
   (parser fast path frozen, 0-alloc guard; tiger A/B shows no regression).
+- **Wing no longer double-closes a Takeover connection's fd on shutdown.**
+  Graceful shutdown discarded the `*os.File` that owns a Takeover connection's
+  fd without closing it while also raw-closing the same fd; the leaked File's
+  finalizer then closed the fd after the kernel had recycled the number for a
+  new socket, surfacing as intermittent `bad file descriptor` errors on a
+  subsequent `net.Listen`/`net.Dial` when Takeover-preset servers were restarted
+  under load. Shutdown now closes each Takeover fd exactly once.
 
 ### Added
 

--- a/wing_shutdown_fd_test.go
+++ b/wing_shutdown_fd_test.go
@@ -1,0 +1,78 @@
+//go:build linux || darwin
+
+package kruda
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/go-kruda/kruda/transport"
+)
+
+// TestWing_TakeoverShutdownNoFdDoubleClose reproduces the takeover server-
+// shutdown fd double-close. cleanup()'s doneCh drain discarded the takeover
+// *os.File without closing it while the cleanup loop raw-closed the same fd, so
+// the File's finalizer later closed a recycled fd ("bad file descriptor").
+//
+// Each iteration parks a takeover goroutine on a keep-alive read, shuts the
+// server down (leaking the File), grabs the just-freed fd numbers with victim
+// listeners, then forces GC so the leaked finalizer fires now. If the finalizer
+// closes a recycled fd, a victim listener's fd is yanked and Accept returns
+// EBADF instead of timing out.
+func TestWing_TakeoverShutdownNoFdDoubleClose(t *testing.T) {
+	handler := transport.HandlerFunc(func(w transport.ResponseWriter, r transport.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	})
+
+	for i := 0; i < 60; i++ {
+		cfg := WingConfig{Workers: 1, DefaultPreset: DB} // DB = takeover dispatch
+		addr, stop := startWingServerWithConfig(t, cfg, handler)
+
+		c, err := net.Dial("tcp", addr)
+		if err != nil {
+			t.Fatalf("iter %d dial: %v", i, err)
+		}
+		fmt.Fprintf(c, "GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+		br := bufio.NewReader(c)
+		if _, err := br.ReadString('\n'); err != nil { // status line => handler ran, takeover active
+			t.Fatalf("iter %d read status: %v", i, err)
+		}
+		// Let the takeover goroutine finish the write and park on the next read.
+		time.Sleep(2 * time.Millisecond)
+
+		stop() // Shutdown: SHUT_RD -> takeover exits -> doneMsg{file} drained (leaked)
+		c.Close()
+
+		// Occupy the just-freed fd numbers before the finalizer runs.
+		victims := make([]*net.TCPListener, 0, 12)
+		for k := 0; k < 12; k++ {
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("iter %d victim listen: %v", i, err)
+			}
+			victims = append(victims, ln.(*net.TCPListener))
+		}
+
+		// Force the leaked takeover File's finalizer to run now.
+		runtime.GC()
+		runtime.GC()
+		time.Sleep(2 * time.Millisecond) // give the finalizer goroutine a turn
+
+		for _, ln := range victims {
+			_ = ln.SetDeadline(time.Now().Add(time.Millisecond))
+			if _, aerr := ln.Accept(); aerr != nil && !errors.Is(aerr, os.ErrDeadlineExceeded) {
+				t.Fatalf("iter %d: victim listener fd closed by stale takeover finalizer: %v", i, aerr)
+			}
+		}
+		for _, ln := range victims {
+			ln.Close()
+		}
+	}
+}

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -206,6 +206,7 @@ type conn struct {
 	sendN        int
 	keepAlive    bool
 	pending      int    // in-flight handler goroutines
+	takenOver    bool   // fd detached to a Takeover goroutine and owned by its *os.File
 	remoteAddr   string // lazy peer address cache, filled only if Request.RemoteAddr is used
 	lastActive   int64  // unix nano — updated on accept + each recv
 	readDeadline int64  // unix nano — set when first byte arrives, cleared on full request
@@ -856,6 +857,7 @@ func (w *worker) tryParse(c *conn) {
 			// Detach fd from epoll so the goroutine owns it exclusively.
 			c.keepAlive = req.keepAlive
 			c.pending++
+			c.takenOver = true
 			w.eng.Detach(c.fd)
 			var leftover []byte
 			if c.readN > 0 {
@@ -1524,8 +1526,15 @@ func (w *worker) cleanup() {
 	go func() {
 		for {
 			select {
-			case <-w.doneCh:
-				// discard — ioLoop has stopped, nothing left to process
+			case msg := <-w.doneCh:
+				// A Takeover completion carries the fd's *os.File. Close it here
+				// to release the fd now; discarding it would leak the File to a
+				// finalizer that later closes a recycled fd. Non-Takeover
+				// completions carry no file and are simply dropped (ioLoop has
+				// stopped, nothing left to process).
+				if msg.file != nil {
+					msg.file.Close()
+				}
 			case <-drainStop:
 				return
 			}
@@ -1534,12 +1543,31 @@ func (w *worker) cleanup() {
 	// Now safe to wait for Spawn + Takeover dispatch goroutines.
 	w.dispatchWG.Wait()
 	close(drainStop)
+	// Close any Takeover Files still buffered in doneCh that the concurrent
+	// drain did not consume before it stopped — same recycled-fd hazard.
+drainBuffered:
+	for {
+		select {
+		case msg := <-w.doneCh:
+			if msg.file != nil {
+				msg.file.Close()
+			}
+		default:
+			break drainBuffered
+		}
+	}
 	for fd, c := range w.conns {
 		if c.cancel != nil {
 			c.cancel()
 		}
 		if c.sendFileFd > 0 {
 			syscall.Close(int(c.sendFileFd))
+		}
+		if c.takenOver {
+			// fd is owned by the Takeover *os.File and was already closed via the
+			// drain above; raw-closing it here would double-close a possibly-
+			// recycled fd.
+			continue
 		}
 		closeFd(int(fd))
 	}


### PR DESCRIPTION
## Summary

Fixes an intermittent `bad file descriptor` fd double-close in the Wing
transport's graceful shutdown when Takeover-preset servers are restarted under
load. Present since v1.3.0 (the Takeover netpoll `*os.File` model).

## Root cause

A Takeover connection's fd is owned by an `*os.File`; the goroutine always hands
that File back to the worker via `doneCh`, and `handleDone` closes it exactly
once. During graceful shutdown, however:

- the `doneCh` drain in `cleanup()` **discarded** the message without closing
  `msg.file`, leaking the `*os.File` — its finalizer then closed the fd later,
  after the kernel had recycled the number for a new socket; and
- the cleanup loop **raw-closed the same fd** (the Takeover conn is still in
  `w.conns`, since `handleDone` never ran during shutdown).

That is two closes of one fd number with a recycle window between them, so a
subsequent `net.Listen`/`net.Dial` could have its fd closed underneath it.

## Fix

- Mark the conn `takenOver` at Takeover dispatch.
- The drain — plus a new post-drain sweep of still-buffered messages — closes
  each Takeover `*os.File`, releasing the fd during shutdown instead of leaking
  it to a finalizer.
- The cleanup loop skips `closeFd` for `takenOver` conns, since their fd is
  owned and closed through the File.

The fd is now closed exactly once across both shutdown paths. `w.conns` stays
single-goroutine — the drain only touches the channel and the File.

## Test

`TestWing_TakeoverShutdownNoFdDoubleClose` parks a Takeover goroutine, shuts the
server down, grabs the freed fds with victim listeners, and forces GC so a stale
finalizer close surfaces as EBADF on a victim. Deterministic red before the fix
(fails iteration 0 on every run); green after.

## Verification

- Full core `go test -race -tags kruda_stdjson .` green; gofmt clean; Sonic and
  stdjson builds OK (local macOS/kqueue).
- Linux/epoll verification on a real box pending.
