### PR TITLE
docs(ws): correct false fasthttp WebSocket support claim

### DIFF
--- a/contrib/ws/doc.go
+++ b/contrib/ws/doc.go
@@ -23,10 +23,11 @@
 // # Transport compatibility
 //
 //   - net/http: supported (via http.Hijacker)
-//   - fasthttp: supported (via RequestCtx.Hijack)
+//   - fasthttp: not supported in v1 — the upgrade returns an error directing
+//     callers to net/http (avoids pulling fasthttp into the hijack path).
 //   - Wing:     not supported in v1 — Wing manages the fd directly via
 //     epoll/kqueue and does not expose a hijack API. Routes that
-//     need WebSocket should run under net/http or fasthttp.
+//     need WebSocket should run under net/http.
 //
 // # What it does
 //

--- a/contrib/ws/ws.go
+++ b/contrib/ws/ws.go
@@ -37,7 +37,7 @@ func (u *Upgrader) Upgrade(c *kruda.Ctx, handler func(*Conn)) error {
 	// R10.16-17: transport compatibility check
 	transport := c.Transport()
 	if transport == "wing" {
-		return fmt.Errorf("ws: WebSocket upgrade not supported on Wing transport — use net/http or fasthttp transport")
+		return fmt.Errorf("ws: WebSocket upgrade not supported on Wing transport — use the net/http transport (kruda.NetHTTP())")
 	}
 
 	// Validate upgrade request headers


### PR DESCRIPTION
Found in the v1.4.0/v1.5.0 review (codex). `contrib/ws` advertised fasthttp WebSocket support it does not have:

- `doc.go` transport-compatibility list said `fasthttp: supported (via RequestCtx.Hijack)`, but `upgradeFastHTTP` returns an error (`upgrade_fasthttp.go`) — fasthttp WS is not implemented in v1.
- The Wing-transport upgrade error message suggested `net/http or fasthttp` as alternatives.

Corrected both to state fasthttp is not supported in v1 and point callers to the net/http transport. Docs/message-only — no behavior change (the upgrade already errored). Verified: `go build` / `go vet` / `go test` ✓. → contrib/ws patch (v1.2.1).