### PR TITLE
feat(config): WithHeaderLimit + env tuning for the Wing safety bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [1.5.0] — unreleased
 
+### Added
+
+- **`WithHeaderLimit(n)` option.** Configures the maximum total request-header size
+  (default 8 KB → HTTP 431). Clients sending large `Authorization`/`Cookie` headers (big
+  JWTs) previously hit a spurious 431 with no escape hatch.
+- **Environment configuration for the Wing safety bundle.** `WithEnvPrefix` now also reads
+  `<PREFIX>_HEADER_LIMIT`, `<PREFIX>_TRUST_PROXY`, `<PREFIX>_MAX_CONNS`,
+  `<PREFIX>_MAX_CONNS_PER_IP`, `<PREFIX>_ACCEPT_RATE_PER_SEC`, and
+  `<PREFIX>_ACCEPT_RATE_BURST`, so Kubernetes/ConfigMap deployments can tune the v1.4.0
+  accept-side DoS limits and proxy trust without code changes.
+
 ### Breaking
 
 - **Removed the no-op `WithHTTP3` option and the `Config.HTTP3` field.** They advertised

--- a/cmd/kruda/cmd_mcp.go
+++ b/cmd/kruda/cmd_mcp.go
@@ -937,7 +937,9 @@ app := kruda.New(
     kruda.WithEnvPrefix("APP"),
 )
 // Reads: APP_READ_TIMEOUT, APP_WRITE_TIMEOUT, APP_IDLE_TIMEOUT,
