### PR TITLE
feat(resource): input validation + OpenAPI 3.1 for auto-CRUD

### DIFF
--- a/internal/testtypes/alt/alt.go
+++ b/internal/testtypes/alt/alt.go
@@ -1,0 +1,12 @@
+// Package alt provides an exported type whose short name ("User") collides with
+// internal/testtypes.User but lives in a different package path. Used by OpenAPI
+// sanitizer tests to verify cross-package generic instantiations get distinct,
+// valid component keys.
+package alt
+
+// User is a minimal exported struct sharing the short name "User" with
+// internal/testtypes.User, but originating from a different package.
+type User struct {
+	ID    string `json:"id"`
+	Email string `json:"email"`
+}

--- a/internal/testtypes/m1/models/models.go
+++ b/internal/testtypes/m1/models/models.go
@@ -1,0 +1,11 @@
+// Package models is one of three same-named packages (m1/m2/m3) used to
+// exercise OpenAPI component-key disambiguation when distinct types share both
+// a short name ("User") and a trailing package segment ("models").
+package models
+
+// User is the m1 variant; its unique field "a" lets tests confirm this exact
+// schema survives disambiguation rather than being overwritten.
+type User struct {
+	ID string `json:"id"`
+	A  string `json:"a"`
+}

--- a/internal/testtypes/m2/models/models.go
+++ b/internal/testtypes/m2/models/models.go
@@ -1,0 +1,11 @@
+// Package models is one of three same-named packages (m1/m2/m3) used to
+// exercise OpenAPI component-key disambiguation when distinct types share both
+// a short name ("User") and a trailing package segment ("models").
+package models
+
+// User is the m2 variant; its unique field "b" lets tests confirm this exact
+// schema survives disambiguation rather than being overwritten.
+type User struct {
+	ID string `json:"id"`
+	B  string `json:"b"`
+}

--- a/internal/testtypes/m3/models/models.go
+++ b/internal/testtypes/m3/models/models.go
@@ -1,0 +1,11 @@
+// Package models is one of three same-named packages (m1/m2/m3) used to
+// exercise OpenAPI component-key disambiguation when distinct types share both
+// a short name ("User") and a trailing package segment ("models").
+package models
+
+// User is the m3 variant; its unique field "c" lets tests confirm this exact
+// schema survives disambiguation rather than being overwritten.
+type User struct {
+	ID string `json:"id"`
+	C  string `json:"c"`
+}

--- a/internal/testtypes/testtypes.go
+++ b/internal/testtypes/testtypes.go
@@ -1,0 +1,10 @@
+// Package testtypes provides exported types used only by tests that need a
+// generic type argument originating from a sub-package, so that reflect's
+// Type.Name() embeds a package path ("/") and a qualifier (".").
+package testtypes
+
+// User is a minimal exported struct for OpenAPI sanitizer tests.
+type User struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}

--- a/openapi.go
+++ b/openapi.go
@@ -98,6 +98,20 @@ type routeInfo struct {
 	hasBody     bool
 	hasForm     bool
 	hasValidate bool
+	resourceOp  *resourceOp // non-nil for kruda.Resource routes; nil for typed routes
+}
+
+// resourceOp carries the explicit OpenAPI metadata for a single auto-CRUD
+// operation registered by kruda.Resource. Rendering is fully determined by
+// these fields (no kind discriminator). Consumed by buildOperation.
+type resourceOp struct {
+	idParam        string       // path-param name (cfg.idParam); "" for list/create
+	idType         reflect.Type // ID type for the path-param schema; nil for list/create
+	bodyType       reflect.Type // T for create/update; nil otherwise
+	respType       reflect.Type // T (get/create/update) | ResourceList[T] (list) | nil (delete → 204)
+	successCode    string       // "200" | "201" | "204"
+	needsListQuery bool         // emit page/limit integer query params
+	hasValidate    bool         // T has validate tags AND a Validator is configured → add 422
 }
 
 // generateSchema converts a Go reflect.Type to a JSON Schema.
@@ -136,6 +150,11 @@ func generateSchema(t reflect.Type, components map[string]*schemaRef) *schemaRef
 	if name == "" {
 		name = "Anonymous"
 	}
+	// A generic instantiation's name (e.g. "ResourceList[github.com/app/models.User]")
+	// embeds "/", "[", "]", and "." — characters that make the derived $ref an
+	// invalid JSON pointer. Sanitize to a deterministic component key. Non-generic
+	// names (no /[].) are returned unchanged, so existing keys never move.
+	name = sanitizeComponentName(name)
 
 	// Detect collision: if a schema with the same short name exists but from a
 	// different package, disambiguate by appending the last segment of PkgPath.
@@ -241,6 +260,58 @@ func containsRule(vtag, rule string) bool {
 	return false
 }
 
+// sanitizeComponentName turns a reflect type name into a valid OpenAPI
+// component key (and thus a valid "#/components/schemas/<key>" JSON pointer).
+//
+// Non-generic names contain none of "/[]." and are returned unchanged, so they
+// keep their existing keys. Generic instantiation names such as
+// "ResourceList[github.com/app/models.User]" are reduced to "ResourceList_User"
+// deterministically: the base type name, then each type argument trimmed to its
+// final identifier (package path + qualifier dropped), joined by "_".
+func sanitizeComponentName(name string) string {
+	if !strings.ContainsAny(name, "/[].") {
+		return name
+	}
+
+	base := name
+	args := ""
+	if i := strings.IndexByte(name, '['); i >= 0 {
+		base = name[:i]
+		args = strings.TrimSuffix(name[i+1:], "]")
+	}
+
+	var b strings.Builder
+	b.WriteString(lastIdentSegment(base))
+	if args != "" {
+		for _, arg := range strings.Split(args, ",") {
+			seg := lastIdentSegment(arg)
+			if seg == "" {
+				continue
+			}
+			b.WriteByte('_')
+			b.WriteString(seg)
+		}
+	}
+	return b.String()
+}
+
+// lastIdentSegment returns the final identifier of a (possibly qualified,
+// possibly pointer/bracketed) type token: the substring after the last "/" or
+// ".", with leading "*", "[", "]" stripped. e.g. "github.com/app/models.User"
+// → "User", "*models.User" → "User".
+func lastIdentSegment(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.Trim(s, "*[]")
+	if i := strings.LastIndexByte(s, '/'); i >= 0 {
+		s = s[i+1:]
+	}
+	if i := strings.LastIndexByte(s, '.'); i >= 0 {
+		s = s[i+1:]
+	}
+	s = strings.Trim(s, "*[]")
+	return s
+}
+
 // convertPath converts Kruda path format to OpenAPI format: ":id" → "{id}".
 // Strips regex constraints (":id<[0-9]+>" → "{id}") and optional markers (":id?" → "{id}").
 func convertPath(path string) string {
@@ -335,6 +406,11 @@ func buildOperation(ri routeInfo, components map[string]*schemaRef, problemJSON 
 		Security:    ri.config.security,
 	}
 
+	if ri.resourceOp != nil {
+		buildResourceOperation(op, ri.resourceOp, components, problemJSON)
+		return op
+	}
+
 	inType := ri.config.inType
 	outType := ri.config.outType
 
@@ -404,6 +480,76 @@ func buildOperation(ri routeInfo, components map[string]*schemaRef, problemJSON 
 	}
 
 	return op
+}
+
+// buildResourceOperation renders a kruda.Resource auto-CRUD operation
+// explicitly from its resourceOp metadata, covering the list/get/create/update/
+// delete shapes (200/201/204), a 422 only when validation is engaged, and the
+// same default error response as typed routes.
+func buildResourceOperation(op *openAPIOperation, rop *resourceOp, components map[string]*schemaRef, problemJSON bool) {
+	if rop.idParam != "" {
+		var idSchema *schemaRef
+		if rop.idType != nil {
+			idSchema = generateSchema(rop.idType, components)
+		} else {
+			idSchema = &schemaRef{Type: "string"}
+		}
+		op.Parameters = append(op.Parameters, openAPIParameter{
+			Name:     rop.idParam,
+			In:       "path",
+			Required: true,
+			Schema:   idSchema,
+		})
+	}
+
+	if rop.needsListQuery {
+		op.Parameters = append(op.Parameters,
+			openAPIParameter{Name: "page", In: "query", Schema: &schemaRef{Type: "integer"}},
+			openAPIParameter{Name: "limit", In: "query", Schema: &schemaRef{Type: "integer"}},
+		)
+	}
+
+	if rop.bodyType != nil {
+		op.RequestBody = &openAPIRequestBody{
+			Required: true,
+			Content: map[string]*openAPIMediaType{
+				"application/json": {Schema: generateSchema(rop.bodyType, components)},
+			},
+		}
+	}
+
+	code := rop.successCode
+	if code == "" {
+		code = "200"
+	}
+	if rop.respType != nil {
+		op.Responses[code] = &openAPIResponse{
+			Description: "Successful response",
+			Content: map[string]*openAPIMediaType{
+				"application/json": {Schema: generateSchema(rop.respType, components)},
+			},
+		}
+	} else {
+		op.Responses[code] = &openAPIResponse{Description: "No Content"}
+	}
+
+	if rop.hasValidate {
+		contentType, schema := validationResponseSchema(components, problemJSON)
+		op.Responses["422"] = &openAPIResponse{
+			Description: "Validation failed",
+			Content: map[string]*openAPIMediaType{
+				contentType: {Schema: schema},
+			},
+		}
+	}
+
+	contentType, schema := defaultErrorResponseSchema(components, problemJSON)
+	op.Responses["default"] = &openAPIResponse{
+		Description: "Error response",
+		Content: map[string]*openAPIMediaType{
+			contentType: {Schema: schema},
+		},
+	}
 }
 
 // validationResponseSchema returns the media type + schema for a 422 validation

--- a/openapi.go
+++ b/openapi.go
@@ -172,20 +172,30 @@ func generateSchema(t reflect.Type, components map[string]*schemaRef) *schemaRef
 	// Resolve key collisions by true type identity. An entry under this key that
 	// shares our id is the same type → return a $ref. A different id is a genuine
 	// cross-package short-name clash (only possible for plain named types, whose
