### PR TITLE
Remove no-op WithHTTP3 stub option and HTTP3 config field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to Kruda are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.5.0] — unreleased
+
+### Breaking
+
+- **Removed the no-op `WithHTTP3` option and the `Config.HTTP3` field.** They advertised
+  HTTP/3 (QUIC) serving, but it was never implemented — nothing consumed the flag, so a
+  caller got the standard net/http fallback (HTTP/1.1 + HTTP/2), not QUIC. HTTP/3 is not on
+  the roadmap, so the dead API is removed rather than left as a misleading promise
+  (rationale: `docs/decisions/0001-break-api-in-v1-minor.md`). TLS is unaffected — use
+  `WithTLS(certFile, keyFile)`.
+
 ## [1.4.0] — 2026-06-27
 
 ### Breaking

--- a/config.go
+++ b/config.go
@@ -28,7 +28,6 @@ type Config struct {
 	TransportName string // "wing" (default on Linux), "fasthttp" (default on macOS), "nethttp" (default on Windows)
 	TLSCertFile   string
 	TLSKeyFile    string
-	HTTP3         bool
 
 	// TrustProxy enables trusting X-Forwarded-For/X-Real-IP headers. Default: false.
 	TrustProxy bool
@@ -308,17 +307,6 @@ func WithTLS(certFile, keyFile string) Option {
 	return func(a *App) {
 		a.config.TLSCertFile = certFile
 		a.config.TLSKeyFile = keyFile
-	}
-}
-
-// WithHTTP3 enables HTTP/3 dual-stack serving (QUIC on UDP + HTTP/2 on TCP).
-// Requires TLS certificate and key since QUIC mandates TLS 1.3.
-// When enabled, the Alt-Svc header is auto-injected to advertise HTTP/3.
-func WithHTTP3(certFile, keyFile string) Option {
-	return func(a *App) {
-		a.config.TLSCertFile = certFile
-		a.config.TLSKeyFile = keyFile
-		a.config.HTTP3 = true
 	}
 }
 

--- a/config_options_test.go
+++ b/config_options_test.go
@@ -87,20 +87,6 @@ func TestWingOption_SetsTransportName(t *testing.T) {
 	}
 }
 
-func TestWithHTTP3_SetsConfig(t *testing.T) {
-	app := &App{config: defaultConfig()}
-	WithHTTP3("cert.pem", "key.pem")(app)
-	if app.config.TLSCertFile != "cert.pem" {
-		t.Errorf("TLSCertFile = %q", app.config.TLSCertFile)
-	}
-	if app.config.TLSKeyFile != "key.pem" {
-		t.Errorf("TLSKeyFile = %q", app.config.TLSKeyFile)
-	}
-	if !app.config.HTTP3 {
-		t.Error("HTTP3 should be true")
-	}
-}
-
 func TestSelectTransport_FastHTTPWithTLS(t *testing.T) {
 	cfg := defaultConfig()
 	cfg.Logger = discardLogger()

--- a/doc.go
+++ b/doc.go
@@ -39,8 +39,7 @@
 //   - Windows: net/http
 //
 // Override with the [WithTransport], [NetHTTP], or [FastHTTP] options. TLS
-// (via [WithTLS] / [WithHTTP3]) auto-falls back to net/http on every
-// platform.
+// (via [WithTLS]) auto-falls back to net/http on every platform.
 //
 // Wing is built into core since v1.2.0; import github.com/go-kruda/kruda
 // directly and use the kruda.Wing option. The legacy

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -122,15 +122,6 @@ func WithTLS(certFile, keyFile string) Option
 
 Enables TLS with the given certificate and key files.
 
-### WithHTTP3
-
-```go
-func WithHTTP3(certFile, keyFile string) Option
-```
-
-Configures HTTP/3 certificate settings. HTTP/3 serving depends on the selected
-transport and must be verified in the target deployment before release.
-
 ### WithTrustProxy
 
 ```go


### PR DESCRIPTION
HTTP/3 was cancelled from the roadmap (no demand, not worth a whole new QUIC/UDP transport against the minimal-deps principle). This removes the dead API it left behind.

`WithHTTP3(cert, key)` and `Config.HTTP3` advertised "HTTP/3 dual-stack (QUIC + HTTP/2) + Alt-Svc" in their godoc, but **nothing ever consumed `config.HTTP3`** — calling `WithHTTP3` only set the TLS cert/key and a flag that was never read, so the caller silently got the standard net/http fallback, not QUIC. The godoc promised a feature that does not exist.

Removed: the `HTTP3` config field, the `WithHTTP3` option, its `[WithHTTP3]` godoc cross-reference in `doc.go`, and `TestWithHTTP3_SetsConfig`. **Breaking** (ADR 0001; ~0 adopters) → CHANGELOG `[1.5.0]`. TLS is unaffected: `WithTLS(certFile, keyFile)` is unchanged and still the way to serve TLS.

Verified: `go build` (sonic + stdjson) ✓, gofmt ✓, config tests ✓, check-godoc ✓, no remaining `WithHTTP3`/`HTTP3` code references.