### PR TITLE
fix(ws): harden WebSocket frame parser (RFC 6455 §5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- **`contrib/ws` frame-parser hardening (RFC 6455 §5).** `readFrame` now rejects
+  undefined/reserved opcodes, fragmented control frames, and control frames whose
+  declared payload exceeds 125 bytes (the last closes an unbounded-allocation DoS
+  that was reachable before the payload buffer was sized), and rejects non-minimal
+  length encodings. `Conn.ReadMessage` now rejects unmasked client frames
+  (RFC 6455 §5.1). These gaps were latent while WebSocket ran only on net/http;
+  they are fixed here as WebSocket support extends to the Wing transport.
+
 ### Fixed
 
 - Wing no longer drops request headers: requests carrying more than 8

--- a/contrib/ws/conn.go
+++ b/contrib/ws/conn.go
@@ -57,6 +57,23 @@ func newConnFromRaw(rwc net.Conn, cfg Config) *Conn {
 	}
 }
 
+// readClientFrame reads a single frame and enforces RFC 6455 §5.1: every
+// client→server frame MUST be masked. readFrame stays direction-agnostic (tests
+// and clients read unmasked server frames through it), so the masking
+// requirement is enforced here, at the server's read boundary. On an unmasked
+// frame it sends a 1002 close and returns an error.
+func (c *Conn) readClientFrame() (*frame, error) {
+	f, err := readFrame(c.br, c.maxMessageSize)
+	if err != nil {
+		return nil, err
+	}
+	if !f.masked {
+		_ = c.Close(CloseProtocolError, "unmasked client frame")
+		return nil, fmt.Errorf("ws: client frame not masked (RFC 6455 §5.1)")
+	}
+	return f, nil
+}
+
 // ReadMessage reads the next complete message from the connection.
 // It handles fragmented messages by assembling continuation frames.
 // Returns the message type (TextMessage or BinaryMessage) and the payload.
@@ -66,7 +83,7 @@ func (c *Conn) ReadMessage() (messageType int, data []byte, err error) {
 			_ = c.rwc.SetReadDeadline(time.Now().Add(c.readTimeout))
 		}
 