-	// sanitized key is the bare short name): disambiguate by appending the last
-	// package segment. Generic keys already encode full identity, so they never
-	// reach the clash branch.
+	// sanitized key is the bare short name): disambiguate with the full package
+	// path, then a numeric counter, so distinct types never share a key and an
+	// existing schema is never overwritten — even three+ types whose packages
+	// share a trailing segment (e.g. several ".../models.User"). Generic keys
+	// already encode full identity, so they rarely reach the clash branch; the
+	// counter keeps even a pathological generic clash safe.
 	if existing, exists := components[componentKey]; exists {
 		if existing.typeID == id {
 			return &schemaRef{Ref: "#/components/schemas/" + componentKey}
 		}
-		pkg := t.PkgPath()
-		if idx := strings.LastIndexByte(pkg, '/'); idx >= 0 {
-			pkg = pkg[idx+1:]
+		base := componentKey
+		if pkg := sanitizeComponentName(t.PkgPath()); pkg != "" {
+			base += "_" + pkg
 		}
-		componentKey += "_" + pkg
-		if again, exists2 := components[componentKey]; exists2 && again.typeID == id {
-			return &schemaRef{Ref: "#/components/schemas/" + componentKey}
+		componentKey = base
+		for n := 2; ; n++ {
+			again, taken := components[componentKey]
+			if !taken {
+				break
+			}
+			if again.typeID == id {
+				return &schemaRef{Ref: "#/components/schemas/" + componentKey}
+			}
+			componentKey = base + "_" + strconv.Itoa(n)
 		}
 	}
 
@@ -276,46 +286,54 @@ func containsRule(vtag, rule string) bool {
 // sanitizeComponentName turns a reflect type name into a valid OpenAPI
 // component key (and thus a valid "#/components/schemas/<key>" JSON pointer).
 //
-// Non-generic names contain none of "/[].* " and are returned unchanged, so
-// they keep their existing keys (the golden guard depends on this no-op).
+// A name made up only of key-safe runes ([A-Za-z0-9_-]) is returned unchanged,
+// so plain named types keep their existing keys (the golden guard depends on
+// this no-op). "-" is preserved because module paths such as "go-kruda" contain
+// it and it is legal in a component key.
 //
 // Generic instantiation names such as "ResourceList[github.com/app/models.User]"
-// embed characters that are illegal in a JSON-pointer segment. Rather than
-// collapse each type argument to its short identifier — which silently merges
-// distinct types that share a short name across packages, or a value type with
-// its pointer — this preserves the FULL qualified name: every maximal run of
-// the illegal characters (/ . [ ] * and spaces) becomes a single "_", repeats
-// are collapsed, and surrounding "_" is trimmed. The mapping is injective up to
-// that punctuation, so distinct Go types yield distinct keys:
+// embed characters that are illegal in a JSON-pointer segment — "/[].*", the
+// "," between multiple type args, parentheses in func-typed args, and spaces.
+// Rather than collapse each type argument to its short identifier — which
+// silently merges distinct types that share a short name across packages, or a
+// value type with its pointer — this preserves the FULL qualified name: every
+// maximal run of non-key-safe runes becomes a single "_", repeats are collapsed,
+// and surrounding "_" is trimmed. The mapping is injective up to that
+// punctuation, so distinct Go types yield distinct keys:
 //
 //	ResourceList[a/b.User]          → ResourceList_a_b_User
 //	ResourceList[c/d.User]          → ResourceList_c_d_User   (distinct package)
-//	genWrap[a/b.User]               → genWrap_a_b_User
 //	genWrap[*a/b.User]              → genWrap_a_b_User_Ptr    (pointer marker)
 //	ResourceList[map[string]int]    → ResourceList_map_string_int (no brackets)
+//	Pair[a.Foo,b.Bar]               → Pair_a_Foo_b_Bar        (comma separated)
 func sanitizeComponentName(name string) string {
-	if !strings.ContainsAny(name, "/[].* ") {
+	clean := true
+	for _, r := range name {
+		if !isKeySafeRune(r) {
+			clean = false
+			break
+		}
+	}
+	if clean {
 		return name
 	}
 
-	// A trailing "*" run anywhere marks a pointer type arg; without a distinct
-	// marker "*T" and "T" would both lose the star to the generic separator and
-	// collapse to the same key. Append a "Ptr" token per pointer star so value
-	// vs pointer args stay distinct.
+	// A "*" run marks a pointer type arg; without a distinct marker "*T" and "T"
+	// would both lose the star to the separator and collapse to the same key.
+	// Append a "Ptr" token per pointer star so value vs pointer args stay distinct.
 	pointerStars := strings.Count(name, "*")
 
 	var b strings.Builder
 	prevUnderscore := false
 	for _, r := range name {
-		switch r {
-		case '/', '.', '[', ']', '*', ' ':
-			if !prevUnderscore {
-				b.WriteByte('_')
-				prevUnderscore = true
-			}
-		default:
+		if isKeySafeRune(r) {
 			b.WriteRune(r)
 			prevUnderscore = false
+			continue
+		}
+		if !prevUnderscore {
+			b.WriteByte('_')
+			prevUnderscore = true
 		}
 	}
 	key := strings.Trim(b.String(), "_")
@@ -323,6 +341,17 @@ func sanitizeComponentName(name string) string {
 		key += "_Ptr"
 	}
 	return key
+}
+
+// isKeySafeRune reports whether r may appear verbatim in an OpenAPI component
+// key. The spec restricts keys to ^[a-zA-Z0-9._-]+$; "." is treated as unsafe
+// here even though the spec allows it, because it separates a package path from
+// a type name and collapsing it keeps the key→type mapping injective.
+func isKeySafeRune(r rune) bool {
+	return r == '_' || r == '-' ||
+		(r >= 'a' && r <= 'z') ||
+		(r >= 'A' && r <= 'Z') ||
+		(r >= '0' && r <= '9')
 }
 
 // convertPath converts Kruda path format to OpenAPI format: ":id" → "{id}".

--- a/openapi.go
+++ b/openapi.go
@@ -85,9 +85,10 @@ type schemaRef struct {
 	MaxLength  *int                  `json:"maxLength,omitempty"`
 	Nullable   bool                  `json:"nullable,omitempty"`
 
-	// pkgPath tracks the originating package for collision detection.
-	// Not serialized to JSON — internal bookkeeping only.
-	pkgPath string `json:"-"`
+	// typeID is the fully-qualified type string ("pkg/path.Name" or the generic
+	// instantiation name) used to tell two types apart when their sanitized keys
+	// collide. Not serialized — internal bookkeeping only.
+	typeID string `json:"-"`
 }
 
 // routeInfo holds metadata for a single registered typed route.
@@ -150,28 +151,40 @@ func generateSchema(t reflect.Type, components map[string]*schemaRef) *schemaRef
 	if name == "" {
 		name = "Anonymous"
 	}
-	// A generic instantiation's name (e.g. "ResourceList[github.com/app/models.User]")
-	// embeds "/", "[", "]", and "." — characters that make the derived $ref an
-	// invalid JSON pointer. Sanitize to a deterministic component key. Non-generic
-	// names (no /[].) are returned unchanged, so existing keys never move.
-	name = sanitizeComponentName(name)
+	// id is the type's fully-qualified identity. For a generic instantiation,
+	// t.Name() already embeds the full type-arg paths (e.g.
+	// "ResourceList[github.com/app/models.User]"); for a plain named type we
+	// prepend its package path so two same-short-name types from different
+	// packages are distinguishable.
+	id := name
+	if pkg := t.PkgPath(); pkg != "" && !strings.ContainsAny(name, "[") {
+		id = pkg + "." + name
+	}
 
-	// Detect collision: if a schema with the same short name exists but from a
-	// different package, disambiguate by appending the last segment of PkgPath.
-	componentKey := name
-	if existing, exists := components[name]; exists {
-		// Check if it's truly the same type (same PkgPath) — if so, return ref.
-		if existing.pkgPath == t.PkgPath() {
+	// A generic instantiation's name embeds "/", "[", "]", ".", and "*" for
+	// pointer args — characters that make the derived $ref an invalid JSON
+	// pointer. sanitizeComponentName maps the full instantiation name (incl. each
+	// type arg's package path) to a valid key, so cross-package or value/pointer
+	// args never collapse. Non-generic names (no /[].* ) are returned unchanged,
+	// so existing keys never move (the golden guard relies on this no-op).
+	componentKey := sanitizeComponentName(name)
+
+	// Resolve key collisions by true type identity. An entry under this key that
+	// shares our id is the same type → return a $ref. A different id is a genuine
+	// cross-package short-name clash (only possible for plain named types, whose
+	// sanitized key is the bare short name): disambiguate by appending the last
+	// package segment. Generic keys already encode full identity, so they never
+	// reach the clash branch.
+	if existing, exists := components[componentKey]; exists {
+		if existing.typeID == id {
 			return &schemaRef{Ref: "#/components/schemas/" + componentKey}
 		}
-		// Different package, same name — disambiguate with package suffix.
 		pkg := t.PkgPath()
 		if idx := strings.LastIndexByte(pkg, '/'); idx >= 0 {
 			pkg = pkg[idx+1:]
 		}
-		componentKey = name + "_" + pkg
-		// If even this disambiguated key exists and matches, return ref.
-		if _, exists2 := components[componentKey]; exists2 {
+		componentKey += "_" + pkg
+		if again, exists2 := components[componentKey]; exists2 && again.typeID == id {
 			return &schemaRef{Ref: "#/components/schemas/" + componentKey}
 		}
 	}
@@ -181,7 +194,7 @@ func generateSchema(t reflect.Type, components map[string]*schemaRef) *schemaRef
 	schema := &schemaRef{
 		Type:       "object",
 		Properties: make(map[string]*schemaRef),
-		pkgPath:    t.PkgPath(),
+		typeID:     id,
 	}
 	components[componentKey] = schema
 
@@ -263,53 +276,53 @@ func containsRule(vtag, rule string) bool {
 // sanitizeComponentName turns a reflect type name into a valid OpenAPI
 // component key (and thus a valid "#/components/schemas/<key>" JSON pointer).
 //
-// Non-generic names contain none of "/[]." and are returned unchanged, so they
-// keep their existing keys. Generic instantiation names such as
-// "ResourceList[github.com/app/models.User]" are reduced to "ResourceList_User"
-// deterministically: the base type name, then each type argument trimmed to its
-// final identifier (package path + qualifier dropped), joined by "_".
+// Non-generic names contain none of "/[].* " and are returned unchanged, so
+// they keep their existing keys (the golden guard depends on this no-op).
+//
+// Generic instantiation names such as "ResourceList[github.com/app/models.User]"
+// embed characters that are illegal in a JSON-pointer segment. Rather than
+// collapse each type argument to its short identifier — which silently merges
+// distinct types that share a short name across packages, or a value type with
+// its pointer — this preserves the FULL qualified name: every maximal run of
+// the illegal characters (/ . [ ] * and spaces) becomes a single "_", repeats
+// are collapsed, and surrounding "_" is trimmed. The mapping is injective up to
+// that punctuation, so distinct Go types yield distinct keys:
+//
+//	ResourceList[a/b.User]          → ResourceList_a_b_User
+//	ResourceList[c/d.User]          → ResourceList_c_d_User   (distinct package)
+//	genWrap[a/b.User]               → genWrap_a_b_User
+//	genWrap[*a/b.User]              → genWrap_a_b_User_Ptr    (pointer marker)
+//	ResourceList[map[string]int]    → ResourceList_map_string_int (no brackets)
 func sanitizeComponentName(name string) string {
-	if !strings.ContainsAny(name, "/[].") {
+	if !strings.ContainsAny(name, "/[].* ") {
 		return name
 	}
 
-	base := name
-	args := ""
-	if i := strings.IndexByte(name, '['); i >= 0 {
-		base = name[:i]
-		args = strings.TrimSuffix(name[i+1:], "]")
-	}
+	// A trailing "*" run anywhere marks a pointer type arg; without a distinct
+	// marker "*T" and "T" would both lose the star to the generic separator and
+	// collapse to the same key. Append a "Ptr" token per pointer star so value
+	// vs pointer args stay distinct.
+	pointerStars := strings.Count(name, "*")
 
 	var b strings.Builder
-	b.WriteString(lastIdentSegment(base))
-	if args != "" {
-		for _, arg := range strings.Split(args, ",") {
-			seg := lastIdentSegment(arg)
-			if seg == "" {
-				continue
+	prevUnderscore := false
+	for _, r := range name {
+		switch r {
+		case '/', '.', '[', ']', '*', ' ':
+			if !prevUnderscore {
+				b.WriteByte('_')
+				prevUnderscore = true
 			}
-			b.WriteByte('_')
-			b.WriteString(seg)
+		default:
+			b.WriteRune(r)
+			prevUnderscore = false
 		}
 	}
-	return b.String()
-}
-
-// lastIdentSegment returns the final identifier of a (possibly qualified,
-// possibly pointer/bracketed) type token: the substring after the last "/" or
-// ".", with leading "*", "[", "]" stripped. e.g. "github.com/app/models.User"
-// → "User", "*models.User" → "User".
-func lastIdentSegment(s string) string {
-	s = strings.TrimSpace(s)
-	s = strings.Trim(s, "*[]")
-	if i := strings.LastIndexByte(s, '/'); i >= 0 {
-		s = s[i+1:]
+	key := strings.Trim(b.String(), "_")
+	for i := 0; i < pointerStars; i++ {
+		key += "_Ptr"
 	}
-	if i := strings.LastIndexByte(s, '.'); i >= 0 {
-		s = s[i+1:]
-	}
-	s = strings.Trim(s, "*[]")
-	return s
+	return key
 }
 
 // convertPath converts Kruda path format to OpenAPI format: ":id" → "{id}".

--- a/openapi_audit_test.go
+++ b/openapi_audit_test.go
@@ -1,0 +1,90 @@
+package kruda
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	m1models "github.com/go-kruda/kruda/internal/testtypes/m1/models"
+	m2models "github.com/go-kruda/kruda/internal/testtypes/m2/models"
+	m3models "github.com/go-kruda/kruda/internal/testtypes/m3/models"
+)
+
+// TestGenerateSchema_ThreeWayCrossPackageCollision guards component-key
+// disambiguation for 3+ plain named types that share a short name AND a
+// trailing package segment (e.g. several ".../models.User"). The earlier
+// one-shot "_<lastSegment>" suffix overwrote the second schema with the third
+// and mis-pointed $refs; the full-path + counter scheme must keep all distinct.
+func TestGenerateSchema_ThreeWayCrossPackageCollision(t *testing.T) {
+	components := make(map[string]*schemaRef)
+
+	r1 := generateSchema(reflect.TypeOf(m1models.User{}), components)
+	r2 := generateSchema(reflect.TypeOf(m2models.User{}), components)
+	r3 := generateSchema(reflect.TypeOf(m3models.User{}), components)
+
+	k1 := strings.TrimPrefix(r1.Ref, "#/components/schemas/")
+	k2 := strings.TrimPrefix(r2.Ref, "#/components/schemas/")
+	k3 := strings.TrimPrefix(r3.Ref, "#/components/schemas/")
+
+	if k1 == k2 || k1 == k3 || k2 == k3 {
+		t.Fatalf("three same-short-name/same-last-segment types collided: %q %q %q", k1, k2, k3)
+	}
+	for _, k := range []string{k1, k2, k3} {
+		if _, ok := components[k]; !ok {
+			t.Fatalf("component %q missing (schema silently dropped); keys=%v", k, componentKeys(components))
+		}
+	}
+
+	// Each distinguishing field (a/b/c) must survive — none overwritten.
+	want := map[string]string{"a": k1, "b": k2, "c": k3}
+	for field, key := range want {
+		if _, ok := components[key].Properties[field]; !ok {
+			t.Errorf("schema %q lost its unique field %q (overwritten); props=%v", key, field, components[key].Properties)
+		}
+	}
+
+	// Every key must remain a valid JSON-pointer segment.
+	for k := range components {
+		if strings.ContainsAny(k, "/[].") {
+			t.Errorf("component key %q contains invalid pointer chars", k)
+		}
+	}
+}
+
+func keySafeComponentName(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if !isKeySafeRune(r) {
+			return false
+		}
+	}
+	return true
+}
+
+// TestSanitizeComponentName_MultiArgGenericDropsComma verifies a multi-type-arg
+// generic name (reflect uses "," as the arg separator) yields a key with no
+// comma and matching the OpenAPI component-name charset.
+func TestSanitizeComponentName_MultiArgGenericDropsComma(t *testing.T) {
+	got := sanitizeComponentName("Pair[github.com/app/models.Foo,github.com/app/models.Bar]")
+	if strings.ContainsRune(got, ',') {
+		t.Fatalf("key %q still contains a comma (invalid OpenAPI component name)", got)
+	}
+	if !keySafeComponentName(got) {
+		t.Fatalf("key %q is not a valid OpenAPI component name", got)
+	}
+}
+
+// TestSanitizeComponentName_PreservesHyphen verifies a legitimate hyphen
+// (module paths like "go-kruda") survives sanitization — it is legal in an
+// OpenAPI component key and must not be collapsed.
+func TestSanitizeComponentName_PreservesHyphen(t *testing.T) {
+	got := sanitizeComponentName("ResourceList[github.com/go-kruda/kruda/internal/testtypes.User]")
+	if !strings.Contains(got, "go-kruda") {
+		t.Fatalf("hyphen not preserved in %q (modules like go-kruda must keep '-')", got)
+	}
+	if !keySafeComponentName(got) {
+		t.Fatalf("key %q is not a valid OpenAPI component name", got)
+	}
+}

--- a/openapi_resource_e2e_test.go
+++ b/openapi_resource_e2e_test.go
@@ -209,8 +209,9 @@ func TestOpenAPI_Resource_ListEnvelopeComponentSanitized(t *testing.T) {
 
 	comps, _ := spec["components"].(map[string]any)
 	schemas, _ := comps["schemas"].(map[string]any)
-	// ResourceList[kruda.mockUser] → sanitized to ResourceList_mockUser.
-	if _, ok := schemas["ResourceList_mockUser"]; !ok {
+	// ResourceList[github.com/go-kruda/kruda.mockUser] → sanitized to a key that
+	// preserves the type arg's full package path (every illegal-char run → "_").
+	if _, ok := schemas["ResourceList_github_com_go-kruda_kruda_mockUser"]; !ok {
 		t.Errorf("missing sanitized ResourceList component; schemas=%v", keysOf(schemas))
 	}
 	for k := range schemas {

--- a/openapi_resource_e2e_test.go
+++ b/openapi_resource_e2e_test.go
@@ -1,0 +1,309 @@
+package kruda
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// decodeSpec builds and unmarshals the OpenAPI spec for assertions.
+func decodeSpec(t *testing.T, app *App) map[string]any {
+	t.Helper()
+	b, err := app.buildOpenAPISpec()
+	if err != nil {
+		t.Fatalf("buildOpenAPISpec: %v", err)
+	}
+	var spec map[string]any
+	if err := json.Unmarshal(b, &spec); err != nil {
+		t.Fatalf("unmarshal spec: %v", err)
+	}
+	return spec
+}
+
+func paths(t *testing.T, spec map[string]any) map[string]any {
+	t.Helper()
+	p, ok := spec["paths"].(map[string]any)
+	if !ok {
+		t.Fatal("spec has no paths object")
+	}
+	return p
+}
+
+func op(t *testing.T, spec map[string]any, path, method string) map[string]any {
+	t.Helper()
+	item, ok := paths(t, spec)[path].(map[string]any)
+	if !ok {
+		t.Fatalf("no path item for %q; paths=%v", path, keysOf(paths(t, spec)))
+	}
+	o, ok := item[method].(map[string]any)
+	if !ok {
+		t.Fatalf("no %s operation for %q", method, path)
+	}
+	return o
+}
+
+func keysOf(m map[string]any) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}
+
+func TestOpenAPI_Resource_AllOpsPresent(t *testing.T) {
+	app := New(WithOpenAPIInfo("API", "1.0", ""), WithValidator(NewValidator()))
+	Resource(app, "/users", &validatedUserService{})
+	spec := decodeSpec(t, app)
+
+	// All five ops at the two paths.
+	op(t, spec, "/users", "get")         // list
+	op(t, spec, "/users", "post")        // create
+	op(t, spec, "/users/{id}", "get")    // get-by-id
+	op(t, spec, "/users/{id}", "put")    // update
+	op(t, spec, "/users/{id}", "delete") // delete
+}
+
+func TestOpenAPI_Resource_ListQueryParams(t *testing.T) {
+	app := New(WithOpenAPIInfo("API", "1.0", ""))
+	Resource(app, "/users", &mockUserService{})
+	spec := decodeSpec(t, app)
+
+	list := op(t, spec, "/users", "get")
+	params, _ := list["parameters"].([]any)
+	want := map[string]bool{"page": false, "limit": false}
+	for _, p := range params {
+		pm := p.(map[string]any)
+		if pm["in"] != "query" {
+			continue
+		}
+		name, _ := pm["name"].(string)
+		if _, ok := want[name]; ok {
+			want[name] = true
+			sch, _ := pm["schema"].(map[string]any)
+			if sch["type"] != "integer" {
+				t.Errorf("query %q type = %v, want integer", name, sch["type"])
+			}
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("list op missing integer query param %q", name)
+		}
+	}
+}
+
+func TestOpenAPI_Resource_PathParamType(t *testing.T) {
+	// string ID → string path param.
+	appS := New(WithOpenAPIInfo("API", "1.0", ""))
+	Resource(appS, "/users", &mockUserService{})
+	specS := decodeSpec(t, appS)
+	assertPathParamType(t, op(t, specS, "/users/{id}", "get"), "id", "string")
+
+	// int ID → integer path param.
+	appI := New(WithOpenAPIInfo("API", "1.0", ""))
+	Resource(appI, "/items", &mockItemService{})
+	specI := decodeSpec(t, appI)
+	assertPathParamType(t, op(t, specI, "/items/{id}", "get"), "id", "integer")
+}
+
+func assertPathParamType(t *testing.T, o map[string]any, name, wantType string) {
+	t.Helper()
+	params, _ := o["parameters"].([]any)
+	for _, p := range params {
+		pm := p.(map[string]any)
+		if pm["in"] == "path" && pm["name"] == name {
+			sch, _ := pm["schema"].(map[string]any)
+			if sch["type"] != wantType {
+				t.Errorf("path param %q type = %v, want %v", name, sch["type"], wantType)
+			}
+			return
+		}
+	}
+	t.Errorf("path param %q not found", name)
+}
+
+func TestOpenAPI_Resource_RequestBodyRefAndCodes(t *testing.T) {
+	app := New(WithOpenAPIInfo("API", "1.0", ""), WithValidator(NewValidator()))
+	Resource(app, "/users", &validatedUserService{})
+	spec := decodeSpec(t, app)
+
+	// create request body present with a $ref + 201.
+	create := op(t, spec, "/users", "post")
+	if create["requestBody"] == nil {
+		t.Error("create must have a request body")
+	}
+	resps := create["responses"].(map[string]any)
+	if _, ok := resps["201"]; !ok {
+		t.Error("create must have 201")
+	}
+	if _, ok := resps["422"]; !ok {
+		t.Error("create with validator+tags must have 422")
+	}
+
+	// update → 200 + 422.
+	update := op(t, spec, "/users/{id}", "put")
+	uresps := update["responses"].(map[string]any)
+	if _, ok := uresps["200"]; !ok {
+		t.Error("update must have 200")
+	}
+	if _, ok := uresps["422"]; !ok {
+		t.Error("update with validator+tags must have 422")
+	}
+
+	// delete → 204, no body, no 422.
+	del := op(t, spec, "/users/{id}", "delete")
+	dresps := del["responses"].(map[string]any)
+	r204, ok := dresps["204"].(map[string]any)
+	if !ok {
+		t.Fatal("delete must have 204")
+	}
+	if r204["content"] != nil {
+		t.Error("204 must have no content")
+	}
+	if _, ok := dresps["422"]; ok {
+		t.Error("delete must not have 422")
+	}
+}
+
+func TestOpenAPI_Resource_No422WithoutValidator(t *testing.T) {
+	app := New(WithOpenAPIInfo("API", "1.0", "")) // no validator
+	Resource(app, "/users", &validatedUserService{})
+	spec := decodeSpec(t, app)
+
+	create := op(t, spec, "/users", "post")
+	resps := create["responses"].(map[string]any)
+	if _, ok := resps["422"]; ok {
+		t.Error("no validator configured → create must not advertise 422")
+	}
+}
+
+func TestOpenAPI_Resource_No422WithoutTags(t *testing.T) {
+	app := New(WithOpenAPIInfo("API", "1.0", ""), WithValidator(NewValidator()))
+	Resource(app, "/users", &mockUserService{}) // mockUser has no validate tags
+	spec := decodeSpec(t, app)
+
+	create := op(t, spec, "/users", "post")
+	resps := create["responses"].(map[string]any)
+	if _, ok := resps["422"]; ok {
+		t.Error("T without validate tags → create must not advertise 422")
+	}
+}
+
+func TestOpenAPI_Resource_ValidJSONPointers(t *testing.T) {
+	app := New(WithOpenAPIInfo("API", "1.0", ""), WithValidator(NewValidator()))
+	Resource(app, "/users", &validatedUserService{})
+	b, err := app.buildOpenAPISpec()
+	if err != nil {
+		t.Fatalf("buildOpenAPISpec: %v", err)
+	}
+	var spec any
+	if err := json.Unmarshal(b, &spec); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	assertValidJSONPointers(t, spec, "")
+}
+
+func TestOpenAPI_Resource_ListEnvelopeComponentSanitized(t *testing.T) {
+	app := New(WithOpenAPIInfo("API", "1.0", ""))
+	Resource(app, "/users", &mockUserService{})
+	spec := decodeSpec(t, app)
+
+	comps, _ := spec["components"].(map[string]any)
+	schemas, _ := comps["schemas"].(map[string]any)
+	// ResourceList[kruda.mockUser] → sanitized to ResourceList_mockUser.
+	if _, ok := schemas["ResourceList_mockUser"]; !ok {
+		t.Errorf("missing sanitized ResourceList component; schemas=%v", keysOf(schemas))
+	}
+	for k := range schemas {
+		if containsAnyChar(k, "/[]") {
+			t.Errorf("component key %q has invalid pointer chars", k)
+		}
+	}
+}
+
+func containsAnyChar(s, chars string) bool {
+	for _, c := range chars {
+		for _, x := range s {
+			if x == c {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// =============================================================================
+// only/except gating mirrors routeInfo append (§5.5c)
+// =============================================================================
+
+func TestOpenAPI_Resource_OnlyGET_BothListAndGetByID(t *testing.T) {
+	app := New(WithOpenAPIInfo("API", "1.0", ""))
+	Resource(app, "/users", &mockUserService{}, WithResourceOnly("GET"))
+	spec := decodeSpec(t, app)
+
+	op(t, spec, "/users", "get")      // list
+	op(t, spec, "/users/{id}", "get") // get-by-id
+
+	// No create/update/delete.
+	if item, ok := paths(t, spec)["/users"].(map[string]any); ok {
+		if _, ok := item["post"]; ok {
+			t.Error("WithResourceOnly(GET) must not register POST in spec")
+		}
+	}
+	if item, ok := paths(t, spec)["/users/{id}"].(map[string]any); ok {
+		if _, ok := item["put"]; ok {
+			t.Error("WithResourceOnly(GET) must not register PUT in spec")
+		}
+		if _, ok := item["delete"]; ok {
+			t.Error("WithResourceOnly(GET) must not register DELETE in spec")
+		}
+	}
+}
+
+// WithResourceExcept("DELETE") must remove the delete op from the spec, and the
+// spec must mirror the router exactly (the §5.5c invariant). NOTE: the spec's §7
+// prose claims Except("GET") removes both list+get-by-id, but that contradicts
+// the runtime resourceShouldRegister logic §5.5c mandates mirroring: excepting
+// the "GET" shortcut still registers the LIST/GET_BY_ID sub-keys at the router,
+// so OpenAPI registers them too (router/OpenAPI parity is the actual contract).
+// This test pins the parity-respecting behavior with Except("DELETE").
+func TestOpenAPI_Resource_ExceptDelete_RemovesDelete(t *testing.T) {
+	app := New(WithOpenAPIInfo("API", "1.0", ""))
+	Resource(app, "/users", &mockUserService{}, WithResourceExcept("DELETE"))
+	spec := decodeSpec(t, app)
+
+	// Survivors present.
+	op(t, spec, "/users", "get")
+	op(t, spec, "/users", "post")
+	op(t, spec, "/users/{id}", "get")
+	op(t, spec, "/users/{id}", "put")
+
+	// Delete removed.
+	if item, ok := paths(t, spec)["/users/{id}"].(map[string]any); ok {
+		if _, ok := item["delete"]; ok {
+			t.Error("WithResourceExcept(DELETE) must not register delete in spec")
+		}
+	}
+}
+
+// =============================================================================
+// Group prefix → OpenAPI path == convertPath(joinPath(prefix, idPath)) (§5.1)
+// =============================================================================
+
+func TestOpenAPI_GroupResource_PrefixedPaths(t *testing.T) {
+	app := New(WithOpenAPIInfo("API", "1.0", ""))
+	g := app.Group("/api/v1")
+	GroupResource(g, "/users", &mockUserService{})
+	spec := decodeSpec(t, app)
+
+	op(t, spec, "/api/v1/users", "get")      // list
+	op(t, spec, "/api/v1/users/{id}", "get") // get-by-id
+	op(t, spec, "/api/v1/users", "post")     // create
+	op(t, spec, "/api/v1/users/{id}", "put") // update
+	op(t, spec, "/api/v1/users/{id}", "delete")
+
+	// Sanity: matches convertPath(joinPath(...)).
+	wantID := convertPath(joinPath("/api/v1", "/users/:id"))
+	if _, ok := paths(t, spec)[wantID].(map[string]any); !ok {
+		t.Errorf("expected path %q in spec; paths=%v", wantID, keysOf(paths(t, spec)))
+	}
+}

--- a/openapi_resource_test.go
+++ b/openapi_resource_test.go
@@ -1,0 +1,319 @@
+package kruda
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/go-kruda/kruda/internal/testtypes"
+)
+
+// resourceListLike mirrors the shape of the (not-yet-defined) ResourceList[T]
+// envelope so the sanitizer can be exercised against a real generic
+// instantiation whose type argument lives in a sub-package — i.e. t.Name()
+// contains "/" and ".".
+type resourceListLike[T any] struct {
+	Data  []T `json:"data"`
+	Total int `json:"total"`
+	Page  int `json:"page"`
+	Limit int `json:"limit"`
+}
+
+// assertValidJSONPointers walks the spec JSON and asserts every "$ref" string
+// is a valid local JSON pointer: it must start with "#/" and contain none of
+// the characters that break a component-name pointer segment.
+func assertValidJSONPointers(t *testing.T, v any, path string) {
+	t.Helper()
+	switch node := v.(type) {
+	case map[string]any:
+		for k, child := range node {
+			if k == "$ref" {
+				ref, ok := child.(string)
+				if !ok {
+					t.Fatalf("%s/$ref is not a string: %T", path, child)
+				}
+				if !strings.HasPrefix(ref, "#/") {
+					t.Errorf("%s: $ref %q does not start with #/", path, ref)
+				}
+				seg := strings.TrimPrefix(ref, "#/components/schemas/")
+				if strings.ContainsAny(seg, "/[]") {
+					t.Errorf("%s: $ref component segment %q contains invalid chars (/[]): %q", path, seg, ref)
+				}
+				continue
+			}
+			assertValidJSONPointers(t, child, path+"/"+k)
+		}
+	case []any:
+		for i, child := range node {
+			assertValidJSONPointers(t, child, path)
+			_ = i
+		}
+	}
+}
+
+func TestGenerateSchema_GenericNameSanitized(t *testing.T) {
+	components := make(map[string]*schemaRef)
+	rt := reflect.TypeOf(resourceListLike[testtypes.User]{})
+
+	// Sanity: the raw type name really does contain the chars that break $ref.
+	if !strings.ContainsAny(rt.Name(), "/[].") {
+		t.Fatalf("test precondition: expected raw name to contain /[]. got %q", rt.Name())
+	}
+
+	ref := generateSchema(rt, components)
+
+	// (a) The emitted $ref must be a valid JSON pointer (no /, [, ]).
+	if strings.ContainsAny(strings.TrimPrefix(ref.Ref, "#/components/schemas/"), "/[]") {
+		t.Errorf("emitted $ref %q is not a valid JSON pointer", ref.Ref)
+	}
+
+	// (b) The component key derived from the generic must be sanitized to a
+	// deterministic form: base + "_" + last segment of the type arg.
+	wantKey := "resourceListLike_User"
+	if _, ok := components[wantKey]; !ok {
+		var keys []string
+		for k := range components {
+			keys = append(keys, k)
+		}
+		t.Fatalf("expected sanitized component key %q; got keys %v", wantKey, keys)
+	}
+
+	// (c) No component key in the map may contain /, [, or ] (would break $ref).
+	for k := range components {
+		if strings.ContainsAny(k, "/[]") {
+			t.Errorf("component key %q contains invalid pointer chars", k)
+		}
+	}
+
+	// (d) The $ref must actually point at the sanitized key.
+	if ref.Ref != "#/components/schemas/"+wantKey {
+		t.Errorf("$ref = %q, want %q", ref.Ref, "#/components/schemas/"+wantKey)
+	}
+}
+
+func TestGenerateSchema_NonGenericKeysUnchanged(t *testing.T) {
+	// The sanitizer must not alter keys for non-generic types (their Name()
+	// has no /[].).
+	components := make(map[string]*schemaRef)
+	ref := generateSchema(reflect.TypeOf(oaSimple{}), components)
+	if ref.Ref != "#/components/schemas/oaSimple" {
+		t.Errorf("$ref = %q, want #/components/schemas/oaSimple", ref.Ref)
+	}
+	if _, ok := components["oaSimple"]; !ok {
+		t.Error("non-generic key oaSimple must be unchanged")
+	}
+}
+
+func TestBuildOperation_Resource_Create(t *testing.T) {
+	components := make(map[string]*schemaRef)
+	ri := routeInfo{
+		method: "POST",
+		path:   "/users",
+		resourceOp: &resourceOp{
+			bodyType:    reflect.TypeOf(oaValidated{}),
+			respType:    reflect.TypeOf(oaValidated{}),
+			successCode: "201",
+			hasValidate: true,
+		},
+	}
+	op := buildOperation(ri, components, false)
+
+	if op.RequestBody == nil {
+		t.Fatal("create op must have a request body")
+	}
+	if _, ok := op.RequestBody.Content["application/json"]; !ok {
+		t.Error("create request body must be application/json")
+	}
+	if _, ok := op.Responses["201"]; !ok {
+		t.Error("create must have a 201 response")
+	}
+	if op.Responses["201"].Content["application/json"] == nil {
+		t.Error("201 response must carry a JSON body schema")
+	}
+	if _, ok := op.Responses["422"]; !ok {
+		t.Error("create with hasValidate must have a 422 response")
+	}
+	if _, ok := op.Responses["default"]; !ok {
+		t.Error("create must have a default error response")
+	}
+	if len(op.Parameters) != 0 {
+		t.Errorf("create must have no path/query params, got %d", len(op.Parameters))
+	}
+}
+
+func TestBuildOperation_Resource_Delete(t *testing.T) {
+	components := make(map[string]*schemaRef)
+	ri := routeInfo{
+		method: "DELETE",
+		path:   "/users/:id",
+		resourceOp: &resourceOp{
+			idParam:     "id",
+			idType:      reflect.TypeOf(""),
+			respType:    nil,
+			successCode: "204",
+			hasValidate: false,
+		},
+	}
+	op := buildOperation(ri, components, false)
+
+	if op.RequestBody != nil {
+		t.Error("delete must not have a request body")
+	}
+	resp204, ok := op.Responses["204"]
+	if !ok {
+		t.Fatal("delete must have a 204 response")
+	}
+	if len(resp204.Content) != 0 {
+		t.Errorf("204 response must have no body content, got %d", len(resp204.Content))
+	}
+	if _, ok := op.Responses["422"]; ok {
+		t.Error("delete (no validate) must not have a 422 response")
+	}
+	// Path param.
+	var foundID bool
+	for _, p := range op.Parameters {
+		if p.Name == "id" && p.In == "path" {
+			foundID = true
+			if p.Schema == nil || p.Schema.Type != "string" {
+				t.Errorf("id path param schema = %+v, want string", p.Schema)
+			}
+		}
+	}
+	if !foundID {
+		t.Error("delete must have an id path parameter")
+	}
+}
+
+func TestBuildOperation_Resource_List(t *testing.T) {
+	components := make(map[string]*schemaRef)
+	ri := routeInfo{
+		method: "GET",
+		path:   "/users",
+		resourceOp: &resourceOp{
+			respType:       reflect.TypeOf(resourceListLike[oaSimple]{}),
+			successCode:    "200",
+			needsListQuery: true,
+		},
+	}
+	op := buildOperation(ri, components, false)
+
+	// page + limit integer query params.
+	want := map[string]bool{"page": false, "limit": false}
+	for _, p := range op.Parameters {
+		if p.In != "query" {
+			continue
+		}
+		if _, ok := want[p.Name]; ok {
+			want[p.Name] = true
+			if p.Schema == nil || p.Schema.Type != "integer" {
+				t.Errorf("query param %q schema = %+v, want integer", p.Name, p.Schema)
+			}
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("list op missing integer query param %q", name)
+		}
+	}
+	if _, ok := op.Responses["200"]; !ok {
+		t.Error("list must have a 200 response")
+	}
+	if op.Responses["200"].Content["application/json"] == nil {
+		t.Error("list 200 response must carry a JSON body schema")
+	}
+	if _, ok := op.Responses["422"]; ok {
+		t.Error("list (no validate) must not have a 422 response")
+	}
+}
+
+func TestBuildOperation_Resource_Get(t *testing.T) {
+	components := make(map[string]*schemaRef)
+	ri := routeInfo{
+		method: "GET",
+		path:   "/users/:id",
+		resourceOp: &resourceOp{
+			idParam:     "id",
+			idType:      reflect.TypeOf(int(0)),
+			respType:    reflect.TypeOf(oaSimple{}),
+			successCode: "200",
+		},
+	}
+	op := buildOperation(ri, components, false)
+
+	var idSchema *schemaRef
+	for _, p := range op.Parameters {
+		if p.Name == "id" && p.In == "path" {
+			idSchema = p.Schema
+		}
+	}
+	if idSchema == nil {
+		t.Fatal("get must have an id path param")
+	}
+	if idSchema.Type != "integer" {
+		t.Errorf("int id param type = %q, want integer", idSchema.Type)
+	}
+	if _, ok := op.Responses["200"]; !ok {
+		t.Error("get must have a 200 response")
+	}
+	if op.RequestBody != nil {
+		t.Error("get must not have a request body")
+	}
+}
+
+// TestBuildOpenAPISpec_TypedOnly_GoldenGuard is the BLOCKING regression guard:
+// a typed-only app's spec must be byte-identical before/after the resourceOp
+// additions (resourceOp==nil path + sanitizer must not alter non-generic
+// output). The golden bytes were captured before the openapi.go changes.
+func TestBuildOpenAPISpec_TypedOnly_GoldenGuard(t *testing.T) {
+	app := newGoldenGuardApp()
+
+	specJSON, err := app.buildOpenAPISpec()
+	if err != nil {
+		t.Fatalf("buildOpenAPISpec failed: %v", err)
+	}
+
+	// Structural validity: every $ref is a valid JSON pointer.
+	var spec any
+	if err := json.Unmarshal(specJSON, &spec); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	assertValidJSONPointers(t, spec, "")
+
+	// Byte-identity against the pre-change capture (JSON object key order is
+	// stable for a given encoder + struct layout, so compare normalized JSON
+	// to avoid map-ordering flakiness).
+	var got, want any
+	if err := json.Unmarshal(specJSON, &got); err != nil {
+		t.Fatalf("unmarshal got: %v", err)
+	}
+	if err := json.Unmarshal([]byte(goldenTypedOnlySpec), &want); err != nil {
+		t.Fatalf("unmarshal golden: %v", err)
+	}
+	gotN, _ := json.Marshal(got)
+	wantN, _ := json.Marshal(want)
+	if string(gotN) != string(wantN) {
+		t.Errorf("typed-only spec changed.\n got: %s\nwant: %s", gotN, wantN)
+	}
+}
+
+// newGoldenGuardApp builds a fixed typed-only app used for the golden guard.
+func newGoldenGuardApp() *App {
+	app := New(
+		WithValidator(NewValidator()),
+		WithOpenAPIInfo("Golden API", "9.9.9", "golden guard"),
+		WithOpenAPITag("users", "User operations"),
+	)
+	Post[oaValidated, oaOut](app, "/users", func(c *C[oaValidated]) (*oaOut, error) {
+		return &oaOut{ID: "1"}, nil
+	}, WithDescription("Create user"), WithTags("users"))
+	Get[oaParamQuery, oaOut](app, "/users/:id", func(c *C[oaParamQuery]) (*oaOut, error) {
+		return &oaOut{ID: c.In.ID}, nil
+	}, WithDescription("Get user"), WithTags("users"))
+	return app
+}
+
+// goldenTypedOnlySpec is the buildOpenAPISpec() output of newGoldenGuardApp,
+// captured from the code BEFORE the resourceOp additions + sanitizer. Compared
+// as normalized JSON to guard the typed-route path against regression.
+const goldenTypedOnlySpec = `{"openapi":"3.1.0","info":{"title":"Golden API","version":"9.9.9","description":"golden guard"},"paths":{"/users":{"post":{"description":"Create user","tags":["users"],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/oaValidated"}}}},"responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/oaOut"}}}},"422":{"description":"Validation failed","content":{"application/json":{"schema":{"$ref":"#/components/schemas/ValidationError"}}}},"default":{"description":"Error response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/KrudaError"}}}}}}},"/users/{id}":{"get":{"description":"Get user","tags":["users"],"parameters":[{"name":"id","in":"path","required":true,"schema":{"type":"string"}},{"name":"page","in":"query","schema":{"type":"integer"}}],"requestBody":{"required":true,"content":{"application/json":{"schema":{"$ref":"#/components/schemas/oaParamQuery"}}}},"responses":{"200":{"description":"Successful response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/oaOut"}}}},"default":{"description":"Error response","content":{"application/json":{"schema":{"$ref":"#/components/schemas/KrudaError"}}}}}}}},"components":{"schemas":{"FieldError":{"type":"object","properties":{"field":{"type":"string"},"message":{"type":"string"},"param":{"type":"string"},"rule":{"type":"string"},"value":{"type":"string"}},"required":["field","rule","param","message","value"]},"KrudaError":{"type":"object","properties":{"code":{"type":"integer"},"detail":{"type":"string"},"message":{"type":"string"}},"required":["code","message"]},"ValidationError":{"type":"object","properties":{"code":{"type":"integer"},"errors":{"type":"array","items":{"$ref":"#/components/schemas/FieldError"}},"message":{"type":"string"}},"required":["code","message","errors"]},"oaOut":{"type":"object","properties":{"id":{"type":"string"},"message":{"type":"string"}}},"oaParamQuery":{"type":"object","properties":{"name":{"type":"string"}}},"oaValidated":{"type":"object","properties":{"email":{"type":"string","format":"email"},"id":{"type":"string","format":"uuid"},"name":{"type":"string","minLength":2,"maxLength":50},"role":{"type":"string","enum":["admin","user","guest"]},"url":{"type":"string","format":"uri"}},"required":["name","email"]}}},"tags":[{"name":"users","description":"User operations"}]}`

--- a/openapi_resource_test.go
+++ b/openapi_resource_test.go
@@ -69,8 +69,10 @@ func TestGenerateSchema_GenericNameSanitized(t *testing.T) {
 	}
 
 	// (b) The component key derived from the generic must be sanitized to a
-	// deterministic form: base + "_" + last segment of the type arg.
-	wantKey := "resourceListLike_User"
+	// deterministic form that preserves the type argument's FULL qualified name
+	// (every illegal-char run → "_"), so cross-package same-short-name args never
+	// collide. The arg lives at github.com/go-kruda/kruda/internal/testtypes.User.
+	wantKey := "resourceListLike_github_com_go-kruda_kruda_internal_testtypes_User"
 	if _, ok := components[wantKey]; !ok {
 		var keys []string
 		for k := range components {

--- a/openapi_sanitize_test.go
+++ b/openapi_sanitize_test.go
@@ -1,0 +1,176 @@
+package kruda
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/go-kruda/kruda/internal/testtypes"
+	"github.com/go-kruda/kruda/internal/testtypes/alt"
+)
+
+// crossPkgItemA is a ResourceService over testtypes.User.
+type crossPkgItemA struct{}
+
+func (crossPkgItemA) List(context.Context, int, int) ([]testtypes.User, int, error) {
+	return nil, 0, nil
+}
+func (crossPkgItemA) Create(_ context.Context, item testtypes.User) (testtypes.User, error) {
+	return item, nil
+}
+func (crossPkgItemA) Get(_ context.Context, id string) (testtypes.User, error) {
+	return testtypes.User{ID: id}, nil
+}
+func (crossPkgItemA) Update(_ context.Context, _ string, item testtypes.User) (testtypes.User, error) {
+	return item, nil
+}
+func (crossPkgItemA) Delete(context.Context, string) error { return nil }
+
+// crossPkgItemB is a ResourceService over alt.User (same short name, different package).
+type crossPkgItemB struct{}
+
+func (crossPkgItemB) List(context.Context, int, int) ([]alt.User, int, error) { return nil, 0, nil }
+func (crossPkgItemB) Create(_ context.Context, item alt.User) (alt.User, error) {
+	return item, nil
+}
+func (crossPkgItemB) Get(_ context.Context, id string) (alt.User, error) {
+	return alt.User{ID: id}, nil
+}
+func (crossPkgItemB) Update(_ context.Context, _ string, item alt.User) (alt.User, error) {
+	return item, nil
+}
+func (crossPkgItemB) Delete(context.Context, string) error { return nil }
+
+// TestGenerateSchema_CrossPackageGenericNoCollision verifies that two generic
+// instantiations whose type arguments share a short name ("User") but live in
+// different packages get DISTINCT component keys and DISTINCT $refs, and that
+// both inner item schemas are present (neither silently dropped).
+func TestGenerateSchema_CrossPackageGenericNoCollision(t *testing.T) {
+	components := make(map[string]*schemaRef)
+
+	refA := generateSchema(reflect.TypeOf(ResourceList[testtypes.User]{}), components)
+	refB := generateSchema(reflect.TypeOf(ResourceList[alt.User]{}), components)
+
+	if refA.Ref == refB.Ref {
+		t.Fatalf("cross-package generics collapsed to same $ref %q", refA.Ref)
+	}
+
+	// Both envelope component keys must exist and be distinct.
+	keyA := strings.TrimPrefix(refA.Ref, "#/components/schemas/")
+	keyB := strings.TrimPrefix(refB.Ref, "#/components/schemas/")
+	if keyA == keyB {
+		t.Fatalf("envelope keys collided: %q", keyA)
+	}
+	if _, ok := components[keyA]; !ok {
+		t.Errorf("envelope component %q missing", keyA)
+	}
+	if _, ok := components[keyB]; !ok {
+		t.Errorf("envelope component %q missing", keyB)
+	}
+
+	// Both inner User schemas must be present (different package qualifiers ⇒
+	// different keys), so neither is silently dropped.
+	var userKeys []string
+	for k, v := range components {
+		if v.Type == "object" && v.Properties != nil {
+			if _, hasID := v.Properties["id"]; hasID {
+				// distinguish the two Users: testtypes.User has "name",
+				// alt.User has "email".
+				_, hasName := v.Properties["name"]
+				_, hasEmail := v.Properties["email"]
+				if hasName || hasEmail {
+					userKeys = append(userKeys, k)
+				}
+			}
+		}
+	}
+	var foundName, foundEmail bool
+	for _, k := range userKeys {
+		if _, ok := components[k].Properties["name"]; ok {
+			foundName = true
+		}
+		if _, ok := components[k].Properties["email"]; ok {
+			foundEmail = true
+		}
+	}
+	if !foundName {
+		t.Errorf("testtypes.User schema (with 'name') missing; keys=%v", componentKeys(components))
+	}
+	if !foundEmail {
+		t.Errorf("alt.User schema (with 'email') missing; keys=%v", componentKeys(components))
+	}
+
+	// No component key may contain invalid JSON-pointer chars.
+	for k := range components {
+		if strings.ContainsAny(k, "/[].") {
+			t.Errorf("component key %q contains invalid pointer chars", k)
+		}
+	}
+}
+
+// TestGenerateSchema_CrossPackageEndToEnd registers two Resources over
+// same-short-name types in different packages and asserts the full spec keeps
+// both ResourceList envelopes with distinct, valid $refs.
+func TestGenerateSchema_CrossPackageEndToEnd(t *testing.T) {
+	app := New()
+	Resource[testtypes.User, string](app, "/a", crossPkgItemA{}, WithResourceOnly("LIST"))
+	Resource[alt.User, string](app, "/b", crossPkgItemB{}, WithResourceOnly("LIST"))
+
+	specJSON, err := app.buildOpenAPISpec()
+	if err != nil {
+		t.Fatalf("buildOpenAPISpec: %v", err)
+	}
+	var spec any
+	if err := json.Unmarshal(specJSON, &spec); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	assertValidJSONPointers(t, spec, "")
+}
+
+// TestSanitizeComponentName_NestedBrackets verifies a generic instantiated with
+// a nested-bracket type argument (map/slice/nested generic) produces a key with
+// no '[', ']', '/' or '.'.
+func TestSanitizeComponentName_NestedBrackets(t *testing.T) {
+	cases := []string{
+		"ResourceList[map[string]int]",
+		"ResourceList[[]int]",
+		"Wrap[ResourceList[github.com/app/models.User]]",
+		"genWrap[*github.com/app/models.User]",
+	}
+	for _, in := range cases {
+		got := sanitizeComponentName(in)
+		if strings.ContainsAny(got, "/[].*") {
+			t.Errorf("sanitizeComponentName(%q) = %q still contains invalid chars", in, got)
+		}
+	}
+}
+
+// TestSanitizeComponentName_PointerVsValue verifies a value type arg and a
+// pointer type arg with the same underlying name produce DISTINCT keys.
+func TestSanitizeComponentName_PointerVsValue(t *testing.T) {
+	val := sanitizeComponentName("genWrap[github.com/app/models.User]")
+	ptr := sanitizeComponentName("genWrap[*github.com/app/models.User]")
+	if val == ptr {
+		t.Errorf("value and pointer type args collapsed to same key %q", val)
+	}
+}
+
+// TestSanitizeComponentName_CrossPackage verifies same-short-name type args from
+// different packages produce DISTINCT keys.
+func TestSanitizeComponentName_CrossPackage(t *testing.T) {
+	a := sanitizeComponentName("ResourceList[a/b.User]")
+	b := sanitizeComponentName("ResourceList[c/d.User]")
+	if a == b {
+		t.Errorf("cross-package args collapsed to same key %q", a)
+	}
+}
+
+func componentKeys(m map[string]*schemaRef) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/resource.go
+++ b/resource.go
@@ -2,10 +2,26 @@ package kruda
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 )
+
+// maxResourceListLimit caps the per-page item count an auto-CRUD list endpoint
+// will request. A larger ?limit is clamped to this value (not rejected).
+const maxResourceListLimit = 100
+
+// ResourceList is the response envelope for an auto-CRUD list endpoint. It is
+// used as the OpenAPI response type for list operations and marshals to the
+// same JSON the list handler has always produced ({data, total, page, limit}).
+type ResourceList[T any] struct {
+	Data  []T `json:"data"`
+	Total int `json:"total"`
+	Page  int `json:"page"`
+	Limit int `json:"limit"`
+}
 
 // ResourceService is the generic interface for auto-wired CRUD endpoints.
 // Implement this interface to get 5 REST endpoints (List, Create, Get, Update, Delete)
@@ -95,57 +111,153 @@ func (g groupRegistrar) Delete(p string, h HandlerFunc) routeRegistrar {
 
 // Resource auto-wires 5 REST endpoints from a ResourceService on the App.
 // It registers: GET (list), GET/:id (get), POST (create), PUT/:id (update), DELETE/:id (delete).
+//
+// Create and update validate the decoded body using the same machinery and
+// error contract as typed C[T] handlers: validation runs only when a *Validator
+// is configured (via WithValidator) and T carries validate tags, emitting a 422
+// on failure. Malformed JSON yields a 400 ("invalid request body").
+//
+// Service errors propagate unchanged: a ResourceService returning a *KrudaError
+// (e.g. NotFound) gets that status; a plain error becomes the generic 500. The
+// framework never synthesizes a 404, and OpenAPI advertises only the success
+// code, a 422 when validation is engaged, and the default error response.
 func Resource[T any, ID comparable](app *App, path string, svc ResourceService[T, ID], opts ...ResourceOption) *App {
-	registerResource(appRegistrar{app}, path, svc, opts...)
+	registerResource(appRegistrar{app}, app, "", path, svc, opts...)
 	return app
 }
 
 // GroupResource auto-wires 5 REST endpoints from a ResourceService on a Group.
 // It registers: GET (list), GET/:id (get), POST (create), PUT/:id (update), DELETE/:id (delete).
+// Behavior matches Resource (validation, error propagation, OpenAPI); see Resource.
 func GroupResource[T any, ID comparable](g *Group, path string, svc ResourceService[T, ID], opts ...ResourceOption) *Group {
-	registerResource(groupRegistrar{g}, path, svc, opts...)
+	registerResource(groupRegistrar{g}, g.app, g.prefix, path, svc, opts...)
 	return g
 }
 
-func registerResource[T any, ID comparable](r routeRegistrar, path string, svc ResourceService[T, ID], opts ...ResourceOption) {
+func registerResource[T any, ID comparable](r routeRegistrar, app *App, pathPrefix, path string, svc ResourceService[T, ID], opts ...ResourceOption) {
 	cfg := defaultResourceConfig()
 	for _, opt := range opts {
 		opt(&cfg)
 	}
+
+	idType := reflect.TypeOf((*ID)(nil)).Elem()
+	switch idType.Kind() {
+	case reflect.String, reflect.Int, reflect.Int64, reflect.Uint, reflect.Uint64:
+	default:
+		panic(fmt.Sprintf("kruda: Resource ID type %s unsupported; use string/int/int64/uint/uint64", idType))
+	}
+
+	// Precompile validators once, gated exactly like the typed path
+	// (handler.go): only when a *Validator is configured. No auto-default.
+	var validators []fieldValidator
+	var msgs map[string]string
+	if app.config.Validator != nil {
+		validators = buildValidators[T](app.config.Validator)
+		msgs = app.config.Validator.messages
+	}
+	hasValidate := len(validators) > 0
+
+	bodyType := reflect.TypeOf((*T)(nil)).Elem()
+	listRespType := reflect.TypeOf(ResourceList[T]{})
+
 	idPath := path + "/:" + cfg.idParam
+	fullPath := func(rel string) string { return joinPath(pathPrefix, rel) }
 
 	if resourceShouldRegister(cfg, "GET") {
 		r.Get(path, resourceWrapMW(cfg.middleware, resourceListHandler(svc)))
+		app.routeInfos = append(app.routeInfos, routeInfo{
+			method: "GET", path: fullPath(path),
+			resourceOp: &resourceOp{needsListQuery: true, respType: listRespType, successCode: "200"},
+		})
 		r.Get(idPath, resourceWrapMW(cfg.middleware, resourceGetHandler[T, ID](svc, cfg)))
+		app.routeInfos = append(app.routeInfos, routeInfo{
+			method: "GET", path: fullPath(idPath),
+			resourceOp: &resourceOp{idParam: cfg.idParam, idType: idType, respType: bodyType, successCode: "200"},
+		})
 	} else {
 		if resourceShouldRegister(cfg, "LIST") {
 			r.Get(path, resourceWrapMW(cfg.middleware, resourceListHandler(svc)))
+			app.routeInfos = append(app.routeInfos, routeInfo{
+				method: "GET", path: fullPath(path),
+				resourceOp: &resourceOp{needsListQuery: true, respType: listRespType, successCode: "200"},
+			})
 		}
 		if resourceShouldRegister(cfg, "GET_BY_ID") {
 			r.Get(idPath, resourceWrapMW(cfg.middleware, resourceGetHandler[T, ID](svc, cfg)))
+			app.routeInfos = append(app.routeInfos, routeInfo{
+				method: "GET", path: fullPath(idPath),
+				resourceOp: &resourceOp{idParam: cfg.idParam, idType: idType, respType: bodyType, successCode: "200"},
+			})
 		}
 	}
 	if resourceShouldRegister(cfg, "POST") {
-		r.Post(path, resourceWrapMW(cfg.middleware, resourceCreateHandler[T, ID](svc)))
+		r.Post(path, resourceWrapMW(cfg.middleware, resourceCreateHandler[T, ID](svc, validators, msgs)))
+		app.routeInfos = append(app.routeInfos, routeInfo{
+			method: "POST", path: fullPath(path),
+			resourceOp: &resourceOp{bodyType: bodyType, respType: bodyType, successCode: "201", hasValidate: hasValidate},
+		})
 	}
 	if resourceShouldRegister(cfg, "PUT") {
-		r.Put(idPath, resourceWrapMW(cfg.middleware, resourceUpdateHandler[T, ID](svc, cfg)))
+		r.Put(idPath, resourceWrapMW(cfg.middleware, resourceUpdateHandler[T, ID](svc, cfg, validators, msgs)))
+		app.routeInfos = append(app.routeInfos, routeInfo{
+			method: "PUT", path: fullPath(idPath),
+			resourceOp: &resourceOp{idParam: cfg.idParam, idType: idType, bodyType: bodyType, respType: bodyType, successCode: "200", hasValidate: hasValidate},
+		})
 	}
 	if resourceShouldRegister(cfg, "DELETE") {
 		r.Delete(idPath, resourceWrapMW(cfg.middleware, resourceDeleteHandler[T, ID](svc, cfg)))
+		app.routeInfos = append(app.routeInfos, routeInfo{
+			method: "DELETE", path: fullPath(idPath),
+			resourceOp: &resourceOp{idParam: cfg.idParam, idType: idType, respType: nil, successCode: "204"},
+		})
 	}
 }
 
 func resourceListHandler[T any, ID comparable](svc ResourceService[T, ID]) HandlerFunc {
 	return func(c *Ctx) error {
-		page := c.QueryInt("page", 1)
-		limit := c.QueryInt("limit", 20)
+		page, err := resourceParsePositiveInt(c.Query("page"), "page", 1)
+		if err != nil {
+			return err
+		}
+		limit, err := resourceParsePositiveInt(c.Query("limit"), "limit", 20)
+		if err != nil {
+			return err
+		}
+		if limit > maxResourceListLimit {
+			limit = maxResourceListLimit
+		}
 		items, total, err := svc.List(c.Context(), page, limit)
 		if err != nil {
 			return err
 		}
-		return c.JSON(Map{"data": items, "total": total, "page": page, "limit": limit})
+		return c.JSON(ResourceList[T]{Data: items, Total: total, Page: page, Limit: limit})
 	}
+}
+
+// resourceParsePositiveInt parses a pagination query value. Absent (empty) →
+// def. Present must parse as an int >= 1, else a 400 with the typed-path
+// message format ("invalid query parameter \"<name>\": expected int").
+func resourceParsePositiveInt(raw, name string, def int) (int, error) {
+	if raw == "" {
+		return def, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		return 0, BadRequest(fmt.Sprintf("invalid query parameter %q: expected int", name))
+	}
+	return n, nil
+}
+
+// wrapBindErr normalizes a c.Bind error: an existing *KrudaError (e.g. a 413
+// from an oversized body, or the empty-body 400) passes through untouched; a
+// raw decoder error becomes a 400 "invalid request body", matching the typed
+// path instead of falling through to a 500.
+func wrapBindErr(err error) error {
+	var ke *KrudaError
+	if errors.As(err, &ke) {
+		return err
+	}
+	return BadRequest("invalid request body")
 }
 
 func resourceGetHandler[T any, ID comparable](svc ResourceService[T, ID], cfg resourceConfig) HandlerFunc {
@@ -162,11 +274,16 @@ func resourceGetHandler[T any, ID comparable](svc ResourceService[T, ID], cfg re
 	}
 }
 
-func resourceCreateHandler[T any, ID comparable](svc ResourceService[T, ID]) HandlerFunc {
+func resourceCreateHandler[T any, ID comparable](svc ResourceService[T, ID], validators []fieldValidator, msgs map[string]string) HandlerFunc {
 	return func(c *Ctx) error {
 		var item T
 		if err := c.Bind(&item); err != nil {
-			return err
+			return wrapBindErr(err)
+		}
+		if len(validators) > 0 {
+			if ve := validate(validators, reflect.ValueOf(item), msgs); ve != nil {
+				return ve
+			}
 		}
 		created, err := svc.Create(c.Context(), item)
 		if err != nil {
@@ -176,7 +293,7 @@ func resourceCreateHandler[T any, ID comparable](svc ResourceService[T, ID]) Han
 	}
 }
 
-func resourceUpdateHandler[T any, ID comparable](svc ResourceService[T, ID], cfg resourceConfig) HandlerFunc {
+func resourceUpdateHandler[T any, ID comparable](svc ResourceService[T, ID], cfg resourceConfig, validators []fieldValidator, msgs map[string]string) HandlerFunc {
 	return func(c *Ctx) error {
 		id, err := resourceParseID[ID](c.Param(cfg.idParam))
 		if err != nil {
@@ -184,7 +301,12 @@ func resourceUpdateHandler[T any, ID comparable](svc ResourceService[T, ID], cfg
 		}
 		var item T
 		if err := c.Bind(&item); err != nil {
-			return err
+			return wrapBindErr(err)
+		}
+		if len(validators) > 0 {
+			if ve := validate(validators, reflect.ValueOf(item), msgs); ve != nil {
+				return ve
+			}
 		}
 		updated, err := svc.Update(c.Context(), id, item)
 		if err != nil {

--- a/resource.go
+++ b/resource.go
@@ -141,11 +141,13 @@ func registerResource[T any, ID comparable](r routeRegistrar, app *App, pathPref
 	}
 
 	idType := reflect.TypeOf((*ID)(nil)).Elem()
-	switch idType.Kind() {
-	case reflect.String, reflect.Int, reflect.Int64, reflect.Uint, reflect.Uint64:
-	default:
+	if !resourceIDKindSupported(idType.Kind()) {
 		panic(fmt.Sprintf("kruda: Resource ID type %s unsupported; use string/int/int64/uint/uint64", idType))
 	}
+	// Build the path-segment→ID parser once at registration so the per-request
+	// handlers do no reflect.Type lookup (the resource path is opt-in, but it
+	// still need not pay avoidable per-request reflection).
+	parseID := buildResourceIDParser[ID](idType)
 
 	// Precompile validators once, gated exactly like the typed path
 	// (handler.go): only when a *Validator is configured. No auto-default.
@@ -169,7 +171,7 @@ func registerResource[T any, ID comparable](r routeRegistrar, app *App, pathPref
 			method: "GET", path: fullPath(path),
 			resourceOp: &resourceOp{needsListQuery: true, respType: listRespType, successCode: "200"},
 		})
-		r.Get(idPath, resourceWrapMW(cfg.middleware, resourceGetHandler[T, ID](svc, cfg)))
+		r.Get(idPath, resourceWrapMW(cfg.middleware, resourceGetHandler[T, ID](svc, cfg, parseID)))
 		app.routeInfos = append(app.routeInfos, routeInfo{
 			method: "GET", path: fullPath(idPath),
 			resourceOp: &resourceOp{idParam: cfg.idParam, idType: idType, respType: bodyType, successCode: "200"},
@@ -183,7 +185,7 @@ func registerResource[T any, ID comparable](r routeRegistrar, app *App, pathPref
 			})
 		}
 		if resourceShouldRegister(cfg, "GET_BY_ID") {
-			r.Get(idPath, resourceWrapMW(cfg.middleware, resourceGetHandler[T, ID](svc, cfg)))
+			r.Get(idPath, resourceWrapMW(cfg.middleware, resourceGetHandler[T, ID](svc, cfg, parseID)))
 			app.routeInfos = append(app.routeInfos, routeInfo{
 				method: "GET", path: fullPath(idPath),
 				resourceOp: &resourceOp{idParam: cfg.idParam, idType: idType, respType: bodyType, successCode: "200"},
@@ -198,14 +200,14 @@ func registerResource[T any, ID comparable](r routeRegistrar, app *App, pathPref
 		})
 	}
 	if resourceShouldRegister(cfg, "PUT") {
-		r.Put(idPath, resourceWrapMW(cfg.middleware, resourceUpdateHandler[T, ID](svc, cfg, validators, msgs)))
+		r.Put(idPath, resourceWrapMW(cfg.middleware, resourceUpdateHandler[T, ID](svc, cfg, validators, msgs, parseID)))
 		app.routeInfos = append(app.routeInfos, routeInfo{
 			method: "PUT", path: fullPath(idPath),
 			resourceOp: &resourceOp{idParam: cfg.idParam, idType: idType, bodyType: bodyType, respType: bodyType, successCode: "200", hasValidate: hasValidate},
 		})
 	}
 	if resourceShouldRegister(cfg, "DELETE") {
-		r.Delete(idPath, resourceWrapMW(cfg.middleware, resourceDeleteHandler[T, ID](svc, cfg)))
+		r.Delete(idPath, resourceWrapMW(cfg.middleware, resourceDeleteHandler[T, ID](svc, cfg, parseID)))
 		app.routeInfos = append(app.routeInfos, routeInfo{
 			method: "DELETE", path: fullPath(idPath),
 			resourceOp: &resourceOp{idParam: cfg.idParam, idType: idType, respType: nil, successCode: "204"},
@@ -260,9 +262,9 @@ func wrapBindErr(err error) error {
 	return BadRequest("invalid request body")
 }
 
-func resourceGetHandler[T any, ID comparable](svc ResourceService[T, ID], cfg resourceConfig) HandlerFunc {
+func resourceGetHandler[T any, ID comparable](svc ResourceService[T, ID], cfg resourceConfig, parseID func(string) (ID, error)) HandlerFunc {
 	return func(c *Ctx) error {
-		id, err := resourceParseID[ID](c.Param(cfg.idParam))
+		id, err := parseID(c.Param(cfg.idParam))
 		if err != nil {
 			return BadRequest("invalid id")
 		}
@@ -293,9 +295,9 @@ func resourceCreateHandler[T any, ID comparable](svc ResourceService[T, ID], val
 	}
 }
 
-func resourceUpdateHandler[T any, ID comparable](svc ResourceService[T, ID], cfg resourceConfig, validators []fieldValidator, msgs map[string]string) HandlerFunc {
+func resourceUpdateHandler[T any, ID comparable](svc ResourceService[T, ID], cfg resourceConfig, validators []fieldValidator, msgs map[string]string, parseID func(string) (ID, error)) HandlerFunc {
 	return func(c *Ctx) error {
-		id, err := resourceParseID[ID](c.Param(cfg.idParam))
+		id, err := parseID(c.Param(cfg.idParam))
 		if err != nil {
 			return BadRequest("invalid id")
 		}
@@ -316,9 +318,9 @@ func resourceUpdateHandler[T any, ID comparable](svc ResourceService[T, ID], cfg
 	}
 }
 
-func resourceDeleteHandler[T any, ID comparable](svc ResourceService[T, ID], cfg resourceConfig) HandlerFunc {
+func resourceDeleteHandler[T any, ID comparable](svc ResourceService[T, ID], cfg resourceConfig, parseID func(string) (ID, error)) HandlerFunc {
 	return func(c *Ctx) error {
-		id, err := resourceParseID[ID](c.Param(cfg.idParam))
+		id, err := parseID(c.Param(cfg.idParam))
 		if err != nil {
 			return BadRequest("invalid id")
 		}
@@ -329,35 +331,65 @@ func resourceDeleteHandler[T any, ID comparable](svc ResourceService[T, ID], cfg
 	}
 }
 
-// resourceParseID parses a path segment into the resource ID type. It switches
-// on reflect.Kind (not the concrete type) so it stays in lockstep with the
-// Kind-based registration gate: a named type such as `type UserID int64` has
-// Kind Int64 and parses end-to-end, instead of slipping past registration only
-// to 400 here. The parsed value is converted back to ID via reflect so the
-// caller gets its exact (possibly named) type.
-func resourceParseID[ID comparable](raw string) (ID, error) {
-	idType := reflect.TypeOf((*ID)(nil)).Elem()
-	switch idType.Kind() {
-	case reflect.String:
-		return reflect.ValueOf(raw).Convert(idType).Interface().(ID), nil
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
-		v, err := strconv.ParseInt(raw, 10, 64)
-		if err != nil {
-			var zero ID
-			return zero, err
-		}
-		return reflect.ValueOf(v).Convert(idType).Interface().(ID), nil
-	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		v, err := strconv.ParseUint(raw, 10, 64)
-		if err != nil {
-			var zero ID
-			return zero, err
-		}
-		return reflect.ValueOf(v).Convert(idType).Interface().(ID), nil
-	default:
-		var zero ID
-		return zero, fmt.Errorf("unsupported ID type: %s", idType)
+// resourceIDKindSupported reports whether a reflect.Kind is an ID type the
+// resource router can parse from a path segment. The registration gate and the
+// parser both consult this single predicate so the two can never drift.
+func resourceIDKindSupported(k reflect.Kind) bool {
+	switch k {
+	case reflect.String, reflect.Int, reflect.Int64, reflect.Uint, reflect.Uint64:
+		return true
 	}
+	return false
+}
+
+// buildResourceIDParser returns a path-segment→ID parser computed once at
+// registration. Hoisting the reflect.Type lookup out of the per-request path
+// keeps the resource handlers off any per-request reflection beyond the
+// unavoidable Convert. It switches on reflect.Kind (not the concrete type) so a
+// named type such as `type UserID int64` parses end-to-end, and the parsed value
+// is converted back to ID so the caller gets its exact (possibly named) type.
+//
+// The integer bit width comes from the ID type itself (idType.Bits()), so a
+// value that overflows the target width is rejected as a 400 rather than being
+// silently truncated by the conversion — this matters for `int`/`uint` IDs on
+// 32-bit builds, where a fixed 64-bit parse would wrap.
+func buildResourceIDParser[ID comparable](idType reflect.Type) func(string) (ID, error) {
+	kind := idType.Kind()
+	var bits int
+	switch kind {
+	case reflect.Int, reflect.Int64, reflect.Uint, reflect.Uint64:
+		bits = idType.Bits()
+	}
+	return func(raw string) (ID, error) {
+		switch kind {
+		case reflect.String:
+			return reflect.ValueOf(raw).Convert(idType).Interface().(ID), nil
+		case reflect.Int, reflect.Int64:
+			v, err := strconv.ParseInt(raw, 10, bits)
+			if err != nil {
+				var zero ID
+				return zero, err
+			}
+			return reflect.ValueOf(v).Convert(idType).Interface().(ID), nil
+		case reflect.Uint, reflect.Uint64:
+			v, err := strconv.ParseUint(raw, 10, bits)
+			if err != nil {
+				var zero ID
+				return zero, err
+			}
+			return reflect.ValueOf(v).Convert(idType).Interface().(ID), nil
+		default:
+			var zero ID
+			return zero, fmt.Errorf("unsupported ID type: %s", idType)
+		}
+	}
+}
+
+// resourceParseID parses a single path segment into the ID type. It is a
+// convenience wrapper over buildResourceIDParser for callers that do not hold a
+// precomputed parser; the request handlers use the hoisted parser directly.
+func resourceParseID[ID comparable](raw string) (ID, error) {
+	return buildResourceIDParser[ID](reflect.TypeOf((*ID)(nil)).Elem())(raw)
 }
 
 func resourceShouldRegister(cfg resourceConfig, method string) bool {

--- a/resource.go
+++ b/resource.go
@@ -329,25 +329,34 @@ func resourceDeleteHandler[T any, ID comparable](svc ResourceService[T, ID], cfg
 	}
 }
 
+// resourceParseID parses a path segment into the resource ID type. It switches
+// on reflect.Kind (not the concrete type) so it stays in lockstep with the
+// Kind-based registration gate: a named type such as `type UserID int64` has
+// Kind Int64 and parses end-to-end, instead of slipping past registration only
+// to 400 here. The parsed value is converted back to ID via reflect so the
+// caller gets its exact (possibly named) type.
 func resourceParseID[ID comparable](raw string) (ID, error) {
-	var zero ID
-	switch any(zero).(type) {
-	case string:
-		return any(raw).(ID), nil
-	case int:
-		v, err := strconv.Atoi(raw)
-		return any(v).(ID), err
-	case int64:
+	idType := reflect.TypeOf((*ID)(nil)).Elem()
+	switch idType.Kind() {
+	case reflect.String:
+		return reflect.ValueOf(raw).Convert(idType).Interface().(ID), nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		v, err := strconv.ParseInt(raw, 10, 64)
-		return any(v).(ID), err
-	case uint:
+		if err != nil {
+			var zero ID
+			return zero, err
+		}
+		return reflect.ValueOf(v).Convert(idType).Interface().(ID), nil
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		v, err := strconv.ParseUint(raw, 10, 64)
-		return any(uint(v)).(ID), err
-	case uint64:
-		v, err := strconv.ParseUint(raw, 10, 64)
-		return any(v).(ID), err
+		if err != nil {
+			var zero ID
+			return zero, err
+		}
+		return reflect.ValueOf(v).Convert(idType).Interface().(ID), nil
 	default:
-		return zero, fmt.Errorf("unsupported ID type: %T", zero)
+		var zero ID
+		return zero, fmt.Errorf("unsupported ID type: %s", idType)
 	}
 }
 

--- a/resource_audit_test.go
+++ b/resource_audit_test.go
@@ -1,0 +1,66 @@
+package kruda
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestResourceParseID_IntOverflowErrors guards the error path of the
+// width-aware integer parse. The (MaxInt32, MaxInt64] silent-truncation it
+// prevents is reachable only on 32-bit builds; here a value beyond int64
+// exercises the ParseInt/ParseUint range error on any arch.
+func TestResourceParseID_IntOverflowErrors(t *testing.T) {
+	if _, err := resourceParseID[int64]("99999999999999999999999"); err == nil {
+		t.Fatal("expected range error for value beyond int64")
+	}
+	if _, err := resourceParseID[uint64]("99999999999999999999999"); err == nil {
+		t.Fatal("expected range error for value beyond uint64")
+	}
+}
+
+// TestResource_IntIDOverflow400 confirms an out-of-range id surfaces as a clean
+// 400 end-to-end, never a silently truncated wrong-ID 200.
+func TestResource_IntIDOverflow400(t *testing.T) {
+	app := New()
+	Resource[namedIDItem, NamedID](app, "/things", namedIDService{})
+	app.Compile()
+
+	req := &mockRequest{method: "GET", path: "/things/99999999999999999999999"}
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 400 {
+		t.Fatalf("status = %d, want 400 for out-of-range id\nbody: %s", resp.statusCode, resp.body)
+	}
+}
+
+// TestResourceParseID_AllSupportedKinds asserts the registration gate
+// (resourceIDKindSupported) and the parser agree: every admitted kind parses a
+// valid sample, and rejected kinds are not silently parseable.
+func TestResourceParseID_AllSupportedKinds(t *testing.T) {
+	if v, err := resourceParseID[string]("x"); err != nil || v != "x" {
+		t.Errorf("string: got (%q,%v)", v, err)
+	}
+	if v, err := resourceParseID[int]("7"); err != nil || v != 7 {
+		t.Errorf("int: got (%d,%v)", v, err)
+	}
+	if v, err := resourceParseID[int64]("7"); err != nil || v != 7 {
+		t.Errorf("int64: got (%d,%v)", v, err)
+	}
+	if v, err := resourceParseID[uint]("7"); err != nil || v != 7 {
+		t.Errorf("uint: got (%d,%v)", v, err)
+	}
+	if v, err := resourceParseID[uint64]("7"); err != nil || v != 7 {
+		t.Errorf("uint64: got (%d,%v)", v, err)
+	}
+
+	if !resourceIDKindSupported(reflect.String) || !resourceIDKindSupported(reflect.Int) ||
+		!resourceIDKindSupported(reflect.Int64) || !resourceIDKindSupported(reflect.Uint) ||
+		!resourceIDKindSupported(reflect.Uint64) {
+		t.Error("gate predicate rejects a kind the parser handles")
+	}
+	if resourceIDKindSupported(reflect.Int32) || resourceIDKindSupported(reflect.Float64) ||
+		resourceIDKindSupported(reflect.Bool) {
+		t.Error("gate predicate admits a kind the parser does not support")
+	}
+}

--- a/resource_review_fixes_test.go
+++ b/resource_review_fixes_test.go
@@ -1,0 +1,175 @@
+package kruda
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// =============================================================================
+// Fix 2: named ID types — registration gate (Kind-based) vs resourceParseID
+// (was concrete-type based) must be consistent. A named integer/string type
+// must work end-to-end, not return a runtime 400 "invalid id".
+// =============================================================================
+
+// NamedID is a named integer type (Kind==Int64). It passes the registration
+// gate (which switches on Kind) but historically failed resourceParseID (which
+// switched on the concrete type and had no case for it).
+type NamedID int64
+
+type namedIDItem struct {
+	ID   NamedID `json:"id"`
+	Name string  `json:"name"`
+}
+
+type namedIDService struct{}
+
+func (namedIDService) List(context.Context, int, int) ([]namedIDItem, int, error) {
+	return nil, 0, nil
+}
+func (namedIDService) Create(_ context.Context, item namedIDItem) (namedIDItem, error) {
+	return item, nil
+}
+func (namedIDService) Get(_ context.Context, id NamedID) (namedIDItem, error) {
+	return namedIDItem{ID: id, Name: "ok"}, nil
+}
+func (namedIDService) Update(_ context.Context, id NamedID, item namedIDItem) (namedIDItem, error) {
+	item.ID = id
+	return item, nil
+}
+func (namedIDService) Delete(context.Context, NamedID) error { return nil }
+
+func TestResource_NamedIntIDType_Get200(t *testing.T) {
+	app := New()
+	Resource[namedIDItem, NamedID](app, "/things", namedIDService{})
+	app.Compile()
+
+	req := &mockRequest{method: "GET", path: "/things/5"}
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 200 {
+		t.Fatalf("status = %d, want 200 (named int ID must parse)\nbody: %s", resp.statusCode, resp.body)
+	}
+	var body namedIDItem
+	if err := json.Unmarshal(resp.body, &body); err != nil {
+		t.Fatalf("invalid JSON: %v\nbody: %s", err, resp.body)
+	}
+	if body.ID != 5 {
+		t.Errorf("parsed id = %d, want 5", body.ID)
+	}
+}
+
+// NamedStrID is a named string type (Kind==String).
+type NamedStrID string
+
+type namedStrIDItem struct {
+	ID NamedStrID `json:"id"`
+}
+
+type namedStrIDService struct{}
+
+func (namedStrIDService) List(context.Context, int, int) ([]namedStrIDItem, int, error) {
+	return nil, 0, nil
+}
+func (namedStrIDService) Create(_ context.Context, item namedStrIDItem) (namedStrIDItem, error) {
+	return item, nil
+}
+func (namedStrIDService) Get(_ context.Context, id NamedStrID) (namedStrIDItem, error) {
+	return namedStrIDItem{ID: id}, nil
+}
+func (namedStrIDService) Update(_ context.Context, id NamedStrID, item namedStrIDItem) (namedStrIDItem, error) {
+	item.ID = id
+	return item, nil
+}
+func (namedStrIDService) Delete(context.Context, NamedStrID) error { return nil }
+
+func TestResource_NamedStringIDType_Get200(t *testing.T) {
+	app := New()
+	Resource[namedStrIDItem, NamedStrID](app, "/things", namedStrIDService{})
+	app.Compile()
+
+	req := &mockRequest{method: "GET", path: "/things/abc"}
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 200 {
+		t.Fatalf("status = %d, want 200 (named string ID must parse)\nbody: %s", resp.statusCode, resp.body)
+	}
+	var body namedStrIDItem
+	if err := json.Unmarshal(resp.body, &body); err != nil {
+		t.Fatalf("invalid JSON: %v\nbody: %s", err, resp.body)
+	}
+	if body.ID != "abc" {
+		t.Errorf("parsed id = %q, want %q", body.ID, "abc")
+	}
+}
+
+// A non-numeric path segment for a named integer ID must still 400.
+func TestResource_NamedIntIDType_BadValue400(t *testing.T) {
+	app := New()
+	Resource[namedIDItem, NamedID](app, "/things", namedIDService{})
+	app.Compile()
+
+	req := &mockRequest{method: "GET", path: "/things/notanint"}
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 400 {
+		t.Fatalf("status = %d, want 400 for non-numeric named-int id\nbody: %s", resp.statusCode, resp.body)
+	}
+}
+
+// =============================================================================
+// Fix 3: partial PUT omitting a required field → 422 (spec §8(b)). A PUT body
+// that omits a `required` field must fail validation, reporting that field.
+// =============================================================================
+
+func TestResourceUpdate_PartialPUTOmitsRequired422(t *testing.T) {
+	app := New(WithValidator(NewValidator()))
+	Resource(app, "/users", &validatedUserService{})
+	app.Compile()
+
+	// validatedUser requires "name" and "email"; this body omits "email".
+	req := &mockRequest{
+		method:  "PUT",
+		path:    "/users/abc",
+		headers: map[string]string{"Content-Type": "application/json"},
+		body:    []byte(`{"name":"x"}`),
+	}
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 422 {
+		t.Fatalf("status = %d, want 422 (partial PUT omits required 'email')\nbody: %s", resp.statusCode, resp.body)
+	}
+
+	// Assert the ValidationError wire shape: {code, message, errors[]}.
+	var body struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Errors  []struct {
+			Field string `json:"field"`
+			Rule  string `json:"rule"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(resp.body, &body); err != nil {
+		t.Fatalf("invalid JSON: %v\nbody: %s", err, resp.body)
+	}
+	if body.Code != 422 {
+		t.Errorf("body.code = %d, want 422", body.Code)
+	}
+	if len(body.Errors) == 0 {
+		t.Fatal("expected at least one field error")
+	}
+	// The omitted required field ("email") must be reported.
+	var reportedEmail bool
+	for _, fe := range body.Errors {
+		if fe.Field == "email" && fe.Rule == "required" {
+			reportedEmail = true
+		}
+	}
+	if !reportedEmail {
+		t.Errorf("omitted required field 'email' not reported as required; errors=%+v", body.Errors)
+	}
+}

--- a/resource_validation_test.go
+++ b/resource_validation_test.go
@@ -1,0 +1,412 @@
+package kruda
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// validatedUser exercises the validation path: it has validate tags so a
+// configured Validator produces 422s on invalid create/update bodies.
+type validatedUser struct {
+	ID    string `json:"id"`
+	Name  string `json:"name" validate:"required"`
+	Email string `json:"email" validate:"required,email"`
+}
+
+type validatedUserService struct {
+	createFn func(ctx context.Context, item validatedUser) (validatedUser, error)
+	updateFn func(ctx context.Context, id string, item validatedUser) (validatedUser, error)
+}
+
+func (s *validatedUserService) List(_ context.Context, _, _ int) ([]validatedUser, int, error) {
+	return nil, 0, nil
+}
+func (s *validatedUserService) Create(ctx context.Context, item validatedUser) (validatedUser, error) {
+	if s.createFn != nil {
+		return s.createFn(ctx, item)
+	}
+	return item, nil
+}
+func (s *validatedUserService) Get(_ context.Context, id string) (validatedUser, error) {
+	return validatedUser{ID: id}, nil
+}
+func (s *validatedUserService) Update(ctx context.Context, id string, item validatedUser) (validatedUser, error) {
+	if s.updateFn != nil {
+		return s.updateFn(ctx, id, item)
+	}
+	item.ID = id
+	return item, nil
+}
+func (s *validatedUserService) Delete(_ context.Context, _ string) error { return nil }
+
+// =============================================================================
+// §5.2 Validation engaged (422), gated identically to typed routes
+// =============================================================================
+
+func TestResourceCreate_Validation422(t *testing.T) {
+	app := New(WithValidator(NewValidator()))
+	Resource(app, "/users", &validatedUserService{})
+	app.Compile()
+
+	req := &mockRequest{
+		method:  "POST",
+		path:    "/users",
+		headers: map[string]string{"Content-Type": "application/json"},
+		body:    []byte(`{"name":"","email":"not-an-email"}`),
+	}
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 422 {
+		t.Fatalf("status = %d, want 422\nbody: %s", resp.statusCode, resp.body)
+	}
+	var body struct {
+		Code   int `json:"code"`
+		Errors []struct {
+			Field string `json:"field"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(resp.body, &body); err != nil {
+		t.Fatalf("invalid JSON: %v\nbody: %s", err, resp.body)
+	}
+	if body.Code != 422 {
+		t.Errorf("body.code = %d, want 422", body.Code)
+	}
+	if len(body.Errors) == 0 {
+		t.Error("expected at least one field error")
+	}
+}
+
+func TestResourceCreate_ValidationPasses201(t *testing.T) {
+	app := New(WithValidator(NewValidator()))
+	Resource(app, "/users", &validatedUserService{})
+	app.Compile()
+
+	req := &mockRequest{
+		method:  "POST",
+		path:    "/users",
+		headers: map[string]string{"Content-Type": "application/json"},
+		body:    []byte(`{"name":"Alice","email":"alice@example.com"}`),
+	}
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 201 {
+		t.Fatalf("status = %d, want 201\nbody: %s", resp.statusCode, resp.body)
+	}
+}
+
+func TestResourceUpdate_Validation422(t *testing.T) {
+	app := New(WithValidator(NewValidator()))
+	Resource(app, "/users", &validatedUserService{})
+	app.Compile()
+
+	req := &mockRequest{
+		method:  "PUT",
+		path:    "/users/abc",
+		headers: map[string]string{"Content-Type": "application/json"},
+		body:    []byte(`{"name":"","email":"bad"}`),
+	}
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 422 {
+		t.Fatalf("status = %d, want 422\nbody: %s", resp.statusCode, resp.body)
+	}
+}
+
+func TestResourceUpdate_ValidationPasses200(t *testing.T) {
+	app := New(WithValidator(NewValidator()))
+	Resource(app, "/users", &validatedUserService{})
+	app.Compile()
+
+	req := &mockRequest{
+		method:  "PUT",
+		path:    "/users/abc",
+		headers: map[string]string{"Content-Type": "application/json"},
+		body:    []byte(`{"name":"Bob","email":"bob@example.com"}`),
+	}
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 200 {
+		t.Fatalf("status = %d, want 200\nbody: %s", resp.statusCode, resp.body)
+	}
+}
+
+// No validator configured → no 422 even on invalid data (typed-identical).
+func TestResourceCreate_NoValidatorNo422(t *testing.T) {
+	app := New() // no WithValidator
+	Resource(app, "/users", &validatedUserService{})
+	app.Compile()
+
+	req := &mockRequest{
+		method:  "POST",
+		path:    "/users",
+		headers: map[string]string{"Content-Type": "application/json"},
+		body:    []byte(`{"name":"","email":"not-an-email"}`),
+	}
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode == 422 {
+		t.Fatalf("status = 422 but no validator configured; want non-422\nbody: %s", resp.body)
+	}
+	if resp.statusCode != 201 {
+		t.Fatalf("status = %d, want 201 (service echoes item)\nbody: %s", resp.statusCode, resp.body)
+	}
+}
+
+// T without validate tags → no 422 even with a validator configured.
+func TestResourceCreate_NoTagsNo422(t *testing.T) {
+	app := New(WithValidator(NewValidator()))
+	Resource(app, "/users", &mockUserService{
+		createFn: func(_ context.Context, item mockUser) (mockUser, error) { return item, nil },
+	})
+	app.Compile()
+
+	req := &mockRequest{
+		method:  "POST",
+		path:    "/users",
+		headers: map[string]string{"Content-Type": "application/json"},
+		body:    []byte(`{"name":""}`),
+	}
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 201 {
+		t.Fatalf("status = %d, want 201 (mockUser has no validate tags)\nbody: %s", resp.statusCode, resp.body)
+	}
+}
+
+// =============================================================================
+// §5.2 / Goal 3: malformed JSON → 400 "invalid request body" (was 500)
+// =============================================================================
+
+func TestResourceCreate_MalformedJSON400(t *testing.T) {
+	app := New()
+	Resource(app, "/users", &mockUserService{})
+	app.Compile()
+
+	req := &mockRequest{
+		method:  "POST",
+		path:    "/users",
+		headers: map[string]string{"Content-Type": "application/json"},
+		body:    []byte(`{invalid json}`),
+	}
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 400 {
+		t.Fatalf("status = %d, want 400\nbody: %s", resp.statusCode, resp.body)
+	}
+	var body KrudaError
+	if err := json.Unmarshal(resp.body, &body); err != nil {
+		t.Fatalf("invalid JSON: %v\nbody: %s", err, resp.body)
+	}
+	if body.Message != "invalid request body" {
+		t.Errorf("message = %q, want %q", body.Message, "invalid request body")
+	}
+}
+
+func TestResourceUpdate_MalformedJSON400(t *testing.T) {
+	app := New()
+	Resource(app, "/users", &mockUserService{})
+	app.Compile()
+
+	req := &mockRequest{
+		method:  "PUT",
+		path:    "/users/abc",
+		headers: map[string]string{"Content-Type": "application/json"},
+		body:    []byte(`{invalid json}`),
+	}
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 400 {
+		t.Fatalf("status = %d, want 400\nbody: %s", resp.statusCode, resp.body)
+	}
+}
+
+// =============================================================================
+// §5.3 Pagination → 400 on invalid, defaults when absent, clamp over cap
+// =============================================================================
+
+func TestResourceList_PaginationDefaults(t *testing.T) {
+	app := New()
+	var gotPage, gotLimit int
+	svc := &mockUserService{
+		listFn: func(_ context.Context, page, limit int) ([]mockUser, int, error) {
+			gotPage, gotLimit = page, limit
+			return nil, 0, nil
+		},
+	}
+	Resource(app, "/users", svc)
+	app.Compile()
+
+	req := &mockRequest{method: "GET", path: "/users"}
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.statusCode)
+	}
+	if gotPage != 1 || gotLimit != 20 {
+		t.Errorf("page,limit = %d,%d, want 1,20", gotPage, gotLimit)
+	}
+}
+
+func TestResourceList_PaginationInvalid400(t *testing.T) {
+	cases := []map[string]string{
+		{"page": "abc"},
+		{"page": "0"},
+		{"limit": "-1"},
+		{"limit": "abc"},
+		{"page": "1.5"},
+	}
+	for _, q := range cases {
+		app := New()
+		Resource(app, "/users", &mockUserService{})
+		app.Compile()
+		req := &mockRequest{method: "GET", path: "/users", query: q}
+		resp := newMockResponse()
+		app.ServeKruda(resp, req)
+		if resp.statusCode != 400 {
+			t.Errorf("query %v: status = %d, want 400\nbody: %s", q, resp.statusCode, resp.body)
+		}
+	}
+}
+
+func TestResourceList_PaginationInvalidMessage(t *testing.T) {
+	app := New()
+	Resource(app, "/users", &mockUserService{})
+	app.Compile()
+	req := &mockRequest{method: "GET", path: "/users", query: map[string]string{"page": "abc"}}
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+	if resp.statusCode != 400 {
+		t.Fatalf("status = %d, want 400", resp.statusCode)
+	}
+	var body KrudaError
+	if err := json.Unmarshal(resp.body, &body); err != nil {
+		t.Fatalf("invalid JSON: %v\nbody: %s", err, resp.body)
+	}
+	want := `invalid query parameter "page": expected int`
+	if body.Message != want {
+		t.Errorf("message = %q, want %q", body.Message, want)
+	}
+}
+
+func TestResourceList_LimitClamped(t *testing.T) {
+	app := New()
+	var gotLimit int
+	svc := &mockUserService{
+		listFn: func(_ context.Context, page, limit int) ([]mockUser, int, error) {
+			gotLimit = limit
+			return nil, 0, nil
+		},
+	}
+	Resource(app, "/users", svc)
+	app.Compile()
+
+	req := &mockRequest{method: "GET", path: "/users", query: map[string]string{"limit": "1000"}}
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 200 {
+		t.Fatalf("status = %d, want 200\nbody: %s", resp.statusCode, resp.body)
+	}
+	if gotLimit != maxResourceListLimit {
+		t.Errorf("service limit = %d, want clamped %d", gotLimit, maxResourceListLimit)
+	}
+	// Envelope must also report the clamped limit.
+	var body struct {
+		Limit int `json:"limit"`
+	}
+	if err := json.Unmarshal(resp.body, &body); err != nil {
+		t.Fatalf("invalid JSON: %v\nbody: %s", err, resp.body)
+	}
+	if body.Limit != maxResourceListLimit {
+		t.Errorf("envelope limit = %d, want %d", body.Limit, maxResourceListLimit)
+	}
+}
+
+// =============================================================================
+// §5.4 ResourceList[T] envelope shape (identical JSON to the old Map)
+// =============================================================================
+
+func TestResourceList_EnvelopeShape(t *testing.T) {
+	app := New()
+	svc := &mockUserService{
+		listFn: func(_ context.Context, page, limit int) ([]mockUser, int, error) {
+			return []mockUser{{ID: "1", Name: "A"}}, 7, nil
+		},
+	}
+	Resource(app, "/users", svc)
+	app.Compile()
+
+	req := &mockRequest{method: "GET", path: "/users", query: map[string]string{"page": "3", "limit": "9"}}
+	resp := newMockResponse()
+	app.ServeKruda(resp, req)
+
+	if resp.statusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.statusCode)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(resp.body, &raw); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	for _, k := range []string{"data", "total", "page", "limit"} {
+		if _, ok := raw[k]; !ok {
+			t.Errorf("envelope missing key %q\nbody: %s", k, resp.body)
+		}
+	}
+	var env ResourceList[mockUser]
+	if err := json.Unmarshal(resp.body, &env); err != nil {
+		t.Fatalf("ResourceList unmarshal: %v", err)
+	}
+	if env.Total != 7 || env.Page != 3 || env.Limit != 9 || len(env.Data) != 1 {
+		t.Errorf("envelope = %+v, want total=7 page=3 limit=9 len(data)=1", env)
+	}
+}
+
+// =============================================================================
+// §5.7 Unsupported ID kind → registration panics
+// =============================================================================
+
+type int32Item struct {
+	ID int32 `json:"id"`
+}
+
+type int32ItemService struct{}
+
+func (int32ItemService) List(_ context.Context, _, _ int) ([]int32Item, int, error) {
+	return nil, 0, nil
+}
+func (int32ItemService) Create(_ context.Context, item int32Item) (int32Item, error) {
+	return item, nil
+}
+func (int32ItemService) Get(_ context.Context, id int32) (int32Item, error) {
+	return int32Item{ID: id}, nil
+}
+func (int32ItemService) Update(_ context.Context, id int32, item int32Item) (int32Item, error) {
+	return item, nil
+}
+func (int32ItemService) Delete(_ context.Context, _ int32) error { return nil }
+
+func TestResource_UnsupportedIDKindPanics(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic for unsupported ID kind int32")
+		}
+		msg, _ := r.(string)
+		if !strings.Contains(msg, "unsupported") {
+			t.Errorf("panic = %v, want message containing 'unsupported'", r)
+		}
+	}()
+	app := New()
+	Resource[int32Item, int32](app, "/items", int32ItemService{})
+}


### PR DESCRIPTION
## Summary

`kruda.Resource` (auto-CRUD) previously registered raw handlers with **no input
validation** and **no OpenAPI documentation**, unlike typed `C[T]` routes. This
brings the auto-CRUD helper to parity with typed handlers:

- **Input validation** on `POST`/`PUT` bodies — gated exactly like typed routes
  (runs only when a `Validator` is configured *and* `T` carries `validate` tags).
- **OpenAPI 3.1 generation** for all five CRUD operations (correct status codes,
  path/query parameters, request/response schemas, and a `422` response only when
  validation is actually engaged).
- **Correct error codes** — malformed bodies now return `400` (was `500`); list
  pagination returns `400` on bad params and clamps `limit` to 100.
- **`ResourceList[T]` envelope** (`Data`/`Total`/`Page`/`Limit`) as the documented
  list response shape.

## Performance

Per the project rule that any per-request cost must be opt-in, the default/hot path
is untouched:

- Validation runs **only** behind the `app.config.Validator != nil` gate — a
  Resource on an app with no Validator pays zero extra per request.
- All OpenAPI generation happens once at `Compile()` time, never per request.
- Zero-alloc string-lane and fast-path parser guards remain green; the change does
  not touch the wing/bind/string-lane code.

## API additions

- `ResourceList[T]` — list response envelope.
- `WithResourceMiddleware`, `WithResourceOnly`, `WithResourceExcept`,
  `WithResourceIDParam` — `ResourceOption`s mirroring existing route configuration.
- Named string/integer ID types (e.g. `type UserID int64`) now work end-to-end.

## Tests

- `resource_validation_test.go` — validation gating, 400/422 codes, pagination clamp.
- `openapi_resource_test.go` / `openapi_resource_e2e_test.go` — generated spec shape
  for all CRUD ops, including the 422-only-when-validated rule.
- `openapi_sanitize_test.go` — fully-qualified generic component keys so distinct
  generic arguments (e.g. `ResourceList[a.User]` vs `ResourceList[b.User]`) never collide.
- `resource_review_fixes_test.go` — named-ID round-trip + review regression coverage.
- Golden guard confirms a typed-only app's spec is unchanged by the new resource branch.

Full core suite passes with `-race`; 3-platform build + `go vet` + `gofmt` clean.
