### PR TITLE
docs(otel): correct stale config field names and response-header claim

### DIFF
--- a/contrib/otel/README.md
+++ b/contrib/otel/README.md
@@ -14,7 +14,7 @@ go get github.com/go-kruda/kruda/contrib/otel
 import "github.com/go-kruda/kruda/contrib/otel"
 
 app.Use(otel.New(otel.Config{
-    ServiceName: "my-api",
+    ServerName: "my-api",
 }))
 
 app.Get("/users", func(c *kruda.Ctx) error {
@@ -27,7 +27,9 @@ app.Get("/users", func(c *kruda.Ctx) error {
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| ServiceName | string | "kruda-app" | Service name in traces |
-| Skip | func(*kruda.Ctx) bool | nil | Skip tracing condition |
-| SpanNameFormatter | func(*kruda.Ctx) string | "METHOD /path" | Custom span names |
-| ExtraAttributes | []attribute.KeyValue | nil | Additional span attributes |
+| TracerProvider | trace.TracerProvider | global provider | OTel tracer provider |
+| Propagators | propagation.TextMapPropagator | global propagator | Propagators for context extraction |
+| ServerName | string | "" (omitted) | Server name in span attributes |
+| Skip | func(*kruda.Ctx) bool | nil | Skip tracing for matching requests |
+| SpanNameFunc | func(*kruda.Ctx) string | "METHOD route" | Custom span names |
+| Attributes | []attribute.KeyValue | nil | Extra attributes on every span |

--- a/contrib/otel/otel.go
+++ b/contrib/otel/otel.go
@@ -14,8 +14,9 @@ import (
 const tracerName = "github.com/go-kruda/kruda/contrib/otel"
 
 // New creates an OpenTelemetry tracing middleware.
-// It extracts trace context from incoming headers, creates a server span,
-// sets standard HTTP attributes, and injects trace context into response headers.
+// It extracts trace context from incoming request headers, creates a server span,
+// and sets standard HTTP semantic-convention attributes. It does not inject trace
+// context back into the response (see the note in the handler for why).
 func New(config ...Config) kruda.HandlerFunc {
 	var cfg Config
 	if len(config) > 0 {


### PR DESCRIPTION
Fixes stale public docs in `contrib/otel` flagged in the v1.4.0 release review (the module itself is unchanged; this is docs/comment-only).

- **README config fields were wrong:** `ServiceName`/`SpanNameFormatter`/`ExtraAttributes` → the real exported fields are `ServerName`/`SpanNameFunc`/`Attributes` (verified against `config.go`). Corrected the usage example, names, and defaults, and added the `TracerProvider`/`Propagators` options that were missing from the table.
- **`New()` doc comment was wrong:** it claimed the middleware "injects trace context into response headers," but the code deliberately does **not** do response-side traceparent injection (`otel.go:101`). Reworded.

`contrib/otel` is its own module (currently `contrib/otel/v1.2.0`) and is **not** part of the v1.4.0 core release; a re-tag is a separate decision. Build: `GOWORK=off go build ./...` ✓, `go vet` ✓.