-		f, err := readFrame(c.br, c.maxMessageSize)
+		f, err := c.readClientFrame()
 		if err != nil {
 			// If frame exceeded size limit, send close 1009 before returning.
 			if c.maxMessageSize > 0 && strings.Contains(err.Error(), "exceeds max size") {
@@ -110,7 +127,7 @@ func (c *Conn) ReadMessage() (messageType int, data []byte, err error) {
 				_ = c.rwc.SetReadDeadline(time.Now().Add(c.readTimeout))
 			}
 
-			cont, err := readFrame(c.br, c.maxMessageSize)
+			cont, err := c.readClientFrame()
 			if err != nil {
 				return 0, nil, err
 			}

--- a/contrib/ws/frame.go
+++ b/contrib/ws/frame.go
@@ -71,9 +71,10 @@ func readFrame(r io.Reader, maxSize int64) (*frame, error) {
 		}
 	}
 
-	// Guard against OOM: reject frames exceeding maxSize before allocating.
-	// Control frames (opcode >= 0x8) are always <= 125 bytes per RFC 6455 §5.5,
-	// so we only enforce this for data frames.
+	// Guard against OOM: reject data frames exceeding maxSize before allocating.
+	// Control frames (opcode >= 0x8) get a stricter <=125 bound plus a FIN check
+	// in the block below, also before allocation; this guard only covers data
+	// frames (opcode < 0x8).
 	if maxSize > 0 && f.opcode < 0x8 && length > uint64(maxSize) {
 		return nil, fmt.Errorf("ws: frame payload %d exceeds max size %d", length, maxSize)
 	}

--- a/contrib/ws/frame.go
+++ b/contrib/ws/frame.go
@@ -70,6 +70,18 @@ func readFrame(r io.Reader, maxSize int64) (*frame, error) {
 		return nil, fmt.Errorf("ws: frame payload %d exceeds max size %d", length, maxSize)
 	}
 
+	// RFC 6455 §5.5: control frames (opcode >= 0x8) MUST NOT be fragmented and
+	// MUST have a payload length <= 125. Enforced BEFORE allocation below so an
+	// oversized control frame cannot force an unbounded make([]byte, length).
+	if f.opcode >= 0x8 {
+		if !f.fin {
+			return nil, fmt.Errorf("ws: fragmented control frame (opcode 0x%X)", f.opcode)
+		}
+		if length > 125 {
+			return nil, fmt.Errorf("ws: control frame payload %d exceeds 125 bytes", length)
+		}
+	}
+
 	// Masking key (4 bytes if masked)
 	var maskKey [4]byte
 	if f.masked {

--- a/contrib/ws/frame.go
+++ b/contrib/ws/frame.go
@@ -52,6 +52,10 @@ func readFrame(r io.Reader, maxSize int64) (*frame, error) {
 			return nil, err
 		}
 		length = uint64(binary.BigEndian.Uint16(ext[:]))
+		// RFC 6455 §5.2: the 2-byte form must not encode a value < 126.
+		if length < 126 {
+			return nil, fmt.Errorf("ws: non-minimal length encoding (%d in 16-bit form)", length)
+		}
 	case length == 127:
 		var ext [8]byte
 		if _, err := io.ReadFull(r, ext[:]); err != nil {
@@ -60,6 +64,10 @@ func readFrame(r io.Reader, maxSize int64) (*frame, error) {
 		length = binary.BigEndian.Uint64(ext[:])
 		if length>>63 != 0 {
 			return nil, fmt.Errorf("ws: payload length overflow")
+		}
+		// RFC 6455 §5.2: the 8-byte form must not encode a value <= 65535.
+		if length <= 0xFFFF {
+			return nil, fmt.Errorf("ws: non-minimal length encoding (%d in 64-bit form)", length)
 		}
 	}
 

--- a/contrib/ws/frame.go
+++ b/contrib/ws/frame.go
@@ -35,6 +35,14 @@ func readFrame(r io.Reader, maxSize int64) (*frame, error) {
 		return nil, fmt.Errorf("ws: reserved bits set")
 	}
 
+	// RFC 6455 §5.2: only these opcodes are defined. Reserved non-control
+	// (0x3-0x7) and reserved control (0xB-0xF) opcodes are protocol errors.
+	switch f.opcode {
+	case 0x0, 0x1, 0x2, 0x8, 0x9, 0xA:
+	default:
+		return nil, fmt.Errorf("ws: reserved opcode 0x%X", f.opcode)
+	}
+
 	// Payload length
 	length := uint64(hdr[1] & 0x7F)
 	switch {

--- a/contrib/ws/ws_test.go
+++ b/contrib/ws/ws_test.go
@@ -1177,17 +1177,20 @@ func TestUpgrade_RejectUnmaskedClientFrame(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Server must reject → send a close frame (opcode 0x8), then drop the conn.
+	// readClientFrame calls Close(CloseProtocolError) synchronously before
+	// ReadMessage returns, so the server deterministically sends a 1002 close
+	// frame before dropping the connection — assert on it directly.
 	br := bufio.NewReader(conn)
 	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
 	f, err := readFrame(br, 0)
 	if err != nil {
-		return // connection closed without a frame is also acceptable
+		t.Fatalf("expected a close frame after unmasked client frame, got read error: %v", err)
 	}
 	if f.opcode != 0x8 {
-		t.Errorf("expected close frame after unmasked client frame, got opcode 0x%X", f.opcode)
+		t.Fatalf("expected close frame (0x8), got opcode 0x%X", f.opcode)
 	}
-	if code, _ := parseClosePayload(f.payload); len(f.payload) >= 2 && code != CloseProtocolError {
-		t.Errorf("expected close code %d, got %d", CloseProtocolError, code)
+	code, _ := parseClosePayload(f.payload)
+	if code != CloseProtocolError {
+		t.Errorf("expected close code %d (protocol error), got %d", CloseProtocolError, code)
 	}
 }

--- a/contrib/ws/ws_test.go
+++ b/contrib/ws/ws_test.go
@@ -1091,3 +1091,37 @@ func TestReadFrame_AcceptDefinedOpcodes(t *testing.T) {
 		}
 	}
 }
+
+func TestReadFrame_RejectFragmentedControlFrame(t *testing.T) {
+	var buf bytes.Buffer
+	buf.WriteByte(0x09) // FIN=0 + ping opcode (0x9) — fragmented control frame
+	buf.WriteByte(0x00) // no mask, length 0
+	if _, err := readFrame(bufio.NewReader(&buf), 0); err == nil {
+		t.Error("expected error for fragmented (FIN=0) control frame")
+	}
+}
+
+func TestReadFrame_RejectOversizedControlFrame(t *testing.T) {
+	// A ping (0x9) declaring a 126-byte payload via the 2-byte extended length.
+	// Must be rejected BEFORE allocating — assert we never read the (absent) body.
+	var buf bytes.Buffer
+	buf.WriteByte(0x89)       // FIN + ping
+	buf.WriteByte(0x7E)       // MASK=0, length marker 126 → 2-byte extended length follows
+	buf.WriteByte(0x00)       // extended length high byte
+	buf.WriteByte(0x7E)       // extended length low byte = 126 (>125)
+	if _, err := readFrame(bufio.NewReader(&buf), 0); err == nil {
+		t.Error("expected error for control frame payload > 125")
+	}
+}
+
+func TestReadFrame_AcceptMaxSizeControlFrame(t *testing.T) {
+	// A 125-byte pong is the largest valid control frame — must still parse.
+	var buf bytes.Buffer
+	payload := make([]byte, 125)
+	if err := writeFrame(&buf, true, 0xA, payload); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readFrame(bufio.NewReader(&buf), 0); err != nil {
+		t.Errorf("125-byte control frame should be accepted, got %v", err)
+	}
+}

--- a/contrib/ws/ws_test.go
+++ b/contrib/ws/ws_test.go
@@ -1066,3 +1066,28 @@ func TestUpgrade_EmptyTextMessage(t *testing.T) {
 		t.Errorf("expected empty payload, got %d bytes", len(f.payload))
 	}
 }
+
+func TestReadFrame_RejectReservedOpcodes(t *testing.T) {
+	// Reserved non-control (0x3-0x7) and reserved control (0xB-0xF) opcodes.
+	for _, op := range []byte{0x3, 0x4, 0x5, 0x6, 0x7, 0xB, 0xC, 0xD, 0xE, 0xF} {
+		var buf bytes.Buffer
+		buf.WriteByte(0x80 | op) // FIN + reserved opcode
+		buf.WriteByte(0x00)      // no mask, length 0
+		if _, err := readFrame(bufio.NewReader(&buf), 0); err == nil {
+			t.Errorf("opcode 0x%X: expected error, got nil", op)
+		}
+	}
+}
+
+func TestReadFrame_AcceptDefinedOpcodes(t *testing.T) {
+	// The six defined opcodes must still parse (empty payload, control frames
+	// are FIN + 0-length which is valid).
+	for _, op := range []byte{0x0, 0x1, 0x2, 0x8, 0x9, 0xA} {
+		var buf bytes.Buffer
+		buf.WriteByte(0x80 | op)
+		buf.WriteByte(0x00)
+		if _, err := readFrame(bufio.NewReader(&buf), 0); err != nil {
+			t.Errorf("opcode 0x%X: expected accept, got %v", op, err)
+		}
+	}
+}

--- a/contrib/ws/ws_test.go
+++ b/contrib/ws/ws_test.go
@@ -1150,3 +1150,44 @@ func TestReadFrame_RejectNonMinimal64(t *testing.T) {
 		t.Error("expected error for non-minimal 8-byte length <= 65535")
 	}
 }
+
+func TestUpgrade_RejectUnmaskedClientFrame(t *testing.T) {
+	app := kruda.New(kruda.NetHTTP())
+	upgrader := New(Config{})
+	app.Get("/ws", func(c *kruda.Ctx) error {
+		return upgrader.Upgrade(c, func(conn *Conn) {
+			_, _, _ = conn.ReadMessage() // expected to return an error
+		})
+	})
+	app.Compile()
+	srv := httptest.NewServer(app)
+	defer srv.Close()
+
+	conn := dialWS(t, srv.URL+"/ws")
+	defer conn.Close()
+
+	// Hand-write an UNMASKED text frame (MASK bit clear) — RFC violation.
+	payload := []byte("hello")
+	var buf bytes.Buffer
+	buf.WriteByte(0x81)               // FIN + text
+	buf.WriteByte(byte(len(payload))) // MASK=0 + length
+	buf.Write(payload)
+	conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	if _, err := conn.Write(buf.Bytes()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Server must reject → send a close frame (opcode 0x8), then drop the conn.
+	br := bufio.NewReader(conn)
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	f, err := readFrame(br, 0)
+	if err != nil {
+		return // connection closed without a frame is also acceptable
+	}
+	if f.opcode != 0x8 {
+		t.Errorf("expected close frame after unmasked client frame, got opcode 0x%X", f.opcode)
+	}
+	if code, _ := parseClosePayload(f.payload); len(f.payload) >= 2 && code != CloseProtocolError {
+		t.Errorf("expected close code %d, got %d", CloseProtocolError, code)
+	}
+}

--- a/contrib/ws/ws_test.go
+++ b/contrib/ws/ws_test.go
@@ -1105,10 +1105,10 @@ func TestReadFrame_RejectOversizedControlFrame(t *testing.T) {
 	// A ping (0x9) declaring a 126-byte payload via the 2-byte extended length.
 	// Must be rejected BEFORE allocating — assert we never read the (absent) body.
 	var buf bytes.Buffer
-	buf.WriteByte(0x89)       // FIN + ping
-	buf.WriteByte(0x7E)       // MASK=0, length marker 126 → 2-byte extended length follows
-	buf.WriteByte(0x00)       // extended length high byte
-	buf.WriteByte(0x7E)       // extended length low byte = 126 (>125)
+	buf.WriteByte(0x89) // FIN + ping
+	buf.WriteByte(0x7E) // MASK=0, length marker 126 → 2-byte extended length follows
+	buf.WriteByte(0x00) // extended length high byte
+	buf.WriteByte(0x7E) // extended length low byte = 126 (>125)
 	if _, err := readFrame(bufio.NewReader(&buf), 0); err == nil {
 		t.Error("expected error for control frame payload > 125")
 	}

--- a/contrib/ws/ws_test.go
+++ b/contrib/ws/ws_test.go
@@ -1125,3 +1125,28 @@ func TestReadFrame_AcceptMaxSizeControlFrame(t *testing.T) {
 		t.Errorf("125-byte control frame should be accepted, got %v", err)
 	}
 }
+
+func TestReadFrame_RejectNonMinimal16(t *testing.T) {
+	// 2-byte extended length carrying 100 (<126) — must use the 7-bit form.
+	var buf bytes.Buffer
+	buf.WriteByte(0x82) // FIN + binary
+	buf.WriteByte(0x7E) // length marker 126 → 2-byte extended
+	buf.WriteByte(0x00)
+	buf.WriteByte(0x64) // 100
+	if _, err := readFrame(bufio.NewReader(&buf), 0); err == nil {
+		t.Error("expected error for non-minimal 2-byte length < 126")
+	}
+}
+
+func TestReadFrame_RejectNonMinimal64(t *testing.T) {
+	// 8-byte extended length carrying 1000 (<=65535) — must use the 2-byte form.
+	var buf bytes.Buffer
+	buf.WriteByte(0x82) // FIN + binary
+	buf.WriteByte(0x7F) // length marker 127 → 8-byte extended
+	var ext [8]byte
+	binary.BigEndian.PutUint64(ext[:], 1000)
+	buf.Write(ext[:])
+	if _, err := readFrame(bufio.NewReader(&buf), 0); err == nil {
+		t.Error("expected error for non-minimal 8-byte length <= 65535")
+	}
+}


### PR DESCRIPTION
## Summary

Closes pre-existing RFC 6455 §5 gaps in the `contrib/ws` frame parser. These were latent while WebSocket ran only on `net/http`; they are fixed now because WebSocket support is being extended to the Wing transport (Kruda's default on Linux), which makes these frames reachable on the browser-facing default path.

All rules are **superset checks** — every valid frame the existing writers and clients produce still parses. No existing test was modified; no behavior changes for valid traffic.

## Changes

- **Reject undefined/reserved opcodes** (`readFrame`). Only `0x0,0x1,0x2,0x8,0x9,0xA` are accepted (RFC 6455 §5.2); reserved `0x3-0x7` and `0xB-0xF` are rejected before any extended-length read or allocation.
- **Bound control frames before allocation** (`readFrame`). Control frames (opcode ≥ 0x8) must have `FIN=1` and a payload ≤125 bytes, enforced *before* `make([]byte, length)`. This closes an unbounded-allocation DoS: previously a control frame could declare a huge length and reach the allocation before any bound (the size check applied only to data frames).
- **Reject non-minimal length encodings** (`readFrame`). A 2-byte length must be ≥126 and an 8-byte length must be >65535 (RFC 6455 §5.2); the pre-existing 63-bit overflow guard is preserved.
- **Reject unmasked client frames** (`Conn.ReadMessage`). RFC 6455 §5.1 requires client→server frames to be masked. Enforced at the server read boundary via a `readClientFrame` helper — `readFrame` stays direction-agnostic (it also reads unmasked *server* frames in tests/clients).

## Testing

- New reject + still-accept tests for each rule (in-memory frame tests + one integration test for the unmasked-frame rejection).
- Full `contrib/ws` suite passes under `-race`.

## Notes

`contrib/ws` only (its own module). CHANGELOG `### Security` entry added under `[Unreleased]`.
