### PR TITLE
chore(release): date-stamp v1.5.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to Kruda are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [1.5.0] — unreleased
+## [1.5.0] — 2026-06-29
 
 ### Added
 


### PR DESCRIPTION
Stamp the CHANGELOG [1.5.0] heading with its release date (2026-06-29), mirroring the dated [1.4.0]/[1.3.1] headings, so the tagged commit carries the dated changelog.