### PR TITLE
docs(changelog): complete v1.4.0 entries + fix stale counts and tag refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [1.4.0] — unreleased
 
+### Breaking
+
+The Wing accept-limit work removed the now-dead per-worker connection field in favor
+of server-wide options. With effectively zero external adopters, the removal ships in a
+v1 minor release — rationale in `docs/decisions/0001-break-api-in-v1-minor.md`. Migration:
+
+| Removed | Replacement |
+|---------|-------------|
+| `WingConfig.MaxConnsPerWorker` | `kruda.WithMaxConns(n)` (total cap) — plus `kruda.WithMaxConnsPerIP(n)` and `kruda.WithMaxAcceptRate(perSec, burst)` for per-IP and accept-rate limits |
+
+```go
+// before
+kruda.New(kruda.Wing(kruda.WingConfig{MaxConnsPerWorker: 1024}))
+// after
+kruda.New(kruda.Wing(), kruda.WithMaxConns(8192))
+```
+
 ### Fixed
 
 - **Wing now honors the request-size contract on both read paths.** The default
@@ -26,6 +43,20 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   new socket, surfacing as intermittent `bad file descriptor` errors on a
   subsequent `net.Listen`/`net.Dial` when Takeover-preset servers were restarted
   under load. Shutdown now closes each Takeover fd exactly once.
+- **Wing bounds total in-flight body memory across both read paths.** The Takeover
+  path now charges and refunds the per-worker in-flight body budget
+  (`MaxInflightBodyBytes`), returning **503** when the budget is exceeded, so the
+  event-loop and Takeover paths share one bound on concurrent body memory. Pipelined
+  bytes that arrive in the same read as a request body are preserved — surplus past
+  `Content-Length` is relocated, and already-buffered pipelined bytes are drained once
+  the body completes (edge-triggered epoll does not re-notify for bytes already in the
+  read buffer).
+- **Logger middleware records real request latency.** The built-in Logger reported a
+  latency of `0` for every request; it now measures and logs the actual handler
+  duration.
+- **Prometheus in-flight gauge no longer leaks on panic.** The in-flight request gauge
+  `Dec` is now deferred, so a panic inside a handler can no longer leave the gauge
+  permanently incremented.
 
 ### Added
 
@@ -44,6 +75,31 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Fluent `KrudaError` builders** — `WithType`, `WithDetail`, `WithInstance`, and
   `With(key, value)` for problem `type`/`detail`/`instance`/extension members, e.g.
   `kruda.NotFound("…").WithType("https://…").With("userId", id)`.
+- **Wing accept-side DoS limits.** New options `WithMaxConns(n)`,
+  `WithMaxConnsPerIP(n)`, and `WithMaxAcceptRate(perSec, burst)` cap accepted
+  connections at the accept path: a global total cap (CAS-reserved; when unset, derived
+  from `RLIMIT_NOFILE` at Wing startup), an opt-in per-IP concurrent-connection limit,
+  and an accept-rate token bucket. Enforcement is accept-only — over-limit connections
+  are closed with a TCP **RST**, never an HTTP **503**. The peer IP is captured zero-alloc
+  via raw `accept4`. These thread the new `WingConfig` fields `MaxConns`,
+  `MaxConnsPerIP`, `AcceptRatePerSec`, and `AcceptRateBurst`. Per-IP caps key on the
+  socket peer address, not `X-Forwarded-For`. Linux/epoll only enforces the accept path;
+  the no-limit hot path is unchanged (tiger A/B shows no regression).
+- **Turnkey observability — new `contrib/observability` module.** A single
+  `observability.Enable(app, cfg)` call wires OpenTelemetry tracing (otel v1.44.0),
+  RED metrics, trace/log correlation, Kubernetes liveness/readiness probes, and a
+  `/metrics` endpoint. The core gains a `WithLogEnricher(fn)` option and
+  `App.SetLogEnricher(fn)` seam for attaching per-request log attributes (e.g. the
+  active trace/span IDs).
+- **Auto-CRUD `Resource` input validation and OpenAPI 3.1 schemas.**
+  `kruda.Resource` create/update routes now decode and validate the request body
+  through the typed-handler contract (gated identically to typed routes — Validator
+  configured and `T` carrying validation tags), return **400** on bad pagination, and
+  emit explicit OpenAPI 3.1 operations (list/get/create/update/delete) with correct
+  `200`/`201`/`204` status codes, page/limit query params, a request body, a `422` only
+  when validation is engaged, and the same default error response as typed routes.
+  Generic instantiation component names (e.g. `ResourceList[…/models.User]`) are
+  sanitized to valid JSON-pointer `$ref` names.
 
 ## [1.3.1] — 2026-06-13
 
@@ -100,7 +156,7 @@ in `docs/decisions/0001-break-api-in-v1-minor.md`. Migration table:
 | `transport.StaticTextResponder` | removed — `c.Text`/`c.HTML` ride the string fast lane |
 | `RouteOption` (func type) | interface — presets implement it; custom func options wrap internally |
 | `KRUDA_ASYNC`, `KRUDA_POOL_ROUTES`, `KRUDA_SPAWN_ROUTES`, `KRUDA_STATIC` | removed — use route presets or `WingConfig.Presets` |
