### PR TITLE
docs(wing): note per-IP cap must key on socket peer, not XFF

### DIFF
--- a/wing_transport.go
+++ b/wing_transport.go
@@ -675,6 +675,8 @@ func (w *worker) handleAccept(ev event) {
 		closeFd(int(fd)) // RST, not 503 — no request parsed at accept time
 		return
 	}
+	// Keyed on ev.PeerIP (kernel accept-time socket peer), never RemoteAddr()/XFF — the latter is
+	// attacker-spoofable under TrustProxy, so trusting it here would let one client evade the per-IP cap.
 	if w.maxConnsPerIP > 0 && ev.HasPeer && w.connsPerIP[ev.PeerIP] >= w.maxConnsPerIP {
 		atomic.AddInt64(w.rejectIP, 1)
 		rejectWarnOnce(w, rejectKindIP, w.maxConnsPerIP)


### PR DESCRIPTION
## What

One-line guard comment at the per-IP accept-DoS connection-cap check in `wing_transport.go` (`handleAccept`, the `w.connsPerIP[ev.PeerIP]` admission gate).

## Why

The per-IP limiter (added in `2ba7676`, accept-side DoS limits) keys on `ev.PeerIP` — the kernel accept-time socket peer captured zero-alloc from `RawSockaddrAny` and stored as a `netip.Addr`. This is intentionally the **true TCP peer**, independent of `X-Forwarded-For`/`X-Real-IP`.

`RemoteAddr()`'s XFF-derived client IP is an app-layer value that is attacker-influenceable when `TrustProxy` is enabled. If a future refactor ever repointed the per-IP cap at `RemoteAddr()`/XFF, a single client could forge per-request source IPs and evade the cap entirely. The comment records that invariant so the decoupling survives future edits.

## Scope

- **Comment-only** — zero behavioral change.
- Accept/slow path only; the string fast lane and hot path are untouched. No benchmark needed.

## Verification

- `go build -tags kruda_stdjson ./...` ✅ and default Sonic `go build ./...` ✅
- `go vet -tags kruda_stdjson .` ✅
- `gofmt -l` clean ✅