### PR TITLE
chore(release): drop local replace from contrib/observability

### DIFF
--- a/contrib/observability/go.mod
+++ b/contrib/observability/go.mod
@@ -64,5 +64,3 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
-
-replace github.com/go-kruda/kruda => ../..

--- a/contrib/observability/go.sum
+++ b/contrib/observability/go.sum
@@ -20,6 +20,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/go-kruda/kruda v1.4.0 h1:SNQYkQWKkwNQVTIoUmIi7knFRvLOKfTTyRpHlvDT51E=
+github.com/go-kruda/kruda v1.4.0/go.mod h1:Qgrl69/hDnU8Qohs0CXMAV2wgjS+lSaug9dsE9t7dhg=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=


### PR DESCRIPTION
Prepares `contrib/observability` for its first published tag (`contrib/observability/v1.0.0`).

Now that core `v1.4.0` is live on the module proxy, drop the development-only `replace github.com/go-kruda/kruda => ../..` and run `go mod tidy` so the module resolves `kruda@v1.4.0` from the proxy with a populated `go.sum` (it had zero core entries while the replace was active).

Verified locally (go1.25.10, GOWORK=off): `go mod tidy` pulls `kruda@v1.4.0`, `go build ./...` ✓, `go test -race ./...` ✓, `go vet` ✓. govulncheck is clean under `go stable` (the CI vuln gate); the only findings under a pinned go1.25.10 are two stdlib CVEs fixed in go1.25.11 (GO-2026-5037/5039), unrelated to this module.

Tagging `contrib/observability/v1.0.0` is a separate step after this merges.