-//        APP_BODY_LIMIT, APP_SHUTDOWN_TIMEOUT
+//        APP_BODY_LIMIT, APP_HEADER_LIMIT, APP_SHUTDOWN_TIMEOUT,
+//        APP_TRUST_PROXY, APP_MAX_CONNS, APP_MAX_CONNS_PER_IP,
+//        APP_ACCEPT_RATE_PER_SEC, APP_ACCEPT_RATE_BURST
 ` + "```",
 
 	"error-handling": `# Error Handling

--- a/config.go
+++ b/config.go
@@ -133,6 +133,13 @@ func WithMaxBodySize(size int) Option {
 	return WithBodyLimit(size)
 }
 
+// WithHeaderLimit sets the maximum total request-header size in bytes (default 8 KB).
+// Requests whose headers exceed this limit get HTTP 431. Raise it for clients that
+// send large Authorization/Cookie headers (e.g. big JWTs); 0 disables the limit.
+func WithHeaderLimit(limit int) Option {
+	return func(a *App) { a.config.HeaderLimit = limit }
+}
+
 // WithDevMode enables or disables development mode.
 // When enabled, the framework relaxes X-Frame-Options to SAMEORIGIN
 // and activates the dev error page (when implemented).
@@ -344,9 +351,41 @@ func applyEnvConfig(prefix string, cfg *Config) {
 			cfg.BodyLimit = int(n)
 		}
 	}
+	if v := os.Getenv(prefix + "_HEADER_LIMIT"); v != "" {
+		if n, err := parseSize(v); err == nil {
+			cfg.HeaderLimit = int(n)
+		}
+	}
 	if v := os.Getenv(prefix + "_SHUTDOWN_TIMEOUT"); v != "" {
 		if d, err := time.ParseDuration(v); err == nil {
 			cfg.ShutdownTimeout = d
+		}
+	}
+	if v := os.Getenv(prefix + "_TRUST_PROXY"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.TrustProxy = b
+		}
+	}
+	// Wing accept-side DoS limits — let K8s/ConfigMap deployments tune the safety
+	// bundle without code changes.
+	if v := os.Getenv(prefix + "_MAX_CONNS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.MaxConns = n
+		}
+	}
+	if v := os.Getenv(prefix + "_MAX_CONNS_PER_IP"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.MaxConnsPerIP = n
+		}
+	}
+	if v := os.Getenv(prefix + "_ACCEPT_RATE_PER_SEC"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.AcceptRatePerSec = n
+		}
+	}
+	if v := os.Getenv(prefix + "_ACCEPT_RATE_BURST"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.AcceptRateBurst = n
 		}
 	}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -61,13 +61,22 @@ func TestApplyEnvConfig(t *testing.T) {
 	os.Setenv("TEST_WRITE_TIMEOUT", "15s")
 	os.Setenv("TEST_IDLE_TIMEOUT", "60s")
 	os.Setenv("TEST_BODY_LIMIT", "8MB")
+	os.Setenv("TEST_HEADER_LIMIT", "16KB")
 	os.Setenv("TEST_SHUTDOWN_TIMEOUT", "20s")
+	os.Setenv("TEST_TRUST_PROXY", "true")
+	os.Setenv("TEST_MAX_CONNS", "50000")
+	os.Setenv("TEST_MAX_CONNS_PER_IP", "128")
+	os.Setenv("TEST_ACCEPT_RATE_PER_SEC", "2000")
+	os.Setenv("TEST_ACCEPT_RATE_BURST", "4000")
 	defer func() {
-		os.Unsetenv("TEST_READ_TIMEOUT")
-		os.Unsetenv("TEST_WRITE_TIMEOUT")
-		os.Unsetenv("TEST_IDLE_TIMEOUT")
-		os.Unsetenv("TEST_BODY_LIMIT")
-		os.Unsetenv("TEST_SHUTDOWN_TIMEOUT")
+		for _, k := range []string{
+			"TEST_READ_TIMEOUT", "TEST_WRITE_TIMEOUT", "TEST_IDLE_TIMEOUT",
+			"TEST_BODY_LIMIT", "TEST_HEADER_LIMIT", "TEST_SHUTDOWN_TIMEOUT",
+			"TEST_TRUST_PROXY", "TEST_MAX_CONNS", "TEST_MAX_CONNS_PER_IP",
+			"TEST_ACCEPT_RATE_PER_SEC", "TEST_ACCEPT_RATE_BURST",
+		} {
+			os.Unsetenv(k)
+		}
 	}()
 
 	cfg := defaultConfig()
@@ -85,8 +94,34 @@ func TestApplyEnvConfig(t *testing.T) {
 	if cfg.BodyLimit != 8*1024*1024 {
 		t.Errorf("BodyLimit = %d, want %d", cfg.BodyLimit, 8*1024*1024)
 	}
+	if cfg.HeaderLimit != 16*1024 {
+		t.Errorf("HeaderLimit = %d, want %d", cfg.HeaderLimit, 16*1024)
+	}
 	if cfg.ShutdownTimeout != 20*time.Second {
 		t.Errorf("ShutdownTimeout = %v, want 20s", cfg.ShutdownTimeout)
+	}
+	if !cfg.TrustProxy {
+		t.Error("TrustProxy = false, want true")
+	}
+	if cfg.MaxConns != 50000 {
+		t.Errorf("MaxConns = %d, want 50000", cfg.MaxConns)
+	}
+	if cfg.MaxConnsPerIP != 128 {
+		t.Errorf("MaxConnsPerIP = %d, want 128", cfg.MaxConnsPerIP)
+	}
+	if cfg.AcceptRatePerSec != 2000 {
+		t.Errorf("AcceptRatePerSec = %d, want 2000", cfg.AcceptRatePerSec)
+	}
+	if cfg.AcceptRateBurst != 4000 {
+		t.Errorf("AcceptRateBurst = %d, want 4000", cfg.AcceptRateBurst)
+	}
+}
+
+func TestWithHeaderLimit(t *testing.T) {
+	app := &App{config: defaultConfig()}
+	WithHeaderLimit(16 * 1024)(app)
+	if app.config.HeaderLimit != 16*1024 {
+		t.Errorf("HeaderLimit = %d, want %d", app.config.HeaderLimit, 16*1024)
 	}
 }
 

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -44,6 +44,14 @@ func WithMaxBodySize(size int) Option
 
 Alias for `WithBodyLimit`.
 
+### WithHeaderLimit
+
+```go
+func WithHeaderLimit(limit int) Option
+```
+
+Sets the maximum total request-header size in bytes (default 8 KB). Requests whose headers exceed this limit get HTTP 431. Raise it for clients that send large `Authorization`/`Cookie` headers (e.g. big JWTs); 0 disables the limit.
+
 ### WithDevMode
 
 ```go


### PR DESCRIPTION
Two high-value/low-risk config additions surfaced by the v1.5.0 opportunity audit (accumulating on main; no tag).

**`WithHeaderLimit(n)`** — `Config.HeaderLimit` (default 8 KB → 431) was enforced but had no setter, so clients sending large `Authorization`/`Cookie` headers (big JWTs) hit a spurious 431 with no escape hatch. Mirrors `WithBodyLimit`.

**Env config for the safety bundle** — `applyEnvConfig` covered only 5 timeout/body fields. The v1.4.0 accept-side DoS knobs were not env-readable, so K8s/ConfigMap adopters couldn't tune the safety bundle they just got. Added `<PREFIX>_HEADER_LIMIT`, `_TRUST_PROXY`, `_MAX_CONNS`, `_MAX_CONNS_PER_IP`, `_ACCEPT_RATE_PER_SEC`, `_ACCEPT_RATE_BURST`.

Pure-additive, perf-neutral (config-time only). Tests extended (`TestApplyEnvConfig` + `TestWithHeaderLimit`); build (sonic + stdjson) ✓, gofmt ✓. → CHANGELOG `[1.5.0]` Added.