### PR TITLE
chore(release): date-stamp v1.4.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to Kruda are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [1.4.0] — unreleased
+## [1.4.0] — 2026-06-27
 
 ### Breaking
 


### PR DESCRIPTION
Final release-prep before tagging v1.4.0: stamp the CHANGELOG `[1.4.0]` heading with its release date (2026-06-27), mirroring the dated `[1.3.1]`/`[1.3.0]` headings. The tagged commit must carry the dated changelog. One-line docs change.