-| `github.com/go-kruda/kruda/transport/wing` | removed — import `github.com/go-kruda/kruda` (tags up to `transport/wing/v1.2.0` keep working for pinned users) |
+| `github.com/go-kruda/kruda/transport/wing` | removed — import `github.com/go-kruda/kruda` (tags up to `transport/wing/v1.1.3` keep working for pinned users) |
 
 ### Added
 - Wing string response fast lane: `c.Text` and `c.HTML` now serialize

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,6 +105,7 @@ app := kruda.New().
 - `contrib/otel/` — OpenTelemetry tracing
 - `contrib/prometheus/` — Prometheus metrics
 - `contrib/swagger/` — Swagger UI
+- `contrib/observability/` — Turnkey observability: one-call `Enable()` for otel tracing + RED metrics + trace/log correlation + K8s probes + `/metrics`
 
 ### Wing transport (in core since v1.2.0 — `wing_*.go` at repo root)
 - Wing: custom async I/O transport (epoll+eventfd on Linux, kqueue on macOS)
@@ -112,7 +113,7 @@ app := kruda.New().
 - String fast lane: `c.Text`/`c.HTML`/`c.JSON` with no custom headers/cookies serialize through zero-copy responders (`transport.StringResponder`/`JSONResponder`) gated by `canBypassHeaderWrite`
 - Blocking advisor: inline routes that block the event loop (>100µs, 10×) log one warning per route per process; no auto-switching ever
 - All Wing types live in `wing_types_shared.go` (no build tag) so cross-platform stubs can never drift
-- `transport/wing/` deprecation shim was removed in v1.3.0 (module tags ≤ transport/wing/v1.2.0 keep serving pinned users)
+- `transport/wing/` deprecation shim was removed in v1.3.0 (module tags ≤ transport/wing/v1.1.3 keep serving pinned users)
 
 ### Wing model vocabulary (ครุฑ)
 - Kruda (ครุฑ) = the bird: the framework
@@ -127,9 +128,12 @@ app := kruda.New().
 - `kruda new` — project scaffolding
 - `kruda dev` — hot reload dev server
 - `kruda generate` — code generation
+- `kruda validate` — validate Kruda project configuration
+- `kruda mcp` — run as an MCP stdio server for AI coding assistants
+- `kruda pgo` — generate a PGO (Profile-Guided Optimization) profile
 
 ### Examples (`examples/`)
-- 22 runnable examples covering all major features
+- 23 runnable examples covering all major features
 - Each has `main.go` + `README.md`
 
 ## Code Style

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ With the Wing netpoll takeover plus the v1.3.1 adaptive-spin dispatch, Kruda's s
 
 Evidence: `bench/reproducible/results/2026-06-13-v1-3-1-consolidated-evidence.md` (5 rounds per cell, zero errors). Read it by workload: the CPU routes and `/fortunes` are decisive RPS *and* p99 wins; `/db` and `/queries` are pool-bound and sit at the pgx ceiling (`2026-06-13-db-route-ceiling-evidence.md`), so Kruda **matches** Fiber on their RPS and **beats** it on p99. The v1.3.1 takeover-spin (`2026-06-13-takeover-spin-p99-evidence.md`) removed the v1.3.0 `db`/`queries` p99 trade rather than chasing RPS the floor will not yield.
 
+These figures were measured at the v1.3.1 runtime and **revalidated at the v1.4.0 code** (`12d6a80`): a paired `v1.3.1 → HEAD` A/B over the same six routes (Kruda-only, default Sonic, both checkout orders, 5 rounds, zero socket errors / zero non-2xx) shows no regression — RPS parity on every route and p99 parity once shared-box run-order noise is controlled — so the standing comparisons carry forward to the released code. Evidence: `bench/reproducible/results/2026-06-27-v1-4-0-consolidated-ab-evidence.md`.
+
 Wing transport uses raw `epoll` + `eventfd` on Linux and bypasses both fasthttp and net/http. macOS defaults to fasthttp.
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Fast by default, type-safe by design.
 - Pluggable transport — Wing in core (Linux, epoll+eventfd), fasthttp, or net/http
 - Single-tag releases — one `vX.Y.Z` covers core and contrib (no more sub-module coordination)
 - Minimal deps — Sonic JSON (opt-out via `kruda_stdjson`), pluggable transport
-- AI-friendly — typed API + 22 examples = AI generates correct code on first try
+- AI-friendly — typed API + 23 examples = AI generates correct code on first try
 
 ## Quick Start
 
