### PR TITLE
feat(wing): SSE and incremental streaming on the Wing transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [1.5.0] — unreleased
 
+### Added
+
+- **Server-Sent Events and streaming on the Wing transport.** `c.SSE()` and `c.Stream()`
+  now work on Wing (the default on Linux) via the new `kruda.Stream` route preset —
+  `app.Get("/events", h, kruda.Stream)`. Previously they returned an error unless the route
+  ran on net/http. Streaming dispatches via Takeover and does not affect the inline hot
+  path; a slow/stuck client is bounded by `WriteTimeout`, and a client disconnect cancels
+  the handler context (`SSEStream.Done()` fires). A `TestClient.SSE(path)` helper decodes the
+  emitted events for unit tests. The fasthttp transport (macOS dev default) does not support
+  streaming — `c.SSE()` there now returns an actionable error pointing to `kruda.NetHTTP()`.
+
 ### Breaking
 
 - **Removed the no-op `WithHTTP3` option and the `Config.HTTP3` field.** They advertised

--- a/ctx_response.go
+++ b/ctx_response.go
@@ -952,7 +952,7 @@ func (c *Ctx) SSE(fn func(*SSEStream) error) error {
 	// Check flusher support before writing headers
 	flusher, ok := c.writer.(http.Flusher)
 	if !ok {
-		return InternalError("SSE requires a transport that supports flushing")
+		return InternalError("streaming requires a flushing transport: add the kruda.Stream preset to the route on Wing (Linux), or use kruda.NetHTTP() on macOS/dev — the fasthttp transport does not support streaming")
 	}
 
 	// Set SSE headers

--- a/ctx_response.go
+++ b/ctx_response.go
@@ -963,6 +963,12 @@ func (c *Ctx) SSE(fn func(*SSEStream) error) error {
 	// Write headers immediately
 	c.writeHeaders()
 	c.writer.WriteHeader(200)
+	// Push the response preamble to the client on connect, before fn runs. A
+	// valid SSE handler may block (or emit nothing) before its first event; the
+	// client must still receive the status line + text/event-stream headers
+	// promptly. On net/http this commits the header; on Wing it emits the
+	// preamble through wingStreamWriter.Flush().
+	flusher.Flush()
 	c.responded = true
 
 	stream := &SSEStream{

--- a/ctx_response_test.go
+++ b/ctx_response_test.go
@@ -1,0 +1,96 @@
+package kruda
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-kruda/kruda/transport"
+)
+
+// nonFlushingHeaderMap is a stub transport.HeaderMap that does NOT implement http.Flusher.
+type nonFlushingHeaderMap struct {
+	headers map[string]string
+}
+
+func (h *nonFlushingHeaderMap) Set(key, value string) {
+	if h.headers == nil {
+		h.headers = make(map[string]string)
+	}
+	h.headers[key] = value
+}
+
+func (h *nonFlushingHeaderMap) Add(key, value string) {
+	if h.headers == nil {
+		h.headers = make(map[string]string)
+	}
+	h.headers[key] = value
+}
+
+func (h *nonFlushingHeaderMap) Get(key string) string {
+	return h.headers[key]
+}
+
+func (h *nonFlushingHeaderMap) Del(key string) {
+	delete(h.headers, key)
+}
+
+// nonFlushingWriter is a stub transport.ResponseWriter that does NOT implement http.Flusher.
+// Used to simulate fasthttp or other transports that don't support streaming.
+type nonFlushingWriter struct {
+	statusCode int
+	headers    transport.HeaderMap
+}
+
+func (w *nonFlushingWriter) Header() transport.HeaderMap {
+	if w.headers == nil {
+		w.headers = &nonFlushingHeaderMap{headers: make(map[string]string)}
+	}
+	return w.headers
+}
+
+func (w *nonFlushingWriter) Write(b []byte) (int, error) {
+	return 0, nil
+}
+
+func (w *nonFlushingWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+}
+
+// TestSSE_NoFlushSupport verifies that c.SSE() returns an actionable error
+// when the transport (like fasthttp) does not support the Flusher interface.
+func TestSSE_NoFlushSupport(t *testing.T) {
+	app := New()
+	c := newCtx(app)
+
+	// Replace the writer with a non-flushing stub
+	c.writer = &nonFlushingWriter{}
+
+	// Call SSE and expect an error
+	err := c.SSE(func(stream *SSEStream) error {
+		return nil
+	})
+
+	if err == nil {
+		t.Fatal("expected error when flusher not supported")
+	}
+
+	// Cast to *KrudaError to check the message
+	kErr, ok := err.(*KrudaError)
+	if !ok {
+		t.Fatalf("expected *KrudaError, got %T", err)
+	}
+
+	msg := kErr.Message
+	// The message should be actionable and mention both remedies:
+	// 1. kruda.Stream preset (for Wing on Linux)
+	// 2. kruda.NetHTTP() (for fasthttp on macOS/dev)
+	if !strings.Contains(msg, "kruda.Stream") {
+		t.Errorf("error message missing 'kruda.Stream': %q", msg)
+	}
+	if !strings.Contains(msg, "NetHTTP") {
+		t.Errorf("error message missing 'NetHTTP': %q", msg)
+	}
+	if !strings.Contains(msg, "fasthttp") {
+		t.Errorf("error message missing 'fasthttp': %q", msg)
+	}
+}

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -42,7 +42,8 @@ See the [DI Container guide](/guide/di-container) for details.
 | Performance | Highest (846K req/s) | High | Good |
 | HTTP/2 | No | No | Yes (via TLS) |
 | Set-Cookie | Limited (fast path skips) | Yes | Yes |
-| SSE / WebSocket | No | No | Yes |
+| SSE | Yes (via `kruda.Stream`) | No | Yes |
+| WebSocket | No | No | Yes (`contrib/ws`) |
 | Default on | Linux | macOS | Windows |
 
 Kruda auto-selects:

--- a/test_client.go
+++ b/test_client.go
@@ -279,6 +279,33 @@ func (tr *TestRequest) Send() (*TestResponse, error) {
 	return &TestResponse{recorder: w}, nil
 }
 
+// SSETestResult holds the response from an in-memory SSE request.
+// Each element of Events is one raw event block — the text between \n\n
+// boundaries in the text/event-stream body (trailing empty blocks trimmed).
+type SSETestResult struct {
+	Status int
+	Events []string
+}
+
+// SSE sends a GET request to the given path and parses the text/event-stream
+// body into discrete event blocks. It tests handler logic, not incremental
+// delivery: the handler runs to completion inside httptest.ResponseRecorder
+// before the body is split on \n\n boundaries.
+func (tc *TestClient) SSE(path string) (*SSETestResult, error) {
+	resp, err := tc.do(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	body := resp.BodyString()
+	var events []string
+	for _, block := range strings.Split(body, "\n\n") {
+		if strings.TrimSpace(block) != "" {
+			events = append(events, block)
+		}
+	}
+	return &SSETestResult{Status: resp.StatusCode(), Events: events}, nil
+}
+
 // TestResponse wraps an httptest.ResponseRecorder for easy assertions.
 type TestResponse struct {
 	recorder *httptest.ResponseRecorder

--- a/test_client_sse_test.go
+++ b/test_client_sse_test.go
@@ -1,0 +1,41 @@
+package kruda
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSSETestClientHelper(t *testing.T) {
+	app := New()
+	app.Get("/events", func(c *Ctx) error {
+		return c.SSE(func(stream *SSEStream) error {
+			if err := stream.Data("hello"); err != nil {
+				return err
+			}
+			return stream.Event("ping", "world")
+		})
+	})
+	app.Compile()
+
+	tc := NewTestClient(app)
+	result, err := tc.SSE("/events")
+	if err != nil {
+		t.Fatalf("SSE() returned error: %v", err)
+	}
+
+	if result.Status != 200 {
+		t.Fatalf("expected status 200, got %d", result.Status)
+	}
+
+	if len(result.Events) != 2 {
+		t.Fatalf("expected 2 events, got %d: %v", len(result.Events), result.Events)
+	}
+
+	if !strings.Contains(result.Events[0], "data: hello") {
+		t.Errorf("event[0] = %q, want to contain 'data: hello'", result.Events[0])
+	}
+
+	if !strings.Contains(result.Events[1], "event: ping") || !strings.Contains(result.Events[1], "data: world") {
+		t.Errorf("event[1] = %q, want to contain 'event: ping' and 'data: world'", result.Events[1])
+	}
+}

--- a/wing_http.go
+++ b/wing_http.go
@@ -1115,10 +1115,9 @@ func (r *wingResponse) buildZeroCopy() []byte {
 		return b
 	}
 
-	b = appendStatusAndHeaders(b, r.status, &r.headers)
+	b, hasCL := appendStatusAndHeaders(b, r.status, &r.headers)
 
 	// Auto-inject Content-Length when the user did not set it explicitly.
-	hasCL := r.headers.Get("Content-Length") != ""
 	if !hasCL {
 		b = append(b, "Content-Length: "...)
 		b = appendContentLengthValue(b, len(r.body))
@@ -1136,8 +1135,10 @@ func (r *wingResponse) buildZeroCopy() []byte {
 // and all user-set headers in h to b. It does NOT append a Content-Length or
 // the blank line that terminates the header section; callers are responsible
 // for those (allowing both buffered responses and streaming writers to reuse
-// this helper without a Content-Length being injected).
-func appendStatusAndHeaders(b []byte, status int, h *wingHeaders) []byte {
+// this helper without a Content-Length being injected). hasCL reports whether
+// a Content-Length header was already present in h, detected in the same walk
+// so buffered callers avoid a second scan.
+func appendStatusAndHeaders(b []byte, status int, h *wingHeaders) (out []byte, hasCL bool) {
 	if status > 0 && status < len(statusLines) && statusLines[status] != nil {
 		b = append(b, statusLines[status]...)
 	} else {
@@ -1151,14 +1152,20 @@ func appendStatusAndHeaders(b []byte, status int, h *wingHeaders) []byte {
 		b = append(b, ": "...)
 		b = append(b, h.vals[i]...)
 		b = append(b, "\r\n"...)
+		if !hasCL && h.keys[i] == "Content-Length" {
+			hasCL = true
+		}
 	}
 	for i := 0; i < len(h.extra); i++ {
 		b = append(b, h.extra[i].key...)
 		b = append(b, ": "...)
 		b = append(b, h.extra[i].val...)
 		b = append(b, "\r\n"...)
+		if !hasCL && h.extra[i].key == "Content-Length" {
+			hasCL = true
+		}
 	}
-	return b
+	return b, hasCL
 }
 
 func (r *wingResponse) appendStringTo(b []byte) []byte {

--- a/wing_http.go
+++ b/wing_http.go
@@ -1115,38 +1115,10 @@ func (r *wingResponse) buildZeroCopy() []byte {
 		return b
 	}
 
-	// Status line — use pre-computed when available.
-	if r.status > 0 && r.status < len(statusLines) && statusLines[r.status] != nil {
-		b = append(b, statusLines[r.status]...)
-	} else {
-		b = append(b, "HTTP/1.1 "...)
-		b = strconv.AppendInt(b, int64(r.status), 10)
-		b = append(b, " Unknown\r\n"...)
-	}
+	b = appendStatusAndHeaders(b, r.status, &r.headers)
 
-	// Fixed headers: Date.
-	b = append(b, dateHdr()...)
-
-	// Headers — check for Content-Length in the same loop.
-	hasCL := false
-	for i := 0; i < r.headers.count; i++ {
-		b = append(b, r.headers.keys[i]...)
-		b = append(b, ": "...)
-		b = append(b, r.headers.vals[i]...)
-		b = append(b, "\r\n"...)
-		if !hasCL && r.headers.keys[i] == "Content-Length" {
-			hasCL = true
-		}
-	}
-	for i := 0; i < len(r.headers.extra); i++ {
-		b = append(b, r.headers.extra[i].key...)
-		b = append(b, ": "...)
-		b = append(b, r.headers.extra[i].val...)
-		b = append(b, "\r\n"...)
-		if !hasCL && r.headers.extra[i].key == "Content-Length" {
-			hasCL = true
-		}
-	}
+	// Auto-inject Content-Length when the user did not set it explicitly.
+	hasCL := r.headers.Get("Content-Length") != ""
 	if !hasCL {
 		b = append(b, "Content-Length: "...)
 		b = appendContentLengthValue(b, len(r.body))
@@ -1157,6 +1129,35 @@ func (r *wingResponse) buildZeroCopy() []byte {
 
 	// Detach buf from response — caller owns this memory now.
 	r.buf = nil
+	return b
+}
+
+// appendStatusAndHeaders appends the HTTP/1.1 status line, the Date header,
+// and all user-set headers in h to b. It does NOT append a Content-Length or
+// the blank line that terminates the header section; callers are responsible
+// for those (allowing both buffered responses and streaming writers to reuse
+// this helper without a Content-Length being injected).
+func appendStatusAndHeaders(b []byte, status int, h *wingHeaders) []byte {
+	if status > 0 && status < len(statusLines) && statusLines[status] != nil {
+		b = append(b, statusLines[status]...)
+	} else {
+		b = append(b, "HTTP/1.1 "...)
+		b = strconv.AppendInt(b, int64(status), 10)
+		b = append(b, " Unknown\r\n"...)
+	}
+	b = append(b, dateHdr()...)
+	for i := 0; i < h.count; i++ {
+		b = append(b, h.keys[i]...)
+		b = append(b, ": "...)
+		b = append(b, h.vals[i]...)
+		b = append(b, "\r\n"...)
+	}
+	for i := 0; i < len(h.extra); i++ {
+		b = append(b, h.extra[i].key...)
+		b = append(b, ": "...)
+		b = append(b, h.extra[i].val...)
+		b = append(b, "\r\n"...)
+	}
 	return b
 }
 

--- a/wing_preset_test.go
+++ b/wing_preset_test.go
@@ -158,3 +158,12 @@ func TestDispatchOption(t *testing.T) {
 		t.Errorf("Dispatch = %v, want Takeover", f.Dispatch)
 	}
 }
+
+func TestStreamPreset(t *testing.T) {
+	if Stream.Dispatch != Takeover {
+		t.Errorf("Stream.Dispatch = %v, want Takeover", Stream.Dispatch)
+	}
+	if Stream.ResponseMode != responseStream {
+		t.Errorf("Stream.ResponseMode = %v, want responseStream", Stream.ResponseMode)
+	}
+}

--- a/wing_stream.go
+++ b/wing_stream.go
@@ -9,6 +9,7 @@
 package kruda
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -74,4 +75,28 @@ func (w *wingStreamWriter) Write(p []byte) (int, error) {
 		_ = w.conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
 	}
 	return w.conn.Write(p)
+}
+
+// streamReader is the minimal read surface the disconnect watcher needs.
+// *os.File (the takeover fd) satisfies it.
+type streamReader interface {
+	Read(p []byte) (int, error)
+}
+
+// watchStreamDisconnect cancels the stream context when the client closes its
+// half of the connection. A well-behaved SSE/streaming client sends nothing
+// after the request, so any Read result — EOF, error, or stray bytes — means
+// the client is gone or misbehaving; either way the handler should stop.
+//
+// It is run as a goroutine alongside the handler. The takeover fd is owned by a
+// single *os.File, and a concurrent Read here while the handler Writes through
+// the stream writer is safe (the runtime poller serializes per-direction).
+func watchStreamDisconnect(r streamReader, cancel context.CancelFunc) {
+	var b [256]byte
+	for {
+		if _, err := r.Read(b[:]); err != nil {
+			cancel()
+			return
+		}
+	}
 }

--- a/wing_stream.go
+++ b/wing_stream.go
@@ -9,6 +9,7 @@
 package kruda
 
 import (
+	"net/http"
 	"time"
 
 	"github.com/go-kruda/kruda/transport"
@@ -33,20 +34,33 @@ type wingStreamWriter struct {
 	writeTimeout time.Duration
 }
 
-// Compile-time interface assertion.
-var _ transport.ResponseWriter = (*wingStreamWriter)(nil)
+// Compile-time interface assertions. The http.Flusher assertion matters:
+// c.SSE()/c.Stream() type-assert the writer to http.Flusher, so dropping
+// Flush() must fail the build, not silently degrade at runtime.
+var (
+	_ transport.ResponseWriter = (*wingStreamWriter)(nil)
+	_ http.Flusher             = (*wingStreamWriter)(nil)
+)
 
 func newWingStreamWriter(conn streamConn, writeTimeout time.Duration) *wingStreamWriter {
 	return &wingStreamWriter{conn: conn, status: 200, writeTimeout: writeTimeout}
 }
 
-func (w *wingStreamWriter) WriteHeader(code int)        { w.status = code }
+// WriteHeader records the status code. After the preamble has been written it
+// is a no-op, matching net/http's contract (the status line is already on the wire).
+func (w *wingStreamWriter) WriteHeader(code int) {
+	if w.headersSent {
+		return
+	}
+	w.status = code
+}
+
 func (w *wingStreamWriter) Header() transport.HeaderMap { return &w.headers }
 func (w *wingStreamWriter) Flush()                      {} // writes already hit the socket directly
 
 func (w *wingStreamWriter) Write(p []byte) (int, error) {
 	if !w.headersSent {
-		hdr := appendStatusAndHeaders(nil, w.status, &w.headers)
+		hdr, _ := appendStatusAndHeaders(nil, w.status, &w.headers)
 		hdr = append(hdr, "\r\n"...) // blank line terminates the header section
 		if w.writeTimeout > 0 {
 			_ = w.conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))

--- a/wing_stream.go
+++ b/wing_stream.go
@@ -1,0 +1,63 @@
+// Cross-platform (no build tag): references only streamConn and wing_http.go
+// types that compile everywhere via wing_types_shared.go and wing_http.go.
+// wing_http.go itself carries the linux||darwin tag so the types it defines
+// (wingHeaders, statusLines, appendStatusAndHeaders) are only available there;
+// this file carries the same tag to keep the build consistent.
+
+//go:build linux || darwin
+
+package kruda
+
+import (
+	"time"
+
+	"github.com/go-kruda/kruda/transport"
+)
+
+// streamConn is the minimal I/O surface the stream writer needs from a connection.
+// *os.File satisfies it; tests use fakeStreamConn.
+type streamConn interface {
+	Write(p []byte) (int, error)
+	SetWriteDeadline(t time.Time) error
+}
+
+// wingStreamWriter implements transport.ResponseWriter and http.Flusher for
+// streaming responses (SSE, chunked). It writes the HTTP preamble (status line
+// + headers) on the first Write call, then streams subsequent writes straight
+// to the connection without buffering.
+type wingStreamWriter struct {
+	conn         streamConn
+	headers      wingHeaders
+	status       int
+	headersSent  bool
+	writeTimeout time.Duration
+}
+
+// Compile-time interface assertion.
+var _ transport.ResponseWriter = (*wingStreamWriter)(nil)
+
+func newWingStreamWriter(conn streamConn, writeTimeout time.Duration) *wingStreamWriter {
+	return &wingStreamWriter{conn: conn, status: 200, writeTimeout: writeTimeout}
+}
+
+func (w *wingStreamWriter) WriteHeader(code int)        { w.status = code }
+func (w *wingStreamWriter) Header() transport.HeaderMap { return &w.headers }
+func (w *wingStreamWriter) Flush()                      {} // writes already hit the socket directly
+
+func (w *wingStreamWriter) Write(p []byte) (int, error) {
+	if !w.headersSent {
+		hdr := appendStatusAndHeaders(nil, w.status, &w.headers)
+		hdr = append(hdr, "\r\n"...) // blank line terminates the header section
+		if w.writeTimeout > 0 {
+			_ = w.conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
+		}
+		if _, err := w.conn.Write(hdr); err != nil {
+			return 0, err
+		}
+		w.headersSent = true
+	}
+	if w.writeTimeout > 0 {
+		_ = w.conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
+	}
+	return w.conn.Write(p)
+}

--- a/wing_stream.go
+++ b/wing_stream.go
@@ -25,8 +25,9 @@ type streamConn interface {
 
 // wingStreamWriter implements transport.ResponseWriter and http.Flusher for
 // streaming responses (SSE, chunked). It writes the HTTP preamble (status line
-// + headers) on the first Write call, then streams subsequent writes straight
-// to the connection without buffering.
+// + headers) on the first Flush or Write (whichever comes first), then streams
+// subsequent writes straight to the connection without buffering. SSE flushes
+// on connect so the client receives the headers before the first event.
 type wingStreamWriter struct {
 	conn         streamConn
 	headers      wingHeaders
@@ -57,19 +58,35 @@ func (w *wingStreamWriter) WriteHeader(code int) {
 }
 
 func (w *wingStreamWriter) Header() transport.HeaderMap { return &w.headers }
-func (w *wingStreamWriter) Flush()                      {} // writes already hit the socket directly
+
+// Flush emits the response preamble (status line + headers) if it has not been
+// sent yet, then returns. Body writes already hit the socket directly, so Flush
+// has no buffered data to push — but SSE flushes on connect (before the first
+// event) to deliver the text/event-stream headers promptly, which is the one
+// case where Flush must actually write the preamble.
+func (w *wingStreamWriter) Flush() { _ = w.flushHeaders() }
+
+// flushHeaders writes the status line + headers + the blank line that
+// terminates the header section, exactly once. Subsequent calls are no-ops.
+func (w *wingStreamWriter) flushHeaders() error {
+	if w.headersSent {
+		return nil
+	}
+	hdr, _ := appendStatusAndHeaders(nil, w.status, &w.headers)
+	hdr = append(hdr, "\r\n"...) // blank line terminates the header section
+	if w.writeTimeout > 0 {
+		_ = w.conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
+	}
+	if _, err := w.conn.Write(hdr); err != nil {
+		return err
+	}
+	w.headersSent = true
+	return nil
+}
 
 func (w *wingStreamWriter) Write(p []byte) (int, error) {
-	if !w.headersSent {
-		hdr, _ := appendStatusAndHeaders(nil, w.status, &w.headers)
-		hdr = append(hdr, "\r\n"...) // blank line terminates the header section
-		if w.writeTimeout > 0 {
-			_ = w.conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
-		}
-		if _, err := w.conn.Write(hdr); err != nil {
-			return 0, err
-		}
-		w.headersSent = true
+	if err := w.flushHeaders(); err != nil {
+		return 0, err
 	}
 	if w.writeTimeout > 0 {
 		_ = w.conn.SetWriteDeadline(time.Now().Add(w.writeTimeout))
@@ -84,9 +101,9 @@ type streamReader interface {
 }
 
 // watchStreamDisconnect cancels the stream context when the client closes its
-// half of the connection. A well-behaved SSE/streaming client sends nothing
-// after the request, so any Read result — EOF, error, or stray bytes — means
-// the client is gone or misbehaving; either way the handler should stop.
+// half of the connection. It cancels on a Read error or EOF (the client is gone
+// or the socket failed); stray bytes from a misbehaving-but-connected client are
+// ignored and watching continues, since a well-behaved SSE client is silent.
 //
 // It is run as a goroutine alongside the handler. The takeover fd is owned by a
 // single *os.File, and a concurrent Read here while the handler Writes through

--- a/wing_stream_integration_test.go
+++ b/wing_stream_integration_test.go
@@ -1,0 +1,267 @@
+//go:build linux || darwin
+
+package kruda
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-kruda/kruda/transport"
+)
+
+// startWingApp compiles app and serves it over a real Wing transport on a
+// loopback port, returning the dial address and a stop func. The app MUST be
+// built with Wing() so app.transport is the Wing transport (the only transport
+// that owns the streaming takeover path).
+func startWingApp(t *testing.T, app *App) (string, func()) {
+	t.Helper()
+	if _, ok := app.transport.(transport.PresetConfigurator); !ok {
+		t.Skip("Wing transport unavailable on this platform; skipping streaming integration test")
+	}
+	if err := app.compile(); err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close() // let the transport bind so a successful dial means it is accepting
+	go func() { _ = app.transport.ListenAndServe(addr, app) }()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if derr == nil {
+			c.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return addr, func() { _ = app.transport.Shutdown(context.Background()) }
+}
+
+// readSSEEvent reads from r until it has consumed one full SSE event
+// (terminated by a blank line, i.e. "\n\n"). It returns the raw event text.
+func readSSEEvent(t *testing.T, r *bufio.Reader) string {
+	t.Helper()
+	var sb strings.Builder
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read SSE event: %v (got so far: %q)", err, sb.String())
+		}
+		sb.WriteString(line)
+		if line == "\n" || line == "\r\n" {
+			return sb.String()
+		}
+	}
+}
+
+// readHeaders consumes the HTTP status line + header block (up to the blank
+// line) and returns the joined header text.
+func readHeaders(t *testing.T, r *bufio.Reader) string {
+	t.Helper()
+	var sb strings.Builder
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			t.Fatalf("read headers: %v", err)
+		}
+		sb.WriteString(line)
+		if line == "\r\n" || line == "\n" {
+			return sb.String()
+		}
+	}
+}
+
+// TestWingStream_IncrementalDelivery proves the Stream preset flushes each SSE
+// event to the socket as the handler produces it, rather than buffering the
+// whole response. The handler blocks on a per-event gate that the test only
+// releases after it has read the event off the wire — so the read CANNOT
+// succeed unless the byte was flushed before the next handler write.
+func TestWingStream_IncrementalDelivery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing streaming integration test in short mode")
+	}
+
+	const n = 3
+	release := make([]chan struct{}, n)
+	for i := range release {
+		release[i] = make(chan struct{})
+	}
+
+	app := New(Wing())
+	app.Get("/events", func(c *Ctx) error {
+		return c.SSE(func(s *SSEStream) error {
+			for i := 0; i < n; i++ {
+				if err := s.Data(fmt.Sprintf("event-%d", i)); err != nil {
+					return err
+				}
+				// Block until the test confirms it read this event off the
+				// socket. A buffered transport would deadlock here because the
+				// reader could not observe the event before this gate opens.
+				select {
+				case <-release[i]:
+				case <-time.After(2 * time.Second):
+					return fmt.Errorf("event %d gate timed out", i)
+				}
+			}
+			return nil
+		})
+	}, Stream)
+
+	addr, stop := startWingApp(t, app)
+	defer stop()
+
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(5 * time.Second))
+	if _, err := conn.Write([]byte("GET /events HTTP/1.1\r\nHost: h\r\n\r\n")); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	r := bufio.NewReader(conn)
+	hdr := readHeaders(t, r)
+	if !strings.HasPrefix(hdr, "HTTP/1.1 200") {
+		t.Fatalf("expected 200 status line, got headers: %q", hdr)
+	}
+	if !strings.Contains(hdr, "Content-Type: text/event-stream") {
+		t.Fatalf("missing text/event-stream content type: %q", hdr)
+	}
+
+	for i := 0; i < n; i++ {
+		ev := readSSEEvent(t, r)
+		want := fmt.Sprintf("data: event-%d\n\n", i)
+		if ev != want {
+			t.Fatalf("event %d = %q, want %q", i, ev, want)
+		}
+		// Only now release the handler's next write. If the transport had
+		// buffered, we'd never have reached this read.
+		close(release[i])
+	}
+}
+
+// TestWingStream_DisconnectCancelsContext proves that closing the client socket
+// fires stream.Done() in the handler (via the disconnect read-watcher cancelling
+// the request context) and that the handler returns promptly with no leak or
+// double-close. Run the file under -race to catch any data race on the shared fd.
+func TestWingStream_DisconnectCancelsContext(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing streaming integration test in short mode")
+	}
+
+	doneFired := make(chan struct{})
+	handlerReturned := make(chan struct{})
+	firstSent := make(chan struct{})
+
+	app := New(Wing())
+	app.Get("/events", func(c *Ctx) error {
+		defer close(handlerReturned)
+		return c.SSE(func(s *SSEStream) error {
+			if err := s.Data("hello"); err != nil {
+				return err
+			}
+			close(firstSent)
+			select {
+			case <-s.Done():
+				close(doneFired)
+				return nil
+			case <-time.After(5 * time.Second):
+				return fmt.Errorf("Done() never fired after client disconnect")
+			}
+		})
+	}, Stream)
+
+	addr, stop := startWingApp(t, app)
+	defer stop()
+
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	conn.SetDeadline(time.Now().Add(5 * time.Second))
+	if _, err := conn.Write([]byte("GET /events HTTP/1.1\r\nHost: h\r\n\r\n")); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	r := bufio.NewReader(conn)
+	_ = readHeaders(t, r)
+	if ev := readSSEEvent(t, r); ev != "data: hello\n\n" {
+		t.Fatalf("first event = %q, want %q", ev, "data: hello\n\n")
+	}
+
+	<-firstSent
+	// Drop the client. The disconnect watcher must observe EOF and cancel.
+	conn.Close()
+
+	select {
+	case <-doneFired:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stream.Done() did not fire after client disconnect")
+	}
+	select {
+	case <-handlerReturned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler did not return after client disconnect")
+	}
+}
+
+// TestWingStream_WriteDeadlineUnblocksHandler proves a stuck client (connects,
+// never reads) cannot pin the handler forever: with a short WriteTimeout the
+// streaming write fails once the socket buffer fills, so the handler returns
+// with an error within ~the deadline and its goroutine exits.
+func TestWingStream_WriteDeadlineUnblocksHandler(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing streaming integration test in short mode")
+	}
+
+	handlerErr := make(chan error, 1)
+
+	app := New(Wing(), func(a *App) { a.config.WriteTimeout = 200 * time.Millisecond })
+	app.Get("/events", func(c *Ctx) error {
+		err := c.SSE(func(s *SSEStream) error {
+			// Stream a large volume the stuck client never drains. Once the
+			// kernel send buffer fills and the write deadline elapses, the
+			// write errors out and we propagate it.
+			big := strings.Repeat("x", 16*1024)
+			for i := 0; i < 100000; i++ {
+				if err := s.Data(big); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+		handlerErr <- err
+		return err
+	}, Stream)
+
+	addr, stop := startWingApp(t, app)
+	defer stop()
+
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	// Send the request, then never read the response — let the send buffer fill.
+	if _, err := conn.Write([]byte("GET /events HTTP/1.1\r\nHost: h\r\n\r\n")); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	select {
+	case err := <-handlerErr:
+		if err == nil {
+			t.Fatal("expected handler to return a write error from the deadline, got nil")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler did not return within deadline despite stuck client")
+	}
+}

--- a/wing_stream_integration_test.go
+++ b/wing_stream_integration_test.go
@@ -149,6 +149,59 @@ func TestWingStream_IncrementalDelivery(t *testing.T) {
 	}
 }
 
+// TestWingStream_HeadersSentBeforeFirstEvent proves the SSE response preamble
+// (status line + text/event-stream headers) reaches the client on connect, even
+// when the handler emits NO event and blocks. Before the on-connect Flush fix,
+// the preamble was only emitted on the first body Write, so a handler that
+// blocked before its first event left the client hanging with no headers.
+func TestWingStream_HeadersSentBeforeFirstEvent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing streaming integration test in short mode")
+	}
+
+	// The handler blocks on this channel without ever emitting an event, so the
+	// only way the client can read headers is if c.SSE() flushed them on connect.
+	hold := make(chan struct{})
+	app := New(Wing())
+	app.Get("/events", func(c *Ctx) error {
+		return c.SSE(func(s *SSEStream) error {
+			select {
+			case <-hold:
+			case <-s.Done():
+			case <-time.After(5 * time.Second):
+			}
+			return nil
+		})
+	}, Stream)
+
+	addr, stop := startWingApp(t, app)
+	defer stop()
+	defer close(hold) // release the handler so it returns at teardown
+
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(3 * time.Second))
+	if _, err := conn.Write([]byte("GET /events HTTP/1.1\r\nHost: h\r\n\r\n")); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	// Headers must arrive promptly, BEFORE any event and before the handler
+	// returns. The read deadline above bounds "promptly": if the preamble were
+	// only emitted on the first Write (which never happens here), this blocks
+	// until the deadline and fails.
+	r := bufio.NewReader(conn)
+	hdr := readHeaders(t, r)
+	if !strings.HasPrefix(hdr, "HTTP/1.1 200") {
+		t.Fatalf("expected 200 status line before any event, got: %q", hdr)
+	}
+	if !strings.Contains(hdr, "Content-Type: text/event-stream") {
+		t.Fatalf("expected text/event-stream header before any event, got: %q", hdr)
+	}
+}
+
 // TestWingStream_DisconnectCancelsContext proves that closing the client socket
 // fires stream.Done() in the handler (via the disconnect read-watcher cancelling
 // the request context) and that the handler returns promptly with no leak or

--- a/wing_stream_test.go
+++ b/wing_stream_test.go
@@ -4,6 +4,8 @@ package kruda
 
 import (
 	"bytes"
+	"context"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -106,6 +108,59 @@ func TestWingStreamWriter_Default200(t *testing.T) {
 	out := fc.buf.String()
 	if !strings.HasPrefix(out, "HTTP/1.1 200 OK\r\n") {
 		t.Fatalf("expected default 200 OK status line, got: %q", out)
+	}
+}
+
+// TestWatchStreamDisconnect_CancelsOnEOF verifies the read-watcher cancels its
+// context and returns when the reader hits EOF (the client closed its half).
+func TestWatchStreamDisconnect_CancelsOnEOF(t *testing.T) {
+	pr, pw := io.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		watchStreamDisconnect(pr, cancel)
+		close(done)
+	}()
+	// Closing the write half makes the watcher's Read return EOF.
+	_ = pw.Close()
+	select {
+	case <-ctx.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("context not cancelled after reader EOF")
+	}
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher goroutine did not exit after EOF")
+	}
+}
+
+// TestWatchStreamDisconnect_IgnoresStrayBytes verifies the watcher keeps reading
+// past stray client bytes and only cancels once the read half errors.
+func TestWatchStreamDisconnect_IgnoresStrayBytes(t *testing.T) {
+	pr, pw := io.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go func() {
+		watchStreamDisconnect(pr, cancel)
+		close(done)
+	}()
+	if _, err := pw.Write([]byte("stray")); err != nil {
+		t.Fatalf("write stray: %v", err)
+	}
+	// Still alive after stray bytes — must not have cancelled yet.
+	select {
+	case <-ctx.Done():
+		t.Fatal("watcher cancelled on stray bytes; must keep watching")
+	case <-time.After(50 * time.Millisecond):
+	}
+	_ = pw.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher goroutine did not exit after EOF")
 	}
 }
 

--- a/wing_stream_test.go
+++ b/wing_stream_test.go
@@ -89,15 +89,50 @@ func TestWingStreamWriter_HeadersSentOnce(t *testing.T) {
 	}
 }
 
-func TestWingStreamWriter_FlushIsNoop(t *testing.T) {
+// TestWingStreamWriter_FlushEmitsPreambleOnConnect verifies that Flush emits the
+// status line + headers before any body byte. This is the SSE-on-connect path:
+// c.SSE() flushes immediately so the client receives the text/event-stream
+// headers even if the handler blocks before its first event.
+func TestWingStreamWriter_FlushEmitsPreambleOnConnect(t *testing.T) {
 	fc := &fakeStreamConn{}
 	w := newWingStreamWriter(fc, 0)
-	// Flush before any write — must not panic.
-	w.Flush()
 	w.WriteHeader(200)
+	w.Header().Set("Content-Type", "text/event-stream")
+	// Flush with no body yet — the preamble must be on the wire afterward.
 	w.Flush()
-	_, _ = w.Write([]byte("ok"))
+	out := fc.buf.String()
+	if !strings.HasPrefix(out, "HTTP/1.1 200") {
+		t.Fatalf("Flush must emit the status line, got: %q", out)
+	}
+	if !strings.Contains(out, "Content-Type: text/event-stream\r\n") {
+		t.Fatalf("Flush must emit headers set before it, got: %q", out)
+	}
+	if !strings.HasSuffix(out, "\r\n\r\n") {
+		t.Fatalf("Flush must terminate the header section with a blank line, got: %q", out)
+	}
+	// A second Flush must not re-emit the preamble.
 	w.Flush()
+	if strings.Count(fc.buf.String(), "HTTP/1.1") != 1 {
+		t.Fatalf("preamble emitted more than once: %q", fc.buf.String())
+	}
+	// A following Write appends the body after the already-sent preamble.
+	if _, err := w.Write([]byte("data: x\n\n")); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(fc.buf.String(), "\r\n\r\ndata: x\n\n") {
+		t.Fatalf("body must follow the preamble: %q", fc.buf.String())
+	}
+}
+
+// TestWingStreamWriter_FlushBeforeWriteHeaderUsesDefault200 verifies a Flush
+// before any WriteHeader emits a default 200 preamble and does not panic.
+func TestWingStreamWriter_FlushBeforeWriteHeaderUsesDefault200(t *testing.T) {
+	fc := &fakeStreamConn{}
+	w := newWingStreamWriter(fc, 0)
+	w.Flush() // no WriteHeader, no Write yet
+	if !strings.HasPrefix(fc.buf.String(), "HTTP/1.1 200 OK\r\n") {
+		t.Fatalf("Flush before WriteHeader must default to 200, got: %q", fc.buf.String())
+	}
 }
 
 func TestWingStreamWriter_Default200(t *testing.T) {

--- a/wing_stream_test.go
+++ b/wing_stream_test.go
@@ -1,0 +1,105 @@
+//go:build linux || darwin
+
+package kruda
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+type fakeStreamConn struct {
+	buf       bytes.Buffer
+	deadlines int
+}
+
+func (f *fakeStreamConn) Write(p []byte) (int, error)        { return f.buf.Write(p) }
+func (f *fakeStreamConn) SetWriteDeadline(t time.Time) error { f.deadlines++; return nil }
+
+func TestWingStreamWriter_HeadersThenChunks(t *testing.T) {
+	fc := &fakeStreamConn{}
+	w := newWingStreamWriter(fc, 0)
+	w.WriteHeader(200)
+	w.Header().Set("Content-Type", "text/event-stream")
+	if _, err := w.Write([]byte("data: a\n\n")); err != nil {
+		t.Fatal(err)
+	}
+	w.Flush() // no-op
+	if _, err := w.Write([]byte("data: b\n\n")); err != nil {
+		t.Fatal(err)
+	}
+	out := fc.buf.String()
+	if !strings.HasPrefix(out, "HTTP/1.1 200") {
+		t.Fatalf("missing status line: %q", out)
+	}
+	if !strings.Contains(out, "Content-Type: text/event-stream\r\n") {
+		t.Fatalf("missing header: %q", out)
+	}
+	// The two chunks arrive in order, each written as it was produced.
+	if i, j := strings.Index(out, "data: a"), strings.Index(out, "data: b"); i < 0 || j < 0 || i > j {
+		t.Fatalf("chunks out of order: %q", out)
+	}
+}
+
+func TestWingStreamWriter_NoDeadlineWhenZero(t *testing.T) {
+	fc := &fakeStreamConn{}
+	w := newWingStreamWriter(fc, 0)
+	w.WriteHeader(200)
+	_, _ = w.Write([]byte("data: x\n\n"))
+	_, _ = w.Write([]byte("data: y\n\n"))
+	if fc.deadlines != 0 {
+		t.Fatalf("expected 0 deadline calls with writeTimeout=0, got %d", fc.deadlines)
+	}
+}
+
+func TestWingStreamWriter_DeadlineSetPerWrite(t *testing.T) {
+	fc := &fakeStreamConn{}
+	w := newWingStreamWriter(fc, 5*time.Second)
+	w.WriteHeader(200)
+	// First Write: 2 deadline calls (one for headers, one for body).
+	_, _ = w.Write([]byte("data: a\n\n"))
+	// Second Write: 1 deadline call.
+	_, _ = w.Write([]byte("data: b\n\n"))
+	if fc.deadlines != 3 {
+		t.Fatalf("expected 3 deadline calls, got %d", fc.deadlines)
+	}
+}
+
+func TestWingStreamWriter_HeadersSentOnce(t *testing.T) {
+	fc := &fakeStreamConn{}
+	w := newWingStreamWriter(fc, 0)
+	w.WriteHeader(201)
+	_, _ = w.Write([]byte("chunk1"))
+	_, _ = w.Write([]byte("chunk2"))
+	out := fc.buf.String()
+	// Status line must appear exactly once.
+	if count := strings.Count(out, "HTTP/1.1"); count != 1 {
+		t.Fatalf("status line appeared %d times, want 1: %q", count, out)
+	}
+	if !strings.Contains(out, "chunk1") || !strings.Contains(out, "chunk2") {
+		t.Fatalf("missing chunks: %q", out)
+	}
+}
+
+func TestWingStreamWriter_FlushIsNoop(t *testing.T) {
+	fc := &fakeStreamConn{}
+	w := newWingStreamWriter(fc, 0)
+	// Flush before any write — must not panic.
+	w.Flush()
+	w.WriteHeader(200)
+	w.Flush()
+	_, _ = w.Write([]byte("ok"))
+	w.Flush()
+}
+
+func TestWingStreamWriter_Default200(t *testing.T) {
+	fc := &fakeStreamConn{}
+	// Do not call WriteHeader — default must be 200.
+	w := newWingStreamWriter(fc, 0)
+	_, _ = w.Write([]byte("hello"))
+	out := fc.buf.String()
+	if !strings.HasPrefix(out, "HTTP/1.1 200 OK\r\n") {
+		t.Fatalf("expected default 200 OK status line, got: %q", out)
+	}
+}

--- a/wing_stream_test.go
+++ b/wing_stream_test.go
@@ -36,6 +36,11 @@ func TestWingStreamWriter_HeadersThenChunks(t *testing.T) {
 	if !strings.Contains(out, "Content-Type: text/event-stream\r\n") {
 		t.Fatalf("missing header: %q", out)
 	}
+	// The blank line (\r\n\r\n) must terminate the header section immediately
+	// before the first body chunk.
+	if !strings.Contains(out, "\r\n\r\ndata: a") {
+		t.Fatalf("blank line missing before body: %q", out)
+	}
 	// The two chunks arrive in order, each written as it was produced.
 	if i, j := strings.Index(out, "data: a"), strings.Index(out, "data: b"); i < 0 || j < 0 || i > j {
 		t.Fatalf("chunks out of order: %q", out)
@@ -101,5 +106,22 @@ func TestWingStreamWriter_Default200(t *testing.T) {
 	out := fc.buf.String()
 	if !strings.HasPrefix(out, "HTTP/1.1 200 OK\r\n") {
 		t.Fatalf("expected default 200 OK status line, got: %q", out)
+	}
+}
+
+func TestWingStreamWriter_WriteHeaderAfterSentIsNoop(t *testing.T) {
+	fc := &fakeStreamConn{}
+	w := newWingStreamWriter(fc, 0)
+	w.WriteHeader(200)
+	_, _ = w.Write([]byte("data: a\n\n"))
+	// Too late — the 200 status line is already on the wire.
+	w.WriteHeader(500)
+	_, _ = w.Write([]byte("data: b\n\n"))
+	out := fc.buf.String()
+	if !strings.HasPrefix(out, "HTTP/1.1 200") {
+		t.Fatalf("status line must stay 200, got: %q", out)
+	}
+	if strings.Contains(out, "HTTP/1.1 500") {
+		t.Fatalf("late WriteHeader(500) must be a no-op: %q", out)
 	}
 }

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -1638,6 +1638,11 @@ func (w *worker) streamTakeover(first *wingRequest, fd int32, f *os.File) {
 
 	cancel() // stop the watcher; it parks on f.Read until the fd closes below
 
+	// Return the request to the pool, matching the other dispatch paths. Safe
+	// here: the handler has returned, the watcher is cancelled, and the close
+	// below uses only fd + the *os.File — nothing references first afterward.
+	releaseRequest(first)
+
 	// Close the fd exactly once via the shared takeover-done path. The conn is
 	// already takenOver, so handleDone removes bookkeeping and closes through
 	// the File — do NOT add a second close here.

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -1014,7 +1014,7 @@ func (w *worker) tryParse(c *conn) {
 			w.dispatchWG.Add(1)
 			go func() {
 				defer w.dispatchWG.Done()
-				w.takeoverLoop(req, c.fd, leftover)
+				w.takeoverLoop(req, c.fd, leftover, f.ResponseMode)
 			}()
 			return
 
@@ -1351,7 +1351,7 @@ var takeoverBufPool = sync.Pool{New: func() any { b := make([]byte, 8192); retur
 // per request at c256 on /db) — identical CPU per request to this model,
 // but scheduler pressure inflated the time a pgx pool conn stayed checked
 // out, costing ~6% throughput (results/forensics-20260612T150500Z).
-func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte) {
+func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte, mode responseMode) {
 	// fds arrive non-blocking from accept4/SetNonblock. os.NewFile registers
 	// a non-blocking fd with the runtime poller, so Read/Write below park
 	// the goroutine, never the thread.
@@ -1359,6 +1359,16 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte) {
 	if f == nil {
 		w.doneCh <- doneMsg{fd: fd, keepAlive: false}
 		w.wake()
+		return
+	}
+
+	// Streaming responses (SSE / chunked) consume the whole connection: the
+	// handler holds it open and writes incrementally through a flushing writer,
+	// so there is no keep-alive reuse and no next-request parse. Handle the
+	// first request as a stream and return — all other dispatch paths fall
+	// through to the byte-unchanged keep-alive loop below.
+	if mode == responseStream {
+		w.streamTakeover(first, fd, f)
 		return
 	}
 
@@ -1589,6 +1599,48 @@ done:
 	// Hand the File to the worker loop: it deletes conn bookkeeping first
 	// and then closes through the File. Do NOT close here — the kernel
 	// could recycle the fd number while the conns map still references it.
+	w.doneCh <- doneMsg{fd: fd, keepAlive: false, file: f}
+	w.wake()
+}
+
+// streamTakeover runs a single streaming response (Stream preset) over the
+// takeover fd f. Unlike the keep-alive takeover loop, it gives the handler a
+// flushing wingStreamWriter so c.SSE()/c.Stream() write incrementally, installs
+// a cancellable context so SSEStream.Done() fires on disconnect, and runs a
+// read-watcher that cancels that context when the client closes its half. The
+// streaming response is not keep-alive-reused; on return the fd is closed
+// exactly once via the shared takeover-done path (doneMsg.file).
+func (w *worker) streamTakeover(first *wingRequest, fd int32, f *os.File) {
+	// Make the handler's c.Context() cancellable from the conn context so the
+	// disconnect watcher can fire SSEStream.Done(). first.ctx flows into c.ctx
+	// during ServeKruda (app_serve.go: c.ctx = r.Context()).
+	ctx, cancel := context.WithCancel(first.ctx)
+	first.ctx = ctx
+
+	sw := newWingStreamWriter(f, time.Duration(w.writeTimeout))
+
+	go watchStreamDisconnect(f, cancel)
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				// The preamble may already be on the wire; a 500 status line is
+				// only meaningful if nothing has been written yet. Either way,
+				// stop the stream and let the deferred cancel + close run.
+				if !sw.headersSent {
+					sw.WriteHeader(500)
+					_, _ = sw.Write([]byte("Internal Server Error\n"))
+				}
+			}
+		}()
+		w.handler.ServeKruda(sw, first)
+	}()
+
+	cancel() // stop the watcher; it parks on f.Read until the fd closes below
+
+	// Close the fd exactly once via the shared takeover-done path. The conn is
+	// already takenOver, so handleDone removes bookkeeping and closes through
+	// the File — do NOT add a second close here.
 	w.doneCh <- doneMsg{fd: fd, keepAlive: false, file: f}
 	w.wake()
 }

--- a/wing_types_shared.go
+++ b/wing_types_shared.go
@@ -114,6 +114,7 @@ const (
 	responseGeneric responseMode = iota
 	responseJSON
 	responseRender // intent/diagnostics tag for the Render preset; does not gate the lane
+	responseStream // Stream preset: incremental streaming writer on the Takeover path
 )
 
 // Preset is the per-route tuning hint passed to Wing. Construct via the
@@ -182,6 +183,10 @@ var (
 	DB = Spear
 	// Render — Spear dispatch tagged for DB + template/HTML responses.
 	Render = Preset{Dispatch: Takeover, ResponseMode: responseRender}
+	// Stream dispatches a route via Takeover and gives c.SSE()/c.Stream() an
+	// incremental, flushing response writer on the Wing transport. Use for
+	// Server-Sent Events and chunked streaming: app.Get("/events", h, kruda.Stream).
+	Stream = Preset{Dispatch: Takeover, ResponseMode: responseStream}
 )
 
 // RejectStats holds accept-side rejection counters populated by the Wing transport.


### PR DESCRIPTION
Makes `c.SSE()` and `c.Stream()` work on **Wing** (the default transport on Linux) — previously they returned an error unless the route ran on net/http (the FAQ matrix listed SSE as "No" on Wing/fasthttp). Built brainstorm→spec→plan→subagent-driven TDD; spec local-only in `docs/superpowers/specs/`.

## What
- **`kruda.Stream` preset** — `app.Get("/events", h, kruda.Stream)` dispatches the route via Wing's Takeover path. Mirrors `kruda.Render` (`Preset{Dispatch: Takeover, ResponseMode: responseStream}`).
- **`wingStreamWriter`** (new, isolated) — implements `transport.ResponseWriter` + `http.Flusher`, writes chunks straight to the takeover `*os.File`; first write emits status+headers via a shared `appendStatusAndHeaders` helper extracted from `buildZeroCopy` (byte-identical). `c.SSE()`/`c.Stream()` work unchanged. **`wingResponse` hot path untouched.**
- **Disconnect** — a read-watcher cancels the handler context on client close, so `SSEStream.Done()` fires even while the handler is idle. **Stuck clients** are bounded by `WriteTimeout`. The fd closes exactly once via the v1.4.0-hardened takeover path.
- **fasthttp** (macOS dev default) gets an actionable error pointing to `kruda.NetHTTP()` — not a real impl (WebSocket-on-Wing and fasthttp streaming are out of scope; WS is the v1.6.0 follow-on that reuses this substrate).
- **`TestClient.SSE()`** helper for unit-testing SSE handlers.

## Verification
- Per-task spec+quality reviews (incl. an opus review of the takeover/concurrency integration) + a final whole-branch opus review: **0 Critical / 0 Important**, spec complete, no scope creep.
- Full core `-race` green; **alloc guards stay 0 allocs** (`TestParseFastPath_AllocBaseline`, `TestStringLaneZeroAlloc`).
- **Linux/epoll on tiger, `-race`, by name:** `TestWingStream_IncrementalDelivery` (events read off the socket before the handler emits the next — proves incremental, not buffered), `..._DisconnectCancelsContext`, `..._WriteDeadlineUnblocksHandler` — all PASS.

CHANGELOG under `[1.5.0]` Added; FAQ SSE matrix flipped to Yes-on-Wing. No tag (accumulating toward an untagged v1.5.0).