### PR TITLE
fix(middleware): Logger records real latency (was always 0)

### DIFF
--- a/middleware/logger.go
+++ b/middleware/logger.go
@@ -44,6 +44,10 @@ func Logger(config ...LoggerConfig) kruda.HandlerFunc {
 			return c.Next()
 		}
 
+		// Record the start time so c.Latency() reports real elapsed time.
+		// MarkStart is opt-in (this middleware is its intended caller) so
+		// non-logging apps skip the time.Now() cost.
+		c.MarkStart()
 		err := c.Next()
 
 		status := c.StatusCode()

--- a/middleware/logger_latency_test.go
+++ b/middleware/logger_latency_test.go
@@ -1,0 +1,47 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/go-kruda/kruda"
+)
+
+// TestLogger_RecordsLatency guards against the Logger reporting latency=0 on
+// every request. The middleware must call c.MarkStart() before c.Next() so
+// c.Latency() measures real elapsed time — MarkStart is opt-in (the Logger is
+// its only intended caller) precisely so non-logging apps skip the time.Now()
+// cost. Before the fix, MarkStart() had no caller, so c.Latency() was always 0.
+func TestLogger_RecordsLatency(t *testing.T) {
+	var buf bytes.Buffer
+	lg := slog.New(slog.NewJSONHandler(&buf, nil))
+
+	app := kruda.New()
+	app.Use(Logger(LoggerConfig{Logger: lg}))
+	app.Get("/slow", func(c *kruda.Ctx) error {
+		time.Sleep(2 * time.Millisecond)
+		return c.JSON(kruda.Map{"ok": true})
+	})
+
+	resp := newMockResponse()
+	app.ServeKruda(resp, getReq("/slow", nil))
+
+	var rec map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &rec); err != nil {
+		t.Fatalf("log line not valid JSON: %v (%s)", err, buf.String())
+	}
+	latStr, ok := rec["latency"].(string)
+	if !ok {
+		t.Fatalf("log line has no string latency field: %s", buf.String())
+	}
+	d, err := time.ParseDuration(latStr)
+	if err != nil {
+		t.Fatalf("latency %q is not a duration: %v", latStr, err)
+	}
+	if d < time.Millisecond {
+		t.Fatalf("Logger latency=%v — MarkStart() not called, so c.Latency() is always 0 (handler slept 2ms)", d)
+	}
+}


### PR DESCRIPTION
## Bug
The built-in `middleware.Logger` logs `latency` via `c.Latency()`, but never calls `c.MarkStart()` — and `MarkStart()` had **zero callers** in production code. So `c.Latency()` always returned 0, and **every request was logged with `latency=0s`**.

`MarkStart` is intentionally opt-in (its doc says "Called automatically by the Logger middleware" — to avoid the ~30ns `time.Now()` on apps that don't log); the call was simply missing.

## Fix
Call `c.MarkStart()` in the Logger middleware after the skip-path check and before `c.Next()`, so skipped paths still pay nothing and logged requests get real elapsed time.

## Test
`TestLogger_RecordsLatency`: a handler that sleeps 2ms must log `latency >= 1ms` (RED before fix: `latency=0s`; GREEN after). Full middleware suite + build + vet + gofmt clean.