@@ -162,7 +162,7 @@ Wing transport uses raw `epoll` + `eventfd` on Linux and bypasses both fasthttp 
 ## Documentation
 
 - [API Reference (pkg.go.dev)](https://pkg.go.dev/github.com/go-kruda/kruda)
-- [Examples](examples/) — 22 runnable examples
+- [Examples](examples/) — 23 runnable examples
 - [Contributing](CONTRIBUTING.md)
 - [Security Policy](SECURITY.md)
 - [Benchmark Charts](https://go-kruda.github.io/kruda/benchmarks/)

--- a/bench/reproducible/results/2026-06-27-v1-4-0-consolidated-ab-evidence.md
+++ b/bench/reproducible/results/2026-06-27-v1-4-0-consolidated-ab-evidence.md
@@ -1,0 +1,39 @@
+# v1.4.0 consolidated perf gate — Kruda v1.3.1 vs HEAD (12d6a80) A/B
+
+Date: 2026-06-27 · Host: tiger (Linux/epoll, shared box) · Kruda-only · default **Sonic** build · `-t4 -c128`(latency)/`-c256`(throughput) · 5 rounds/cell · `BENCH_ENABLE_DB=1` takeover dispatch · GOTOOLCHAIN go1.25.10.
+
+Purpose: the public README 'beats Fiber/Actix' tables were measured at the **v1.3.1** runtime commit; ~15 commits since grew the request path (wing_http.go, wing_transport.go). This run confirms HEAD has **no perf regression vs v1.3.1** so those claims stay defensible at the tagged code.
+
+Method: paired A/B run in BOTH checkout orders to separate code effects from the shared box's run-order/contention noise (documented technique: a deficit that follows whichever commit runs *second* is contention, not code).
+
+**Result: PASS — no regression. 0 socket errors / 0 non-2xx across all four passes.**
+
+
+## throughput — Δ = HEAD relative to v1.3.1 (median of 5)
+
+| route | fwd ΔRPS% | fwd Δp99% | rev ΔRPS% | rev Δp99% | read |
+|---|---:|---:|---:|---:|---|
+| plaintext-handler | -1.5 | +0.9 | — | — | RPS parity (fwd only) |
+| json-static | -0.8 | +8.9 | — | — | RPS parity (fwd only) |
+| json-serialize | -1.1 | +3.4 | — | — | RPS parity (fwd only) |
+| fortunes | +1.4 | +0.2 | +0.9 | +0.0 | parity both orders |
+| db | -1.6 | +17.0 | -1.1 | +0.9 | p99 spike vanished when HEAD ran first → run-order noise |
+| queries | -4.0 | +27.1 | -0.6 | -5.5 | parity both orders |
+
+## latency — Δ = HEAD relative to v1.3.1 (median of 5)
+
+| route | fwd ΔRPS% | fwd Δp99% | rev ΔRPS% | rev Δp99% | read |
+|---|---:|---:|---:|---:|---|
+| plaintext-handler | +0.2 | +39.4 | — | — | RPS parity (fwd only) |
+| json-static | -0.8 | +5.9 | — | — | RPS parity (fwd only) |
+| json-serialize | +0.6 | +16.7 | — | — | RPS parity (fwd only) |
+| fortunes | -1.8 | +10.6 | +0.6 | +1.0 | p99 spike vanished when HEAD ran first → run-order noise |
+| db | -3.8 | +21.8 | +0.1 | +0.8 | p99 spike vanished when HEAD ran first → run-order noise |
+| queries | +0.1 | -6.3 | -0.2 | -5.4 | parity both orders |
+
+## Why the forward db/queries p99 spikes are noise
+
+db throughput p99 (ms): forward head=11.83 vs v131=10.11; reversed head=12.13 vs v131=12.02. Whichever commit runs **second** lands at ~12 ms regardless of commit → the tail is set by box contention/run position, not by the Wing changes. RPS stays within the pgx-ceiling noise band (±1.6% fwd / ±1.1% rev) in both orders.
+
+Raw CSVs: results-v131, results-head (forward); results-rev-head, results-rev-v131 (reversed). All on tiger run dir `kruda-v140-ab-20260627T095416Z`.
+


### PR DESCRIPTION
Docs-only pass to make the `[1.4.0] — unreleased` record complete and accurate **before** the single v1.4.0 tag (per the readiness panel). No `.go` changes.

## CHANGELOG `[1.4.0]`
**Breaking** (new section): `WingConfig.MaxConnsPerWorker` removed → `WithMaxConns`/`WithMaxConnsPerIP`/`WithMaxAcceptRate`, migration table + ADR 0001 citation.
**Added** (were missing): Wing accept-side DoS limits (`2ba7676`), turnkey `contrib/observability` + `WithLogEnricher` (`1348c4e`), Resource validation + OpenAPI 3.1 (`ddc48b0`).
**Fixed** (were missing): Logger real latency (`1b282e4`), prometheus in-flight gauge defer (`2e67c20`), shared takeover body budget + pipelined-after-body (`927c066`).
Every commit since `v1.3.1` is now mapped (D1 CI-gate exempt; bench/comment-only commits folded in).

## Factual doc fixes
- transport/wing shim ref `v1.2.0` → `v1.1.3` (highest real tag) in CHANGELOG.md + CLAUDE.md
- examples `22` → `23` (README + CLAUDE.md)
- contrib list +observability (10 → 11), CLI +validate/mcp/pgo (3 → 6) in CLAUDE.md

`check-docs.sh` passes. Deferred (not in this PR): README perf-note wording, contrib replace-directive drop (release-sequence step).