### PR TITLE
chore(ci): fuzz the Wing HTTP parser in pre-release

### DIFF
--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -57,7 +57,7 @@ GOOS=windows go build ./...
 ok "windows build"
 
 section "fuzz suites (30s each)"
-for fuzz in FuzzRouterPattern FuzzRouterMatch FuzzBindJSON FuzzValidateString; do
+for fuzz in FuzzRouterPattern FuzzRouterMatch FuzzBindJSON FuzzValidateString FuzzParseHTTPRequest; do
   if go test -tags kruda_stdjson -fuzz="$fuzz" -fuzztime=30s -run=^$ . >/tmp/fuzz-"$fuzz".log 2>&1; then
     ok "$fuzz no crashes"
   else


### PR DESCRIPTION
Quick win from the v1.5.0 audit. `FuzzParseHTTPRequest` is defined (`wing_http_fuzz_test.go`) but was missing from the `scripts/pre-release.sh` fuzz loop, so the Wing request parser — the most adversarially-exposed code on the default internet-facing transport (request smuggling, duplicate Content-Length, etc.) — only ever replayed its seed corpus, never live-fuzzed. One-word change adds it to the existing 30s-each suite. Ran 30s locally: no crashes. Pure safety, zero runtime cost.