### PR TITLE
fix(prometheus): defer in-flight gauge Dec so a panic can't leak it

### DIFF
--- a/contrib/prometheus/prometheus.go
+++ b/contrib/prometheus/prometheus.go
@@ -86,6 +86,7 @@ func New(config ...Config) kruda.HandlerFunc {
 		}
 
 		requestsInFlight.Inc()
+		defer requestsInFlight.Dec() // deferred so a panicking handler can't leak the gauge
 		start := time.Now()
 
 		// Execute next handler in chain.
@@ -105,8 +106,6 @@ func New(config ...Config) kruda.HandlerFunc {
 		// needed, set Content-Length explicitly and it will be captured here in
 		// future Kruda versions that expose response metadata.
 		responseSizeBytes.WithLabelValues(method, status, path).Observe(0)
-
-		requestsInFlight.Dec()
 
 		return err
 	}

--- a/contrib/prometheus/prometheus_test.go
+++ b/contrib/prometheus/prometheus_test.go
@@ -215,6 +215,34 @@ func TestNew_InFlight(t *testing.T) {
 	}
 }
 
+// TestNew_InFlightNoLeakOnPanic guards that the in-flight gauge is decremented
+// even when a handler panics. The prometheus middleware is the only one
+// installed, so the panic propagates through its c.Next() to Kruda's
+// serve-level recovery — exercising the Dec path under a panic. With a
+// non-deferred Dec(), the gauge would leak to 1 on every panic.
+func TestNew_InFlightNoLeakOnPanic(t *testing.T) {
+	reg := newTestRegistry()
+	app := kruda.New(kruda.NetHTTP())
+
+	app.Use(New(Config{Registry: reg}))
+	app.Get("/boom", func(c *kruda.Ctx) error {
+		panic("boom")
+	})
+	app.Compile()
+	srv := httptest.NewServer(app)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/boom")
+	if err == nil {
+		resp.Body.Close()
+	}
+
+	family := gatherMetric(reg, "http_requests_in_flight")
+	if val := findGaugeValue(family); val != 0 {
+		t.Errorf("in_flight after panicking handler = %v, want 0 (Dec must be deferred)", val)
+	}
+}
+
 func TestNew_StatusLabels(t *testing.T) {
 	_, srv, reg := newTestApp(Config{})
 	defer srv.Close()


### PR DESCRIPTION
## Bug
`requestsInFlight.Dec()` ran *after* `c.Next()` (`prometheus.go:109`). When a handler panics, the panic propagates through this middleware's `c.Next()` to Kruda's serve-level recovery — skipping the `Dec()` — so `http_requests_in_flight` **leaks by 1 on every panic**, permanently inflating the gauge.

## Fix
`defer requestsInFlight.Dec()` immediately after `Inc()`, so it always runs (including during a panic unwind).

## Test
`TestNew_InFlightNoLeakOnPanic`: a panicking handler with prometheus as the only middleware must leave the gauge at 0 (RED before: `in_flight=1`; GREEN after). Full package + build + vet + gofmt clean.