### PR TITLE
feat(wing): WebSocket support on the Wing transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `http.Hijacker` contract (a new generic `kruda.Hijack` route preset); the
   RFC 6455 frame code is reused unchanged. Dispatches via Takeover, so the inline
   hot path is untouched. A pipelined first frame is preserved, a rejected upgrade
-  returns a clean 4xx, and server shutdown drains blocked handlers (`conn.Done()`
-  + `SHUT_RDWR`). The fasthttp transport still does not support WebSocket.
+  returns a clean 4xx, and on shutdown Wing wakes I/O-blocked handlers
+  (`SHUT_RDWR`) and signals `conn.Done()` so a handler blocked in application
+  logic can exit cooperatively. The fasthttp transport still does not support
+  WebSocket.
 - `WingHeaderSpills()` — process-wide counter of requests whose extra headers
   spilled past the inline capacity (observability for header-heavy traffic).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,23 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   carries ~10-12 non-fast headers) previously lost every extra header past the
   8th — `c.Header()` returned "" for them. The inline fast path (≤8 extra
   headers) is unchanged, so the zero-extra-header hot path keeps its footprint.
+- Wing now retains the `Connection` request header value, so
+  `c.Header("Connection")` returns it. Previously Wing parsed `Connection` only
+  to derive keep-alive and dropped the raw value (always returning ""), which
+  broke the WebSocket upgrade handshake (`Connection: Upgrade`) on Wing. The fix
+  uses the same zero-copy path as `Host`/`Accept`, so the hot path stays zero-alloc.
 
 ### Added
 
+- **WebSocket on the Wing transport.** `contrib/ws` now works on Wing (the
+  default on Linux), previously net/http-only. Register with
+  `ws.HandleFunc(app, "/ws", handler)` — identical on every transport. Internally
+  Wing hands the taken-over connection to `contrib/ws` via the standard
+  `http.Hijacker` contract (a new generic `kruda.Hijack` route preset); the
+  RFC 6455 frame code is reused unchanged. Dispatches via Takeover, so the inline
+  hot path is untouched. A pipelined first frame is preserved, a rejected upgrade
+  returns a clean 4xx, and server shutdown drains blocked handlers (`conn.Done()`
+  + `SHUT_RDWR`). The fasthttp transport still does not support WebSocket.
 - `WingHeaderSpills()` — process-wide counter of requests whose extra headers
   spilled past the inline capacity (observability for header-heavy traffic).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (`SHUT_RDWR`) and signals `conn.Done()` so a handler blocked in application
   logic can exit cooperatively. The fasthttp transport still does not support
   WebSocket.
+- `App.Serve(ln net.Listener)` — run the app on a pre-created listener instead of
+  binding an address, for graceful restart, systemd socket activation, or tests
+  that need the bound address before the server accepts (no signal handler; the
+  caller owns the lifecycle via `Shutdown`).
 - `WingHeaderSpills()` — process-wide counter of requests whose extra headers
   spilled past the inline capacity (observability for header-heavy traffic).
 

--- a/contrib/ws/conn.go
+++ b/contrib/ws/conn.go
@@ -222,6 +222,23 @@ func (c *Conn) SetWriteDeadline(t time.Time) error {
 	return c.rwc.SetWriteDeadline(t)
 }
 
+// doner is the optional interface a transport's net.Conn implements to signal
+// server shutdown / connection teardown. Wing's hijack adapter implements it;
+// net/http's net.Conn does not.
+type doner interface{ Done() <-chan struct{} }
+
+// Done returns a channel that is closed when the server is shutting down the
+// connection, letting a handler blocked in application logic (not in Read/Write)
+// select on it and exit. On transports that do not expose a shutdown signal
+// (net/http today) it returns nil — a nil channel blocks forever in select, so
+// existing handlers are unaffected.
+func (c *Conn) Done() <-chan struct{} {
+	if d, ok := c.rwc.(doner); ok {
+		return d.Done()
+	}
+	return nil
+}
+
 // handleControl processes control frames (ping, pong, close).
 func (c *Conn) handleControl(f *frame) error {
 	switch f.opcode {

--- a/contrib/ws/conn.go
+++ b/contrib/ws/conn.go
@@ -232,6 +232,11 @@ type doner interface{ Done() <-chan struct{} }
 // select on it and exit. On transports that do not expose a shutdown signal
 // (net/http today) it returns nil — a nil channel blocks forever in select, so
 // existing handlers are unaffected.
+//
+// Done signals server shutdown only, NOT client disconnect: a WebSocket handler
+// detects a peer close through a failed Read (ReadMessage returning an error),
+// which is the normal way to notice a gone client. Use Done for graceful
+// shutdown; use the Read error for disconnect.
 func (c *Conn) Done() <-chan struct{} {
 	if d, ok := c.rwc.(doner); ok {
 		return d.Done()

--- a/contrib/ws/go.mod
+++ b/contrib/ws/go.mod
@@ -4,6 +4,11 @@ go 1.25.11
 
 require github.com/go-kruda/kruda v1.2.0
 
+// DEV-ONLY: contrib/ws now uses kruda.Hijack, which is in unreleased core.
+// RELEASE CHECKLIST: after core is tagged, bump the require above to that
+// version and DELETE this replace before re-tagging contrib/ws (contrib is not
+// in the root go.work, so this replace — not the workspace — is what resolves
+// the local core during development; matches the contrib/observability pattern).
 replace github.com/go-kruda/kruda => ../..
 
 require (

--- a/contrib/ws/go.mod
+++ b/contrib/ws/go.mod
@@ -4,6 +4,8 @@ go 1.25.11
 
 require github.com/go-kruda/kruda v1.2.0
 
+replace github.com/go-kruda/kruda => ../..
+
 require (
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect

--- a/contrib/ws/upgrade.go
+++ b/contrib/ws/upgrade.go
@@ -1,0 +1,68 @@
+package ws
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/go-kruda/kruda"
+)
+
+// hijacker is the optional interface a wrapped ResponseWriter exposes to reach
+// the underlying http.ResponseWriter.
+type hijacker interface {
+	Unwrap() http.ResponseWriter
+}
+
+// upgradeHijacker performs the WebSocket upgrade over any transport whose
+// c.ResponseWriter() implements the standard http.Hijacker contract. It is
+// transport-agnostic: net/http and Wing both route here.
+func upgradeHijacker(c *kruda.Ctx, acceptKey string, handler func(*Conn), cfg Config) error {
+	w := c.ResponseWriter()
+	if w == nil {
+		return fmt.Errorf("ws: response writer is nil")
+	}
+
+	var netConn net.Conn
+	var brw *bufio.ReadWriter
+	if hj, ok := w.(http.Hijacker); ok {
+		var err error
+		netConn, brw, err = hj.Hijack()
+		if err != nil {
+			return fmt.Errorf("ws: hijack failed: %w", err)
+		}
+	} else if unwrapper, ok := w.(hijacker); ok {
+		hw := unwrapper.Unwrap()
+		hj, ok := hw.(http.Hijacker)
+		if !ok {
+			return fmt.Errorf("ws: response writer does not support hijack")
+		}
+		var err error
+		netConn, brw, err = hj.Hijack()
+		if err != nil {
+			return fmt.Errorf("ws: hijack failed: %w", err)
+		}
+	} else {
+		return fmt.Errorf("ws: response writer does not support hijack")
+	}
+
+	resp := "HTTP/1.1 101 Switching Protocols\r\n" +
+		"Upgrade: websocket\r\n" +
+		"Connection: Upgrade\r\n" +
+		"Sec-WebSocket-Accept: " + acceptKey + "\r\n" +
+		"\r\n"
+	if _, err := brw.WriteString(resp); err != nil {
+		netConn.Close()
+		return fmt.Errorf("ws: failed to write upgrade response: %w", err)
+	}
+	if err := brw.Flush(); err != nil {
+		netConn.Close()
+		return fmt.Errorf("ws: failed to flush upgrade response: %w", err)
+	}
+
+	conn := newConn(netConn, brw, cfg)
+	defer conn.Close(CloseGoingAway, "")
+	handler(conn)
+	return nil
+}

--- a/contrib/ws/upgrade_nethttp.go
+++ b/contrib/ws/upgrade_nethttp.go
@@ -1,81 +1,9 @@
 package ws
 
-import (
-	"bufio"
-	"fmt"
-	"net"
-	"net/http"
+import "github.com/go-kruda/kruda"
 
-	"github.com/go-kruda/kruda"
-)
-
-// hijacker is the interface for accessing the underlying http.ResponseWriter.
-type hijacker interface {
-	Unwrap() http.ResponseWriter
-}
-
-// upgradeNetHTTP performs WebSocket upgrade on net/http transport via http.Hijacker.
+// upgradeNetHTTP performs the WebSocket upgrade on the net/http transport via
+// the standard http.Hijacker. The hijack logic is shared with the Wing path.
 func (u *Upgrader) upgradeNetHTTP(c *kruda.Ctx, acceptKey string, handler func(*Conn)) error {
-	// Get the underlying http.ResponseWriter through the transport adapter
-	raw := c.Request().RawRequest()
-	if raw == nil {
-		return fmt.Errorf("ws: cannot access raw request")
-	}
-
-	// The ResponseWriter is accessible through the writer chain.
-	// We need to find the http.Hijacker interface.
-	var netConn net.Conn
-	var brw *bufio.ReadWriter
-
-	// Try to get the response writer that supports hijacking.
-	// The Kruda transport wraps http.ResponseWriter — we need to unwrap it.
-	w := c.ResponseWriter()
-	if w == nil {
-		return fmt.Errorf("ws: response writer is nil")
-	}
-
-	// Check if the writer itself or its underlying type supports Hijack
-	if hj, ok := w.(http.Hijacker); ok {
-		var err error
-		netConn, brw, err = hj.Hijack()
-		if err != nil {
-			return fmt.Errorf("ws: hijack failed: %w", err)
-		}
-	} else if unwrapper, ok := w.(hijacker); ok {
-		hw := unwrapper.Unwrap()
-		if hj, ok := hw.(http.Hijacker); ok {
-			var err error
-			netConn, brw, err = hj.Hijack()
-			if err != nil {
-				return fmt.Errorf("ws: hijack failed: %w", err)
-			}
-		} else {
-			return fmt.Errorf("ws: response writer does not support hijack")
-		}
-	} else {
-		return fmt.Errorf("ws: response writer does not support hijack")
-	}
-
-	// Write the HTTP 101 Switching Protocols response
-	resp := "HTTP/1.1 101 Switching Protocols\r\n" +
-		"Upgrade: websocket\r\n" +
-		"Connection: Upgrade\r\n" +
-		"Sec-WebSocket-Accept: " + acceptKey + "\r\n" +
-		"\r\n"
-
-	if _, err := brw.WriteString(resp); err != nil {
-		netConn.Close()
-		return fmt.Errorf("ws: failed to write upgrade response: %w", err)
-	}
-	if err := brw.Flush(); err != nil {
-		netConn.Close()
-		return fmt.Errorf("ws: failed to flush upgrade response: %w", err)
-	}
-
-	// Create WebSocket connection and run handler
-	conn := newConn(netConn, brw, u.Config)
-	defer conn.Close(CloseGoingAway, "")
-
-	handler(conn)
-	return nil
+	return upgradeHijacker(c, acceptKey, handler, u.Config)
 }

--- a/contrib/ws/ws.go
+++ b/contrib/ws/ws.go
@@ -84,6 +84,16 @@ func (u *Upgrader) validateUpgrade(c *kruda.Ctx) error {
 		return fmt.Errorf("ws: upgrade requires GET method")
 	}
 
+	// RFC 6455: the upgrade is a bodyless GET. Reject a body here — in the
+	// transport-agnostic validator, not just at a Wing-specific boundary — so the
+	// outcome does not depend on TCP packetization (a body arriving in the same
+	// read as the headers would otherwise reach the hijack path while a split
+	// body is rejected earlier by Wing). Check the parsed body rather than the
+	// Content-Length header, which not every transport exposes via c.Header.
+	if body, _ := c.BodyBytes(); len(body) > 0 {
+		return fmt.Errorf("ws: upgrade request must not carry a body")
+	}
+
 	upgrade := c.Header("Upgrade")
 	if !strings.EqualFold(upgrade, "websocket") {
 		return fmt.Errorf("ws: missing or invalid Upgrade header")

--- a/contrib/ws/ws.go
+++ b/contrib/ws/ws.go
@@ -36,9 +36,6 @@ func New(config ...Config) *Upgrader {
 func (u *Upgrader) Upgrade(c *kruda.Ctx, handler func(*Conn)) error {
 	// R10.16-17: transport compatibility check
 	transport := c.Transport()
-	if transport == "wing" {
-		return fmt.Errorf("ws: WebSocket upgrade not supported on Wing transport — use the net/http transport (kruda.NetHTTP())")
-	}
 
 	// Validate upgrade request headers
 	if err := u.validateUpgrade(c); err != nil {
@@ -59,6 +56,8 @@ func (u *Upgrader) Upgrade(c *kruda.Ctx, handler func(*Conn)) error {
 	switch transport {
 	case "nethttp":
 		return u.upgradeNetHTTP(c, accept, handler)
+	case "wing":
+		return upgradeHijacker(c, accept, handler, u.Config)
 	case "fasthttp":
 		return u.upgradeFastHTTP(c, accept, handler)
 	default:

--- a/contrib/ws/ws.go
+++ b/contrib/ws/ws.go
@@ -28,6 +28,19 @@ func New(config ...Config) *Upgrader {
 	return &Upgrader{Config: cfg}
 }
 
+// HandleFunc registers a WebSocket route: it wires the route with the
+// kruda.Hijack preset (needed by the Wing transport; a harmless no-op on
+// net/http and fasthttp, which ignore route presets) and performs the upgrade,
+// so the same call works identically on every transport. For manual control,
+// use Upgrader.Upgrade directly (on Wing that requires adding kruda.Hijack to
+// the route yourself — which is exactly what this does for you).
+func HandleFunc(app *kruda.App, path string, handler func(*Conn), cfg ...Config) *kruda.App {
+	u := New(cfg...)
+	return app.Get(path, func(c *kruda.Ctx) error {
+		return u.Upgrade(c, handler)
+	}, kruda.Hijack)
+}
+
 // Upgrade performs the WebSocket handshake and calls handler with the connection.
 // The handler runs synchronously — when it returns, the connection is closed.
 //

--- a/contrib/ws/ws_test.go
+++ b/contrib/ws/ws_test.go
@@ -1205,3 +1205,26 @@ func TestConn_DoneNilOnPlainConn(t *testing.T) {
 		t.Error("Done() should be nil on a transport with no shutdown signal")
 	}
 }
+
+func TestHandleFunc_NetHTTPEcho(t *testing.T) {
+	app := kruda.New(kruda.NetHTTP())
+	HandleFunc(app, "/ws", func(conn *Conn) {
+		mt, data, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		conn.WriteMessage(mt, data)
+	})
+	app.Compile()
+	srv := httptest.NewServer(app)
+	defer srv.Close()
+
+	conn := dialWS(t, srv.URL+"/ws")
+	defer conn.Close()
+	sendClientFrame(t, conn, true, 0x1, []byte("hi"))
+	br := bufio.NewReader(conn)
+	f := readServerFrame(t, conn, br)
+	if f.opcode != 0x1 || string(f.payload) != "hi" {
+		t.Errorf("echo = opcode 0x%X %q, want text 'hi'", f.opcode, f.payload)
+	}
+}

--- a/contrib/ws/ws_test.go
+++ b/contrib/ws/ws_test.go
@@ -1194,3 +1194,14 @@ func TestUpgrade_RejectUnmaskedClientFrame(t *testing.T) {
 		t.Errorf("expected close code %d (protocol error), got %d", CloseProtocolError, code)
 	}
 }
+
+func TestConn_DoneNilOnPlainConn(t *testing.T) {
+	// A Conn over a plain net.Conn (no doner) reports a nil Done channel.
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+	c := newConnFromRaw(server, Config{})
+	if c.Done() != nil {
+		t.Error("Done() should be nil on a transport with no shutdown signal")
+	}
+}

--- a/contrib/ws/ws_test.go
+++ b/contrib/ws/ws_test.go
@@ -545,21 +545,29 @@ func TestUpgrade_FragmentedMessage(t *testing.T) {
 // dialWS performs a WebSocket handshake and returns the raw TCP connection.
 func dialWS(t *testing.T, rawURL string) net.Conn {
 	t.Helper()
-	url := strings.Replace(rawURL, "http://", "", 1)
+	addr := strings.Replace(rawURL, "http://", "", 1)
 	path := "/"
-	if idx := strings.Index(url, "/"); idx >= 0 {
-		path = url[idx:]
-		url = url[:idx]
+	if idx := strings.Index(addr, "/"); idx >= 0 {
+		path = addr[idx:]
+		addr = addr[:idx]
 	}
+	return dialWSAddr(t, addr, path)
+}
 
-	conn, err := net.DialTimeout("tcp", url, 2*time.Second)
+// dialWSAddr performs a WebSocket handshake against a raw host:port address
+// and returns the resulting connection. Shared by dialWS (net/http tests,
+// which derive addr/path from an httptest.Server URL) and the Wing
+// integration tests (which already have a raw addr from listenWingApp).
+func dialWSAddr(t *testing.T, addr, path string) net.Conn {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
 
 	key := base64.StdEncoding.EncodeToString([]byte("test-key-1234567"))
 	req := "GET " + path + " HTTP/1.1\r\n" +
-		"Host: " + url + "\r\n" +
+		"Host: " + addr + "\r\n" +
 		"Upgrade: websocket\r\n" +
 		"Connection: Upgrade\r\n" +
 		"Sec-WebSocket-Key: " + key + "\r\n" +
@@ -614,11 +622,12 @@ func (p *prebufConn) Read(b []byte) (int, error) {
 	return p.Conn.Read(b)
 }
 
-// sendClientFrame writes a masked frame (client-to-server per RFC 6455).
-func sendClientFrame(t *testing.T, conn net.Conn, fin bool, opcode byte, payload []byte) {
-	t.Helper()
+// appendMaskedFrame builds a masked client-to-server frame (per RFC 6455) and
+// appends it to buf. Shared by sendClientFrame (writes straight to a conn)
+// and the Wing pipelined-frame test (which needs the raw bytes to concatenate
+// with the HTTP handshake before a single conn.Write).
+func appendMaskedFrame(buf *bytes.Buffer, fin bool, opcode byte, payload []byte) {
 	length := len(payload)
-	var buf bytes.Buffer
 
 	b0 := opcode
 	if fin {
@@ -649,6 +658,13 @@ func sendClientFrame(t *testing.T, conn net.Conn, fin bool, opcode byte, payload
 	copy(masked, payload)
 	maskBytes(key, masked)
 	buf.Write(masked)
+}
+
+// sendClientFrame writes a masked frame (client-to-server per RFC 6455).
+func sendClientFrame(t *testing.T, conn net.Conn, fin bool, opcode byte, payload []byte) {
+	t.Helper()
+	var buf bytes.Buffer
+	appendMaskedFrame(&buf, fin, opcode, payload)
 
 	conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
 	if _, err := conn.Write(buf.Bytes()); err != nil {

--- a/contrib/ws/ws_wing_test.go
+++ b/contrib/ws/ws_wing_test.go
@@ -124,6 +124,45 @@ func TestWSOverWing_CloseHandshake(t *testing.T) {
 	}
 }
 
+// TestWSOverWing_RejectUpgradeWithBodyOnePacket sends a full, valid WS upgrade
+// GET that ALSO carries a body, all in a single write (so the whole request is
+// parsed in one read and reaches the hijack path — not the split-body
+// accumulation path). validateUpgrade must reject the body, so the outcome is a
+// 4xx regardless of TCP packetization, never a 101 protocol switch.
+func TestWSOverWing_RejectUpgradeWithBodyOnePacket(t *testing.T) {
+	app := kruda.New(kruda.Wing())
+	HandleFunc(app, "/ws", func(conn *Conn) {})
+	app.Compile()
+	addr, stop := listenWingApp(t, app)
+	defer stop()
+
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	key := base64.StdEncoding.EncodeToString([]byte("test-key-1234567"))
+	req := "GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n" +
+		"Sec-WebSocket-Key: " + key + "\r\nSec-WebSocket-Version: 13\r\nContent-Length: 5\r\n\r\nhello"
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatal(err)
+	}
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == 101 {
+		t.Fatal("bodied upgrade must not switch protocols, got 101")
+	}
+	if resp.StatusCode != 400 {
+		t.Errorf("expected 400 for bodied upgrade, got %d", resp.StatusCode)
+	}
+}
+
 func TestWSOverWing_PipelinedFirstFrame(t *testing.T) {
 	app := kruda.New(kruda.Wing())
 	HandleFunc(app, "/ws", func(conn *Conn) {

--- a/contrib/ws/ws_wing_test.go
+++ b/contrib/ws/ws_wing_test.go
@@ -17,7 +17,9 @@ import (
 )
 
 // listenWingApp starts app on a real loopback listener via Wing and returns its
-// address + a stop func. Public API only (package ws can't touch app.transport).
+// address + a stop func. It serves the OPEN listener via app.Serve, so there is
+// no close-then-rebind port race (which is flaky on macOS): the port stays bound
+// the whole time and a dial succeeds as soon as the transport accepts.
 func listenWingApp(t *testing.T, app *kruda.App) (addr string, stop func()) {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -25,16 +27,15 @@ func listenWingApp(t *testing.T, app *kruda.App) (addr string, stop func()) {
 		t.Fatal(err)
 	}
 	addr = ln.Addr().String()
-	_ = ln.Close() // free the port; app.Listen re-binds it (readiness poll closes the race)
-	go func() { _ = app.Listen(addr) }()
-	// Readiness poll.
+	go func() { _ = app.Serve(ln) }()
+	// Readiness: the listener is already bound, so this succeeds promptly.
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if c, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond); derr == nil {
 			c.Close()
 			break
 		}
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(5 * time.Millisecond)
 	}
 	return addr, func() { _ = app.Shutdown(context.Background()) }
 }

--- a/contrib/ws/ws_wing_test.go
+++ b/contrib/ws/ws_wing_test.go
@@ -1,0 +1,170 @@
+//go:build linux || darwin
+
+package ws
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-kruda/kruda"
+)
+
+// listenWingApp starts app on a real loopback listener via Wing and returns its
+// address + a stop func. Public API only (package ws can't touch app.transport).
+func listenWingApp(t *testing.T, app *kruda.App) (addr string, stop func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr = ln.Addr().String()
+	_ = ln.Close() // free the port; app.Listen re-binds it (readiness poll closes the race)
+	go func() { _ = app.Listen(addr) }()
+	// Readiness poll.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond); derr == nil {
+			c.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return addr, func() { _ = app.Shutdown(context.Background()) }
+}
+
+func TestWSOverWing_Echo(t *testing.T) {
+	app := kruda.New(kruda.Wing()) // force Wing on every platform
+	HandleFunc(app, "/ws", func(conn *Conn) {
+		mt, data, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		conn.WriteMessage(mt, data)
+	})
+	app.Compile()
+	addr, stop := listenWingApp(t, app)
+	defer stop()
+
+	conn := dialWSAddr(t, addr, "/ws") // reuse dialWS logic against a raw addr
+	defer conn.Close()
+	sendClientFrame(t, conn, true, 0x1, []byte("hello-wing"))
+	br := bufio.NewReader(conn)
+	f := readServerFrame(t, conn, br)
+	if f.opcode != 0x1 || string(f.payload) != "hello-wing" {
+		t.Errorf("echo = 0x%X %q", f.opcode, f.payload)
+	}
+}
+
+func TestWSOverWing_PingPong(t *testing.T) {
+	app := kruda.New(kruda.Wing())
+	HandleFunc(app, "/ws", func(conn *Conn) {
+		// Just read messages until close/error
+		for {
+			_, _, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+		}
+	})
+	app.Compile()
+	addr, stop := listenWingApp(t, app)
+	defer stop()
+
+	conn := dialWSAddr(t, addr, "/ws")
+	defer conn.Close()
+
+	// Send ping
+	sendClientFrame(t, conn, true, 0x9, []byte("ping-data"))
+
+	// Expect pong with same payload
+	br := bufio.NewReader(conn)
+	f := readServerFrame(t, conn, br)
+	if f.opcode != 0xA {
+		t.Errorf("expected pong (0xA), got opcode %d", f.opcode)
+	}
+	if string(f.payload) != "ping-data" {
+		t.Errorf("expected 'ping-data', got %q", f.payload)
+	}
+}
+
+func TestWSOverWing_CloseHandshake(t *testing.T) {
+	app := kruda.New(kruda.Wing())
+	HandleFunc(app, "/ws", func(conn *Conn) {
+		for {
+			_, _, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+		}
+	})
+	app.Compile()
+	addr, stop := listenWingApp(t, app)
+	defer stop()
+
+	conn := dialWSAddr(t, addr, "/ws")
+	defer conn.Close()
+
+	// Send close frame
+	closePayload := make([]byte, 2)
+	binary.BigEndian.PutUint16(closePayload, uint16(CloseNormalClosure))
+	sendClientFrame(t, conn, true, 0x8, closePayload)
+
+	// Expect close frame back
+	br := bufio.NewReader(conn)
+	f := readServerFrame(t, conn, br)
+	if f.opcode != 0x8 {
+		t.Errorf("expected close frame, got opcode %d", f.opcode)
+	}
+}
+
+func TestWSOverWing_PipelinedFirstFrame(t *testing.T) {
+	app := kruda.New(kruda.Wing())
+	HandleFunc(app, "/ws", func(conn *Conn) {
+		mt, data, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		conn.WriteMessage(mt, data)
+	})
+	app.Compile()
+	addr, stop := listenWingApp(t, app)
+	defer stop()
+
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// Build handshake + first masked frame as ONE buffer, write once.
+	key := base64.StdEncoding.EncodeToString([]byte("test-key-1234567"))
+	handshake := "GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\n" +
+		"Connection: Upgrade\r\nSec-WebSocket-Key: " + key +
+		"\r\nSec-WebSocket-Version: 13\r\n\r\n"
+	var one bytes.Buffer
+	one.WriteString(handshake)
+	appendMaskedFrame(&one, true, 0x1, []byte("pipelined")) // helper: same masking as sendClientFrame
+	conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	if _, err := conn.Write(one.Bytes()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read the 101, then the echoed first frame.
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	if err != nil || resp.StatusCode != 101 {
+		t.Fatalf("handshake: %v status %v", err, resp)
+	}
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	f := readServerFrame(t, conn, br)
+	if f.opcode != 0x1 || string(f.payload) != "pipelined" {
+		t.Errorf("pipelined first frame lost: got 0x%X %q", f.opcode, f.payload)
+	}
+}

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -43,7 +43,7 @@ See the [DI Container guide](/guide/di-container) for details.
 | HTTP/2 | No | No | Yes (via TLS) |
 | Set-Cookie | Limited (fast path skips) | Yes | Yes |
 | SSE | Yes (via `kruda.Stream`) | No | Yes |
-| WebSocket | No | No | Yes (`contrib/ws`) |
+| WebSocket | Yes (`ws.HandleFunc`) | No | Yes (`contrib/ws`) |
 | Default on | Linux | macOS | Windows |
 
 Kruda auto-selects:

--- a/kruda.go
+++ b/kruda.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/textproto"
 	"os"
 	"os/signal"
@@ -305,6 +306,23 @@ func (app *App) Listen(addr string) error {
 	}
 
 	return app.shutdown()
+}
+
+// Serve runs the app on a pre-created net.Listener instead of binding an address
+// itself. Useful for graceful restart, systemd socket activation, or tests that
+// need the bound address before the server starts accepting (avoiding a
+// close-then-rebind race). It compiles the routes and starts the DI container,
+// then serves until the transport is shut down via Shutdown, whose result it
+// returns. Unlike Listen it installs no OS signal handler — the caller owns the
+// lifecycle and calls Shutdown to stop.
+func (app *App) Serve(ln net.Listener) error {
+	if err := app.compile(); err != nil {
+		return err
+	}
+	if err := app.startContainer(context.Background()); err != nil {
+		return err
+	}
+	return app.transport.Serve(ln, app)
 }
 
 // shutdown performs graceful shutdown: drains connections, runs OnShutdown hooks in LIFO order.

--- a/wing_http.go
+++ b/wing_http.go
@@ -250,20 +250,14 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 			if asciiEqualFold(val, bClose) {
 				keepAlive = false
 			}
-			// Retain the raw value so Header("Connection") works (e.g. a
-			// WebSocket "Connection: Upgrade" check). Zero-copy like host/accept
-			// for the common single-line case; comma-join repeated Connection
-			// lines (a proxy may split "Upgrade" and "keep-alive" across lines)
-			// so the token scan still sees every token — matching net/http.
+			// Retain the FIRST Connection value so Header("Connection") works
+			// (e.g. a WebSocket "Connection: Upgrade" check). First-wins matches
+			// net/http's http.Header.Get, so c.Header("Connection") is identical
+			// across transports; keep-alive detection above still scans every
+			// line. Zero-copy like host/accept.
 			if connection == "" {
 				connection = copyOrUnsafeString(val, unsafePath)
 				connectionUnsafe = unsafePath && len(val) > 0
-			} else {
-				if connectionUnsafe {
-					connection = strings.Clone(connection)
-					connectionUnsafe = false
-				}
-				connection = connection + ", " + string(val)
 			}
 			continue
 		case headerTransferEncoding:
@@ -331,17 +325,11 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 			if asciiEqualFold(val, bClose) {
 				keepAlive = false
 			}
-			// Retain the raw value (comma-joining repeated lines) — see the
-			// matching fast-path case above for the rationale.
+			// Retain the FIRST Connection value (first-wins, matching net/http) —
+			// see the fast-path case above for the rationale.
 			if connection == "" {
 				connection = copyOrUnsafeString(val, unsafePath)
 				connectionUnsafe = unsafePath && len(val) > 0
-			} else {
-				if connectionUnsafe {
-					connection = strings.Clone(connection)
-					connectionUnsafe = false
-				}
-				connection = connection + ", " + string(val)
 			}
 		case headerTransferEncoding:
 			hasTE = true

--- a/wing_http.go
+++ b/wing_http.go
@@ -251,9 +251,20 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 				keepAlive = false
 			}
 			// Retain the raw value so Header("Connection") works (e.g. a
-			// WebSocket "Connection: Upgrade" check). Zero-copy like host/accept.
-			connection = copyOrUnsafeString(val, unsafePath)
-			connectionUnsafe = unsafePath && len(val) > 0
+			// WebSocket "Connection: Upgrade" check). Zero-copy like host/accept
+			// for the common single-line case; comma-join repeated Connection
+			// lines (a proxy may split "Upgrade" and "keep-alive" across lines)
+			// so the token scan still sees every token — matching net/http.
+			if connection == "" {
+				connection = copyOrUnsafeString(val, unsafePath)
+				connectionUnsafe = unsafePath && len(val) > 0
+			} else {
+				if connectionUnsafe {
+					connection = strings.Clone(connection)
+					connectionUnsafe = false
+				}
+				connection = connection + ", " + string(val)
+			}
 			continue
 		case headerTransferEncoding:
 			hasTE = true
@@ -320,8 +331,18 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 			if asciiEqualFold(val, bClose) {
 				keepAlive = false
 			}
-			connection = copyOrUnsafeString(val, unsafePath)
-			connectionUnsafe = unsafePath && len(val) > 0
+			// Retain the raw value (comma-joining repeated lines) — see the
+			// matching fast-path case above for the rationale.
+			if connection == "" {
+				connection = copyOrUnsafeString(val, unsafePath)
+				connectionUnsafe = unsafePath && len(val) > 0
+			} else {
+				if connectionUnsafe {
+					connection = strings.Clone(connection)
+					connectionUnsafe = false
+				}
+				connection = connection + ", " + string(val)
+			}
 		case headerTransferEncoding:
 			hasTE = true
 		case headerCookie:

--- a/wing_http.go
+++ b/wing_http.go
@@ -129,6 +129,7 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 	cookie := ""
 	host := ""
 	accept := ""
+	connection := ""
 	forwardedFor := ""
 	realIP := ""
 	forwardedForSeen := false // first header wins even if its value is empty (net/http Get)
@@ -136,6 +137,7 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 	hostSeen := false
 	hostUnsafe := false
 	acceptUnsafe := false
+	connectionUnsafe := false
 	keepAlive := true // HTTP/1.1 default
 	headerCount := 0
 	contentLengthSeen := false
@@ -248,6 +250,10 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 			if asciiEqualFold(val, bClose) {
 				keepAlive = false
 			}
+			// Retain the raw value so Header("Connection") works (e.g. a
+			// WebSocket "Connection: Upgrade" check). Zero-copy like host/accept.
+			connection = copyOrUnsafeString(val, unsafePath)
+			connectionUnsafe = unsafePath && len(val) > 0
 			continue
 		case headerTransferEncoding:
 			hasTE = true
@@ -314,6 +320,8 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 			if asciiEqualFold(val, bClose) {
 				keepAlive = false
 			}
+			connection = copyOrUnsafeString(val, unsafePath)
+			connectionUnsafe = unsafePath && len(val) > 0
 		case headerTransferEncoding:
 			hasTE = true
 		case headerCookie:
@@ -399,10 +407,12 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 		r.cookie = cookie
 		r.host = host
 		r.accept = accept
+		r.connection = connection
 		r.forwardedFor = forwardedFor
 		r.realIP = realIP
 		r.hostUnsafe = hostUnsafe
 		r.acceptUnsafe = acceptUnsafe
+		r.connectionUnsafe = connectionUnsafe
 		// Copy only the populated inline slots; a full value-array copy would
 		// move the whole array every request even when there are no extra
 		// headers. Slots past extraN are never read (Header scans [0:extraN]),
@@ -423,10 +433,12 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 	r.cookie = cookie
 	r.host = host
 	r.accept = accept
+	r.connection = connection
 	r.forwardedFor = forwardedFor
 	r.realIP = realIP
 	r.hostUnsafe = hostUnsafe
 	r.acceptUnsafe = acceptUnsafe
+	r.connectionUnsafe = connectionUnsafe
 	// Copy only the populated inline slots (see the with-body path above for
 	// why a full value-array copy is avoided on the hot path).
 	copy(r.extraHdrs[:extraN], extraHdrs[:extraN])
@@ -467,6 +479,10 @@ func finalizeRequestCommonHeaders(r *wingRequest) {
 	if r.acceptUnsafe {
 		r.accept = strings.Clone(r.accept)
 		r.acceptUnsafe = false
+	}
+	if r.connectionUnsafe {
+		r.connection = strings.Clone(r.connection)
+		r.connectionUnsafe = false
 	}
 }
 
@@ -833,10 +849,12 @@ func releaseRequest(r *wingRequest) {
 	r.cookie = ""
 	r.host = ""
 	r.accept = ""
+	r.connection = ""
 	r.forwardedFor = ""
 	r.realIP = ""
 	r.hostUnsafe = false
 	r.acceptUnsafe = false
+	r.connectionUnsafe = false
 	r.remoteAddr = ""
 	r.remoteAddrRef = nil
 	r.trustProxy = false
@@ -870,28 +888,30 @@ func parseCookieValue(cookie, name string) string {
 
 // wingRequest implements transport.Request with safe-copied strings.
 type wingRequest struct {
-	method        string
-	path          string
-	query         string
-	body          []byte
-	contentType   string
-	cookie        string
-	host          string
-	accept        string
-	forwardedFor  string
-	realIP        string
-	remoteAddr    string
-	remoteAddrRef *string
-	trustProxy    bool
-	keepAlive     bool
-	pathUnsafe    bool
-	hostUnsafe    bool
-	acceptUnsafe  bool
-	fd            int32 // connection fd — for RawRequest().Fd()
-	extraHdrs     [8]wingExtraHeader
-	extraN        int
-	extraOverflow []wingExtraHeader
-	ctx           context.Context
+	method           string
+	path             string
+	query            string
+	body             []byte
+	contentType      string
+	cookie           string
+	host             string
+	accept           string
+	connection       string
+	forwardedFor     string
+	realIP           string
+	remoteAddr       string
+	remoteAddrRef    *string
+	trustProxy       bool
+	keepAlive        bool
+	pathUnsafe       bool
+	hostUnsafe       bool
+	acceptUnsafe     bool
+	connectionUnsafe bool
+	fd               int32 // connection fd — for RawRequest().Fd()
+	extraHdrs        [8]wingExtraHeader
+	extraN           int
+	extraOverflow    []wingExtraHeader
+	ctx              context.Context
 }
 
 func (r *wingRequest) Method() string        { return r.method }
@@ -974,6 +994,13 @@ func (r *wingRequest) Header(key string) string {
 			r.acceptUnsafe = false
 		}
 		return r.accept
+	}
+	if key == "Connection" || key == "connection" {
+		if r.connectionUnsafe {
+			r.connection = strings.Clone(r.connection)
+			r.connectionUnsafe = false
+		}
+		return r.connection
 	}
 	if strings.EqualFold(key, "x-forwarded-for") {
 		return r.forwardedFor

--- a/wing_http_test.go
+++ b/wing_http_test.go
@@ -203,6 +203,22 @@ func TestParseHTTPRequestFast_RetainsConnectionHeader(t *testing.T) {
 	}
 }
 
+// TestParseHTTPRequest_MultiLineConnectionHeader guards against over-rejecting
+// a valid WebSocket upgrade when a proxy splits the Connection tokens across
+// separate header lines with "Upgrade" NOT last. Wing must retain every token
+// (comma-joined), matching net/http, so the "Connection: Upgrade" check passes.
+func TestParseHTTPRequest_MultiLineConnectionHeader(t *testing.T) {
+	raw := []byte("GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nConnection: keep-alive\r\n\r\n")
+	req, _, ok := parseHTTPRequest(raw, noLimits)
+	if !ok {
+		t.Fatal("parse failed")
+	}
+	got := req.Header("Connection")
+	if !strings.Contains(strings.ToLower(got), "upgrade") {
+		t.Fatalf("Header(Connection) = %q, must retain the Upgrade token across multiple Connection lines", got)
+	}
+}
+
 // TestParseHTTPRequest_RejectsWhitespaceBeforeColon is the regression test
 // for the anti-smuggling fix that replaced the old tolerant behavior: a
 // space or tab between a header field-name and its colon (RFC 9112 §5.1)

--- a/wing_http_test.go
+++ b/wing_http_test.go
@@ -203,19 +203,19 @@ func TestParseHTTPRequestFast_RetainsConnectionHeader(t *testing.T) {
 	}
 }
 
-// TestParseHTTPRequest_MultiLineConnectionHeader guards against over-rejecting
-// a valid WebSocket upgrade when a proxy splits the Connection tokens across
-// separate header lines with "Upgrade" NOT last. Wing must retain every token
-// (comma-joined), matching net/http, so the "Connection: Upgrade" check passes.
+// TestParseHTTPRequest_MultiLineConnectionHeader pins first-wins retention for
+// repeated Connection lines, matching net/http's http.Header.Get (which returns
+// the first value) so c.Header("Connection") is identical across transports. A
+// proxy that sends "Connection: Upgrade" before "Connection: keep-alive" keeps
+// the Upgrade token, so the WebSocket "Connection: Upgrade" check still passes.
 func TestParseHTTPRequest_MultiLineConnectionHeader(t *testing.T) {
 	raw := []byte("GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nConnection: keep-alive\r\n\r\n")
 	req, _, ok := parseHTTPRequest(raw, noLimits)
 	if !ok {
 		t.Fatal("parse failed")
 	}
-	got := req.Header("Connection")
-	if !strings.Contains(strings.ToLower(got), "upgrade") {
-		t.Fatalf("Header(Connection) = %q, must retain the Upgrade token across multiple Connection lines", got)
+	if got := req.Header("Connection"); got != "Upgrade" {
+		t.Fatalf("Header(Connection) = %q, want first value \"Upgrade\" (first-wins, matching net/http)", got)
 	}
 }
 

--- a/wing_http_test.go
+++ b/wing_http_test.go
@@ -176,8 +176,30 @@ func TestParseHTTPRequest_CommonHeadersAreSafeCopies(t *testing.T) {
 	if got := req.Header("Accept"); got != "text/plain" {
 		t.Fatalf("Header(Accept) = %q, want text/plain", got)
 	}
-	if got := req.Header("Connection"); got != "" {
-		t.Fatalf("Header(Connection) = %q, want empty", got)
+	// Connection is retained as a safe copy (so c.Header("Connection") works —
+	// e.g. a WebSocket "Connection: Upgrade" check). Previously Wing parsed it
+	// only for keep-alive and dropped the raw value.
+	if got := req.Header("Connection"); got != "keep-alive" {
+		t.Fatalf("Header(Connection) = %q, want keep-alive", got)
+	}
+}
+
+// TestParseHTTPRequestFast_RetainsConnectionHeader guards the fix that lets
+// c.Header("Connection") work on Wing — required for the WebSocket upgrade
+// handshake ("Connection: Upgrade"), which Wing previously always failed
+// because it parsed Connection only for keep-alive and dropped the raw value.
+// Uses the fast path (unsafePath=true) so it exercises the clone-on-read route.
+func TestParseHTTPRequestFast_RetainsConnectionHeader(t *testing.T) {
+	raw := []byte("GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n")
+	req, _, ok := parseHTTPRequestFast(raw, noLimits)
+	if !ok {
+		t.Fatal("parse failed")
+	}
+	if got := req.Header("Connection"); got != "Upgrade" {
+		t.Fatalf("Header(Connection) = %q, want Upgrade", got)
+	}
+	if got := req.Header("Upgrade"); got != "websocket" {
+		t.Fatalf("Header(Upgrade) = %q, want websocket", got)
 	}
 }
 

--- a/wing_preset_test.go
+++ b/wing_preset_test.go
@@ -167,3 +167,16 @@ func TestStreamPreset(t *testing.T) {
 		t.Errorf("Stream.ResponseMode = %v, want responseStream", Stream.ResponseMode)
 	}
 }
+
+func TestHijackPreset(t *testing.T) {
+	if Hijack.Dispatch != Takeover {
+		t.Errorf("Hijack.Dispatch = %v, want Takeover", Hijack.Dispatch)
+	}
+	if Hijack.ResponseMode != responseHijack {
+		t.Errorf("Hijack.ResponseMode = %v, want responseHijack", Hijack.ResponseMode)
+	}
+	// Hijack must be distinct from Stream/Render so the takeover loop can branch.
+	if responseHijack == responseStream || responseHijack == responseRender {
+		t.Error("responseHijack must be a distinct responseMode value")
+	}
+}

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -1372,6 +1372,11 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte, mod
 		return
 	}
 
+	if mode == responseHijack {
+		w.hijackTakeover(first, fd, f, leftover)
+		return
+	}
+
 	bp := takeoverBufPool.Get().(*[]byte)
 	buf := *bp
 	// The pool's default buffer is 8 KB; grow it to the configured ReadBufSize so

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -1221,6 +1221,17 @@ func (w *worker) finishBodyAccum(c *conn) {
 // Accumulated bodies are always dispatched inline; non-inline presets
 // with large bodies are uncommon and correctness takes precedence here.
 func (w *worker) dispatchAccumulated(c *conn, req *wingRequest, f Preset) {
+	// A Hijack-preset route (WebSocket upgrade) is a bodyless GET. A body forces
+	// inline accumulation, where c.ResponseWriter() is not an http.Hijacker — so
+	// reject it cleanly (400) rather than letting the upgrade fail opaquely.
+	if f.ResponseMode == responseHijack {
+		c.keepAlive = false
+		c.sendBuf = append(c.sendBuf, wingStatusClose(400)...)
+		releaseRequest(req)
+		c.sendN = 0
+		w.directSend(c)
+		return
+	}
 	finalizeRequestCommonHeaders(req)
 	resp := acquireResponse()
 	resp.responseMode = f.ResponseMode

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -1749,15 +1749,21 @@ func (w *worker) cleanup() {
 		// could land on an fd the kernel has already recycled.
 		w.pool.wg.Wait()
 	}
-	// Takeover goroutines block on syscall.Read until the client sends data
-	// or the connection closes. To unblock them WITHOUT yet closing the fd
-	// (which would race with Spawn writes), half-close the read side. The
-	// pending Read returns EOF, takeoverLoop exits, dispatchWG.Done fires.
-	// SHUT_RD doesn't free the fd number, so kernel won't recycle it — Spawn's
-	// write side stays valid until we run closeFd below.
+	// Takeover goroutines can block in a syscall.Read, a syscall.Write (a
+	// WebSocket WriteMessage), or in app logic with no pending socket call at
+	// all. To unblock all three WITHOUT yet closing the fd (which would race
+	// with Spawn writes), shut down both directions and cancel the conn
+	// context. SHUT_RDWR unblocks a pending Read (EOF) or Write (EPIPE/ECONNRESET);
+	// cancelling ctx wakes a handler blocked in app logic via Conn.Done().
+	// Either way takeoverLoop exits and dispatchWG.Done fires. SHUT_* doesn't
+	// free the fd number, so kernel won't recycle it — Spawn's write side
+	// stays valid until we run closeFd below.
 	for _, c := range w.conns {
 		if c.pending > 0 {
-			_ = syscall.Shutdown(int(c.fd), syscall.SHUT_RD)
+			_ = syscall.Shutdown(int(c.fd), syscall.SHUT_RDWR)
+			if c.cancel != nil {
+				c.cancel()
+			}
 		}
 	}
 	// Drain doneCh concurrently with dispatchWG.Wait. Without this, a wave

--- a/wing_types_shared.go
+++ b/wing_types_shared.go
@@ -116,6 +116,7 @@ const (
 	responseJSON
 	responseRender // intent/diagnostics tag for the Render preset; does not gate the lane
 	responseStream // Stream preset: incremental streaming writer on the Takeover path
+	responseHijack // Hijack preset: hand the raw connection to the handler via http.Hijacker
 )
 
 // Preset is the per-route tuning hint passed to Wing. Construct via the
@@ -188,6 +189,11 @@ var (
 	// incremental, flushing response writer on the Wing transport. Use for
 	// Server-Sent Events and chunked streaming: app.Get("/events", h, kruda.Stream).
 	Stream = Preset{Dispatch: Takeover, ResponseMode: responseStream}
+	// Hijack dispatches a route via Takeover and gives c.ResponseWriter() an
+	// http.Hijacker, handing the raw connection to the handler. It is generic —
+	// WebSocket (contrib/ws) is one consumer; any raw-connection protocol can use
+	// it. Prefer ws.HandleFunc for WebSocket, which applies this preset for you.
+	Hijack = Preset{Dispatch: Takeover, ResponseMode: responseHijack}
 )
 
 // RejectStats holds accept-side rejection counters populated by the Wing transport.

--- a/wing_ws.go
+++ b/wing_ws.go
@@ -1,0 +1,69 @@
+//go:build linux || darwin
+
+package kruda
+
+import (
+	"context"
+	"net"
+	"os"
+	"sync/atomic"
+	"syscall"
+	"time"
+)
+
+// wingAddr is a minimal net.Addr synthesized from Wing's per-connection remote
+// address string (os.File has no LocalAddr/RemoteAddr). WebSocket handlers
+// rarely need it; it exists to satisfy the net.Conn contract contrib/ws expects.
+type wingAddr struct{ s string }
+
+func (a wingAddr) Network() string { return "tcp" }
+func (a wingAddr) String() string  { return a.s }
+
+// wingHijackConn adapts a taken-over *os.File to net.Conn so contrib/ws (which
+// is entirely net.Conn-based) works over Wing unchanged. Read/Write/deadlines
+// forward to the *os.File (pollable on Linux/Darwin, so they park the goroutine,
+// not the thread). Close is coordinated: it half-closes the socket to unblock
+// the peer but does NOT close the fd — hijackTakeover owns the single physical
+// close via doneMsg.file after the handler returns.
+type wingHijackConn struct {
+	f      *os.File
+	fd     int32 // raw fd for syscall.Shutdown (avoids os.File.Fd()'s blocking side effect)
+	remote string
+	ctx    context.Context
+	closed atomic.Bool
+}
+
+func newWingHijackConn(f *os.File, fd int32, remote string, ctx context.Context) *wingHijackConn {
+	return &wingHijackConn{f: f, fd: fd, remote: remote, ctx: ctx}
+}
+
+func (c *wingHijackConn) Read(b []byte) (int, error)         { return c.f.Read(b) }
+func (c *wingHijackConn) Write(b []byte) (int, error)        { return c.f.Write(b) }
+func (c *wingHijackConn) LocalAddr() net.Addr                { return wingAddr{"wing"} }
+func (c *wingHijackConn) RemoteAddr() net.Addr               { return wingAddr{c.remote} }
+func (c *wingHijackConn) SetDeadline(t time.Time) error      { return c.f.SetDeadline(t) }
+func (c *wingHijackConn) SetReadDeadline(t time.Time) error  { return c.f.SetReadDeadline(t) }
+func (c *wingHijackConn) SetWriteDeadline(t time.Time) error { return c.f.SetWriteDeadline(t) }
+
+// Close half-closes both directions to unblock the peer promptly, then returns.
+// It does NOT close the fd (single-close invariant): hijackTakeover closes it
+// once via doneMsg.file after the handler returns. Idempotent.
+func (c *wingHijackConn) Close() error {
+	if c.closed.Swap(true) {
+		return nil
+	}
+	// Use the raw fd, not c.f.Fd(): os.File.Fd() can move the fd off the runtime
+	// poller (blocking mode), which would break concurrent parked I/O.
+	_ = syscall.Shutdown(int(c.fd), syscall.SHUT_RDWR)
+	return nil
+}
+
+// Done reports when the owning Wing connection is being torn down (server
+// shutdown cancels the conn context). contrib/ws.Conn surfaces this so a handler
+// blocked in app logic (not in a socket call) can select on it and exit.
+func (c *wingHijackConn) Done() <-chan struct{} {
+	if c.ctx == nil {
+		return nil
+	}
+	return c.ctx.Done()
+}

--- a/wing_ws.go
+++ b/wing_ws.go
@@ -62,9 +62,16 @@ func (c *wingHijackConn) SetWriteDeadline(t time.Time) error { return c.f.SetWri
 // signals the owning takeover goroutine that the fd may be reclaimed. It does
 // NOT close the fd itself (single-close invariant): hijackTakeover, which is
 // still holding the fd open, performs the one physical close after done fires.
-// Idempotent.
+//
+// Idempotent AND synchronizing: the first caller does the raw-fd Shutdown and
+// closes done; any concurrent/later caller BLOCKS on done before returning. That
+// guarantee is load-bearing — hijackTakeover reclaims (and the kernel may
+// recycle) the fd only after a Close returns, so every caller must observe the
+// raw-fd Shutdown as complete before returning, or a losing closer could run
+// Shutdown on an already-recycled fd.
 func (c *wingHijackConn) Close() error {
 	if c.closed.Swap(true) {
+		<-c.done // a concurrent closer won; wait until its Shutdown has completed
 		return nil
 	}
 	// Use the raw fd, not c.f.Fd(): os.File.Fd() can move the fd off the runtime

--- a/wing_ws.go
+++ b/wing_ws.go
@@ -3,12 +3,18 @@
 package kruda
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"github.com/go-kruda/kruda/transport"
 )
 
 // wingAddr is a minimal net.Addr synthesized from Wing's per-connection remote
@@ -66,4 +72,63 @@ func (c *wingHijackConn) Done() <-chan struct{} {
 		return nil
 	}
 	return c.ctx.Done()
+}
+
+// wingHijackWriter is the c.ResponseWriter() for a Hijack-preset route. It
+// buffers a normal handler response through a pooled wingResponse (so a rejected
+// upgrade returns a correct 4xx via Wing's own serialization) and implements
+// http.Hijacker so contrib/ws can take over the raw connection. It deliberately
+// does NOT implement the responder fast-lane interfaces, so c.JSON/c.Text on the
+// not-hijacked path fall through to plain buffering.
+type wingHijackWriter struct {
+	resp     *wingResponse
+	f        *os.File
+	fd       int32
+	leftover []byte
+	remote   string
+	ctx      context.Context
+	hijacked bool
+}
+
+func newWingHijackWriter(resp *wingResponse, f *os.File, fd int32, leftover []byte, remote string, ctx context.Context) *wingHijackWriter {
+	return &wingHijackWriter{resp: resp, f: f, fd: fd, leftover: leftover, remote: remote, ctx: ctx}
+}
+
+// Compile-time interface assertions.
+var (
+	_ transport.ResponseWriter = (*wingHijackWriter)(nil)
+	_ http.Hijacker            = (*wingHijackWriter)(nil)
+)
+
+func (hw *wingHijackWriter) WriteHeader(code int) {
+	if hw.hijacked {
+		return
+	}
+	hw.resp.WriteHeader(code)
+}
+
+func (hw *wingHijackWriter) Header() transport.HeaderMap { return hw.resp.Header() }
+
+func (hw *wingHijackWriter) Write(p []byte) (int, error) {
+	if hw.hijacked {
+		return 0, http.ErrHijacked
+	}
+	return hw.resp.Write(p)
+}
+
+// Hijack detaches the connection: it returns the wingHijackConn adapter and a
+// *bufio.ReadWriter whose reader is seeded with any bytes the client already
+// sent past the handshake (leftover), so a pipelined first WS frame is not lost.
+func (hw *wingHijackWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if hw.hijacked {
+		return nil, nil, http.ErrHijacked
+	}
+	hw.hijacked = true
+	nc := newWingHijackConn(hw.f, hw.fd, hw.remote, hw.ctx)
+	var r io.Reader = nc
+	if len(hw.leftover) > 0 {
+		r = io.MultiReader(bytes.NewReader(hw.leftover), nc)
+	}
+	brw := bufio.NewReadWriter(bufio.NewReader(r), bufio.NewWriter(nc))
+	return nc, brw, nil
 }

--- a/wing_ws.go
+++ b/wing_ws.go
@@ -206,7 +206,15 @@ func (w *worker) hijackTakeover(first *wingRequest, fd int32, f *os.File, leftov
 	if hw.hijacked && hw.hijackedConn != nil {
 		select {
 		case <-hw.hijackedConn.done:
+			// App closed the connection: the adapter is already marked closed and
+			// has done its raw-fd Shutdown while the fd was still valid.
 		case <-ctx.Done():
+			// Server shutdown won the race before the app closed. Retire the
+			// adapter ourselves (idempotent atomic guard) BEFORE we reclaim the
+			// fd below, so a late app Close() finds it already closed and is a
+			// no-op — it can never Shutdown the (soon-to-be-recycled) raw fd. A
+			// concurrent app Close races harmlessly: exactly one wins.
+			_ = hw.hijackedConn.Close()
 		}
 	}
 

--- a/wing_ws.go
+++ b/wing_ws.go
@@ -28,19 +28,26 @@ func (a wingAddr) String() string  { return a.s }
 // wingHijackConn adapts a taken-over *os.File to net.Conn so contrib/ws (which
 // is entirely net.Conn-based) works over Wing unchanged. Read/Write/deadlines
 // forward to the *os.File (pollable on Linux/Darwin, so they park the goroutine,
-// not the thread). Close is coordinated: it half-closes the socket to unblock
-// the peer but does NOT close the fd — hijackTakeover owns the single physical
-// close via doneMsg.file after the handler returns.
+// not the thread).
+//
+// Close honors the standard http.Hijacker ownership contract: after Hijack the
+// caller owns the connection and closes it when done — possibly from a goroutine
+// that outlives the route handler. Close half-closes the socket (to unblock the
+// peer / concurrent I/O) and signals the owning takeover goroutine via done; it
+// does NOT close the fd itself. hijackTakeover holds the fd open until done fires
+// (or the server shuts down) and performs the single physical close then — so a
+// late Close from an app goroutine can never Shutdown a recycled fd.
 type wingHijackConn struct {
 	f      *os.File
 	fd     int32 // raw fd for syscall.Shutdown (avoids os.File.Fd()'s blocking side effect)
 	remote string
 	ctx    context.Context
 	closed atomic.Bool
+	done   chan struct{} // closed once by Close() — tells hijackTakeover the app is done with the fd
 }
 
 func newWingHijackConn(f *os.File, fd int32, remote string, ctx context.Context) *wingHijackConn {
-	return &wingHijackConn{f: f, fd: fd, remote: remote, ctx: ctx}
+	return &wingHijackConn{f: f, fd: fd, remote: remote, ctx: ctx, done: make(chan struct{})}
 }
 
 func (c *wingHijackConn) Read(b []byte) (int, error)         { return c.f.Read(b) }
@@ -51,16 +58,20 @@ func (c *wingHijackConn) SetDeadline(t time.Time) error      { return c.f.SetDea
 func (c *wingHijackConn) SetReadDeadline(t time.Time) error  { return c.f.SetReadDeadline(t) }
 func (c *wingHijackConn) SetWriteDeadline(t time.Time) error { return c.f.SetWriteDeadline(t) }
 
-// Close half-closes both directions to unblock the peer promptly, then returns.
-// It does NOT close the fd (single-close invariant): hijackTakeover closes it
-// once via doneMsg.file after the handler returns. Idempotent.
+// Close half-closes both directions (to unblock the peer / concurrent I/O) and
+// signals the owning takeover goroutine that the fd may be reclaimed. It does
+// NOT close the fd itself (single-close invariant): hijackTakeover, which is
+// still holding the fd open, performs the one physical close after done fires.
+// Idempotent.
 func (c *wingHijackConn) Close() error {
 	if c.closed.Swap(true) {
 		return nil
 	}
 	// Use the raw fd, not c.f.Fd(): os.File.Fd() can move the fd off the runtime
-	// poller (blocking mode), which would break concurrent parked I/O.
+	// poller (blocking mode), which would break concurrent parked I/O. Safe here
+	// because hijackTakeover has not closed the fd yet — it waits for done below.
 	_ = syscall.Shutdown(int(c.fd), syscall.SHUT_RDWR)
+	close(c.done)
 	return nil
 }
 
@@ -81,13 +92,14 @@ func (c *wingHijackConn) Done() <-chan struct{} {
 // does NOT implement the responder fast-lane interfaces, so c.JSON/c.Text on the
 // not-hijacked path fall through to plain buffering.
 type wingHijackWriter struct {
-	resp     *wingResponse
-	f        *os.File
-	fd       int32
-	leftover []byte
-	remote   string
-	ctx      context.Context
-	hijacked bool
+	resp         *wingResponse
+	f            *os.File
+	fd           int32
+	leftover     []byte
+	remote       string
+	ctx          context.Context
+	hijacked     bool
+	hijackedConn *wingHijackConn // set by Hijack(); hijackTakeover waits on its done
 }
 
 func newWingHijackWriter(resp *wingResponse, f *os.File, fd int32, leftover []byte, remote string, ctx context.Context) *wingHijackWriter {
@@ -125,6 +137,7 @@ func (hw *wingHijackWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	}
 	hw.hijacked = true
 	nc := newWingHijackConn(hw.f, hw.fd, hw.remote, hw.ctx)
+	hw.hijackedConn = nc
 	var r io.Reader = nc
 	if len(hw.leftover) > 0 {
 		r = io.MultiReader(bytes.NewReader(hw.leftover), nc)
@@ -138,8 +151,15 @@ func (hw *wingHijackWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 // Upgrade) either hijacks the raw connection and runs its own read/write loop, or
 // returns a normal buffered response (a rejected upgrade) which we serialize
 // here. Unlike streamTakeover it seeds leftover (a pipelined first frame) into
-// the hijacked reader and runs NO read-watcher — the handler owns reads on f. The
-// fd is closed exactly once via the shared takeover-done path (doneMsg.file).
+// the hijacked reader and runs NO read-watcher — the handler owns reads on f.
+//
+// http.Hijacker ownership: once hijacked, the connection belongs to the caller,
+// which may keep using it from a goroutine that outlives the route handler. So
+// after the handler returns we hold the fd open until the app closes the adapter
+// (its done channel) OR the server shuts down (ctx cancel), and only then perform
+// the single physical close via the shared takeover-done path (doneMsg.file).
+// This is what makes a late Conn.Close() from an app goroutine safe — the fd is
+// never reclaimed (and thus never recycled) while the app still references it.
 func (w *worker) hijackTakeover(first *wingRequest, fd int32, f *os.File, leftover []byte) {
 	// Cancellable conn context so shutdown (Task 6) can fire Conn.Done().
 	ctx, cancel := context.WithCancel(first.ctx)
@@ -168,6 +188,9 @@ func (w *worker) hijackTakeover(first *wingRequest, fd int32, f *os.File, leftov
 	// Phase 3 state machine: not hijacked → serialize the buffered response;
 	// hijacked → the handler already wrote everything to the raw connection.
 	if !hw.hijacked {
+		// The fd is closed right after this write, so advertise Connection: close
+		// rather than letting an HTTP/1.1 client treat the socket as reusable.
+		resp.Header().Set("Connection", "close")
 		data := resp.buildZeroCopy()
 		if w.writeTimeout > 0 {
 			_ = f.SetWriteDeadline(time.Now().Add(time.Duration(w.writeTimeout)))
@@ -175,10 +198,19 @@ func (w *worker) hijackTakeover(first *wingRequest, fd int32, f *os.File, leftov
 		_, _ = f.Write(data)
 	}
 	releaseResponse(resp)
+	releaseRequest(first) // handler returned; the adapter holds ctx/remote independently
+
+	// Hijacked: the app owns the connection. Wait until it closes the adapter
+	// (done) or the server shuts down (ctx) before reclaiming the fd, so an app
+	// goroutine that outlives the handler never Shutdowns a recycled fd.
+	if hw.hijacked && hw.hijackedConn != nil {
+		select {
+		case <-hw.hijackedConn.done:
+		case <-ctx.Done():
+		}
+	}
 
 	cancel()
-	releaseRequest(first)
-
 	// Close the fd exactly once via the shared takeover-done path (handleDone
 	// removes bookkeeping then closes through the File). Do NOT close here.
 	w.doneCh <- doneMsg{fd: fd, keepAlive: false, file: f}

--- a/wing_ws.go
+++ b/wing_ws.go
@@ -132,3 +132,55 @@ func (hw *wingHijackWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	brw := bufio.NewReadWriter(bufio.NewReader(r), bufio.NewWriter(nc))
 	return nc, brw, nil
 }
+
+// hijackTakeover runs a Hijack-preset route over the takeover fd f. It gives the
+// handler a wingHijackWriter (an http.Hijacker); the handler (e.g. contrib/ws
+// Upgrade) either hijacks the raw connection and runs its own read/write loop, or
+// returns a normal buffered response (a rejected upgrade) which we serialize
+// here. Unlike streamTakeover it seeds leftover (a pipelined first frame) into
+// the hijacked reader and runs NO read-watcher — the handler owns reads on f. The
+// fd is closed exactly once via the shared takeover-done path (doneMsg.file).
+func (w *worker) hijackTakeover(first *wingRequest, fd int32, f *os.File, leftover []byte) {
+	// Cancellable conn context so shutdown (Task 6) can fire Conn.Done().
+	ctx, cancel := context.WithCancel(first.ctx)
+	first.ctx = ctx
+
+	remote := ""
+	if first.remoteAddrRef != nil {
+		remote = *first.remoteAddrRef
+	}
+
+	resp := acquireResponse()
+	hw := newWingHijackWriter(resp, f, fd, leftover, remote, ctx)
+
+	func() {
+		defer func() {
+			if r := recover(); r != nil && !hw.hijacked {
+				// Only meaningful if the connection was not hijacked; a panic
+				// inside a hijacked WS loop cannot produce an HTTP response.
+				resp.WriteHeader(500)
+				resp.Write([]byte("Internal Server Error\n"))
+			}
+		}()
+		w.handler.ServeKruda(hw, first)
+	}()
+
+	// Phase 3 state machine: not hijacked → serialize the buffered response;
+	// hijacked → the handler already wrote everything to the raw connection.
+	if !hw.hijacked {
+		data := resp.buildZeroCopy()
+		if w.writeTimeout > 0 {
+			_ = f.SetWriteDeadline(time.Now().Add(time.Duration(w.writeTimeout)))
+		}
+		_, _ = f.Write(data)
+	}
+	releaseResponse(resp)
+
+	cancel()
+	releaseRequest(first)
+
+	// Close the fd exactly once via the shared takeover-done path (handleDone
+	// removes bookkeeping then closes through the File). Do NOT close here.
+	w.doneCh <- doneMsg{fd: fd, keepAlive: false, file: f}
+	w.wake()
+}

--- a/wing_ws_test.go
+++ b/wing_ws_test.go
@@ -1,0 +1,83 @@
+//go:build linux || darwin
+
+package kruda
+
+import (
+	"context"
+	"net"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// newSocketpairFiles returns two connected *os.File endpoints (AF_UNIX stream).
+func newSocketpairFiles(t *testing.T) (a, b *os.File) {
+	t.Helper()
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatalf("socketpair: %v", err)
+	}
+	return os.NewFile(uintptr(fds[0]), "a"), os.NewFile(uintptr(fds[1]), "b")
+}
+
+func TestWingHijackConn_SatisfiesNetConn(t *testing.T) {
+	var _ net.Conn = (*wingHijackConn)(nil) // compile-time assertion
+	af, bf := newSocketpairFiles(t)
+	defer af.Close()
+	defer bf.Close()
+	c := newWingHijackConn(af, int32(af.Fd()), "203.0.113.7:5555", context.Background())
+	if c.RemoteAddr().String() != "203.0.113.7:5555" {
+		t.Errorf("RemoteAddr = %q", c.RemoteAddr().String())
+	}
+	// Write on the adapter is readable on the peer.
+	if _, err := c.Write([]byte("ping")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := make([]byte, 4)
+	bf.SetReadDeadline(time.Now().Add(time.Second))
+	if _, err := bf.Read(got); err != nil || string(got) != "ping" {
+		t.Fatalf("peer read = %q, %v", got, err)
+	}
+}
+
+func TestWingHijackConn_CloseIsCoordinated(t *testing.T) {
+	af, bf := newSocketpairFiles(t)
+	defer bf.Close()
+	fd := int32(af.Fd())
+	c := newWingHijackConn(af, fd, "", context.Background())
+
+	// Close half-closes the socket (peer sees EOF) but does NOT close the fd:
+	// af must still be a valid fd afterward (hijackTakeover owns the real close).
+	if err := c.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := c.Close(); err != nil { // idempotent
+		t.Fatalf("second close: %v", err)
+	}
+	// fd still open: a syscall referencing it must not be EBADF.
+	var st syscall.Stat_t
+	if err := syscall.Fstat(int(fd), &st); err == syscall.EBADF {
+		t.Fatal("adapter Close physically closed the fd; it must not")
+	}
+	af.Close() // real close for the test
+}
+
+func TestWingHijackConn_Done(t *testing.T) {
+	af, bf := newSocketpairFiles(t)
+	defer af.Close()
+	defer bf.Close()
+	ctx, cancel := context.WithCancel(context.Background())
+	c := newWingHijackConn(af, int32(af.Fd()), "", ctx)
+	select {
+	case <-c.Done():
+		t.Fatal("Done fired before cancel")
+	default:
+	}
+	cancel()
+	select {
+	case <-c.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Done did not fire after cancel")
+	}
+}

--- a/wing_ws_test.go
+++ b/wing_ws_test.go
@@ -3,7 +3,9 @@
 package kruda
 
 import (
+	"bytes"
 	"context"
+	"io"
 	"net"
 	"os"
 	"syscall"
@@ -79,5 +81,70 @@ func TestWingHijackConn_Done(t *testing.T) {
 	case <-c.Done():
 	case <-time.After(time.Second):
 		t.Fatal("Done did not fire after cancel")
+	}
+}
+
+func TestWingHijackWriter_HijackSeedsLeftover(t *testing.T) {
+	af, bf := newSocketpairFiles(t)
+	defer af.Close()
+	defer bf.Close()
+	resp := acquireResponse()
+	defer releaseResponse(resp)
+	leftover := []byte("FRAME-BYTES")
+	hw := newWingHijackWriter(resp, af, int32(af.Fd()), leftover, "", context.Background())
+
+	nc, brw, err := hw.Hijack()
+	if err != nil {
+		t.Fatalf("hijack: %v", err)
+	}
+	if nc == nil || brw == nil {
+		t.Fatal("hijack returned nil conn/brw")
+	}
+	if !hw.hijacked {
+		t.Error("hijacked flag not set")
+	}
+	// The reader must serve leftover first, before any live fd read.
+	got := make([]byte, len(leftover))
+	if _, err := io.ReadFull(brw.Reader, got); err != nil {
+		t.Fatalf("read leftover: %v", err)
+	}
+	if string(got) != "FRAME-BYTES" {
+		t.Errorf("leftover = %q, want FRAME-BYTES", got)
+	}
+	// Second Hijack must error (already hijacked).
+	if _, _, err := hw.Hijack(); err == nil {
+		t.Error("second Hijack should error")
+	}
+	// Write after hijack must be rejected.
+	if _, err := hw.Write([]byte("x")); err == nil {
+		t.Error("Write after hijack should return an error")
+	}
+}
+
+func TestWingHijackWriter_BuffersWhenNotHijacked(t *testing.T) {
+	af, bf := newSocketpairFiles(t)
+	defer af.Close()
+	defer bf.Close()
+	resp := acquireResponse()
+	defer releaseResponse(resp)
+	hw := newWingHijackWriter(resp, af, int32(af.Fd()), nil, "", context.Background())
+
+	// A normal handler response buffers into the wrapped wingResponse; nothing
+	// is hijacked and nothing hits the socket until hijackTakeover serializes it.
+	hw.WriteHeader(400)
+	hw.Header().Set("Content-Type", "application/json")
+	if _, err := hw.Write([]byte(`{"error":"bad upgrade"}`)); err != nil {
+		t.Fatal(err)
+	}
+	if hw.hijacked {
+		t.Error("must not be hijacked")
+	}
+	// buildZeroCopy on the wrapped resp yields a well-formed 400 response.
+	data := resp.buildZeroCopy()
+	if !bytes.HasPrefix(data, []byte("HTTP/1.1 400")) {
+		t.Fatalf("expected 400 status line, got %q", data[:min(24, len(data))])
+	}
+	if !bytes.Contains(data, []byte(`{"error":"bad upgrade"}`)) {
+		t.Fatalf("buffered body missing: %q", data)
 	}
 }

--- a/wing_ws_wing_test.go
+++ b/wing_ws_wing_test.go
@@ -205,6 +205,15 @@ func TestWSOverWing_ShutdownDrainsBlockedHandlers(t *testing.T) {
 		// write iteration.
 		time.Sleep(100 * time.Millisecond)
 
+		// Guard against a vacuous pass: if the handler has already finished, the
+		// Write never actually blocked (nothing for Shutdown to drain), so this
+		// subtest would prove nothing about SHUT_RDWR waking a blocked writer.
+		select {
+		case <-handlerDone:
+			t.Fatal("write handler exited before Shutdown — Write never blocked, drain is unproven")
+		default:
+		}
+
 		ctx, cancel := context.WithTimeout(context.Background(), shutdownDeadline)
 		defer cancel()
 		start := time.Now()

--- a/wing_ws_wing_test.go
+++ b/wing_ws_wing_test.go
@@ -5,6 +5,7 @@ package kruda
 import (
 	"bufio"
 	"context"
+	"fmt"
 	"net"
 	"net/http"
 	"testing"
@@ -69,5 +70,292 @@ func TestWingHijack_RejectUpgradeWithBody(t *testing.T) {
 	}
 	if resp.StatusCode != 400 {
 		t.Errorf("expected 400 for hijack route with body, got %d", resp.StatusCode)
+	}
+}
+
+// wsHijackDoner is the interface wingHijackConn exposes so a handler blocked in
+// app logic (no pending socket call) can select on server shutdown. Mirrors the
+// "doner" interface contrib/ws.Conn asserts against its rwc.
+type wsHijackDoner interface {
+	Done() <-chan struct{}
+}
+
+// dialRawHijack dials addr and performs the plain-HTTP handshake that the /ws
+// route expects (no real WebSocket framing needed — the handler hijacks the
+// connection before ever looking at the request beyond routing, so a minimal
+// GET is enough to reach the handler).
+func dialRawHijack(t *testing.T, addr string) net.Conn {
+	t.Helper()
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	req := "GET /ws HTTP/1.1\r\nHost: x\r\n\r\n"
+	if _, err := conn.Write([]byte(req)); err != nil {
+		t.Fatalf("write handshake: %v", err)
+	}
+	return conn
+}
+
+// TestWSOverWing_ShutdownDrainsBlockedHandlers is the Phase 4 shutdown arbiter:
+// a hijacked handler blocked in read, in write, or in app logic (no socket call
+// at all) must ALL drain within the Shutdown deadline, proving cleanup()'s
+// SHUT_RDWR + conn-context cancel (commit bc5de18) actually wake every shape of
+// blocked handler contrib/ws can produce.
+func TestWSOverWing_ShutdownDrainsBlockedHandlers(t *testing.T) {
+	const shutdownDeadline = 2 * time.Second
+
+	t.Run("blocked_in_read", func(t *testing.T) {
+		ready := make(chan struct{})
+		handlerDone := make(chan struct{})
+
+		app := New(Wing())
+		app.Get("/ws", func(c *Ctx) error {
+			w := c.ResponseWriter()
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				return c.Text("no hijack")
+			}
+			nc, _, err := hj.Hijack()
+			if err != nil {
+				return nil
+			}
+			defer close(handlerDone)
+			close(ready)
+			buf := make([]byte, 16)
+			nc.Read(buf) // client sends nothing; SHUT_RDWR must wake this with EOF/error
+			return nil
+		}, Hijack)
+		app.Compile()
+		addr, _ := startWingHijackServer(t, app) // Shutdown driven manually below
+
+		conn := dialRawHijack(t, addr)
+		defer conn.Close()
+
+		select {
+		case <-ready:
+		case <-time.After(2 * time.Second):
+			t.Fatal("handler never reached the blocked-read state")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownDeadline)
+		defer cancel()
+		start := time.Now()
+		err := app.transport.Shutdown(ctx)
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Errorf("Shutdown returned error: %v", err)
+		}
+		if elapsed > shutdownDeadline {
+			t.Errorf("Shutdown took %v, exceeding deadline %v", elapsed, shutdownDeadline)
+		}
+
+		select {
+		case <-handlerDone:
+		case <-time.After(shutdownDeadline):
+			t.Fatal("handler blocked in Read did not return within the shutdown deadline")
+		}
+	})
+
+	t.Run("blocked_in_write", func(t *testing.T) {
+		ready := make(chan struct{})
+		handlerDone := make(chan struct{})
+
+		app := New(Wing())
+		app.Get("/ws", func(c *Ctx) error {
+			w := c.ResponseWriter()
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				return c.Text("no hijack")
+			}
+			nc, _, err := hj.Hijack()
+			if err != nil {
+				return nil
+			}
+			defer close(handlerDone)
+			close(ready)
+			big := make([]byte, 64*1024)
+			// Client never reads; once the kernel send buffer + the client's
+			// unread-but-full receive buffer back up, Write blocks. SHUT_RDWR
+			// must wake it (EPIPE/ECONNRESET) rather than let it hang forever.
+			for {
+				if _, werr := nc.Write(big); werr != nil {
+					return nil
+				}
+			}
+		}, Hijack)
+		app.Compile()
+		addr, _ := startWingHijackServer(t, app)
+
+		conn := dialRawHijack(t, addr)
+		defer conn.Close()
+		// Shrink the client's receive buffer and never read, so the server's
+		// write side backs up and blocks quickly instead of needing megabytes.
+		if tc, ok := conn.(*net.TCPConn); ok {
+			_ = tc.SetReadBuffer(1024)
+		}
+
+		select {
+		case <-ready:
+		case <-time.After(2 * time.Second):
+			t.Fatal("handler never reached the blocked-write state")
+		}
+		// Give the handler a moment to actually fill the socket buffers and
+		// land inside a blocking Write, not just start its first (non-blocking)
+		// write iteration.
+		time.Sleep(100 * time.Millisecond)
+
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownDeadline)
+		defer cancel()
+		start := time.Now()
+		err := app.transport.Shutdown(ctx)
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Errorf("Shutdown returned error: %v", err)
+		}
+		if elapsed > shutdownDeadline {
+			t.Errorf("Shutdown took %v, exceeding deadline %v", elapsed, shutdownDeadline)
+		}
+
+		select {
+		case <-handlerDone:
+		case <-time.After(shutdownDeadline):
+			t.Fatal("handler blocked in Write did not return within the shutdown deadline")
+		}
+	})
+
+	t.Run("blocked_in_app_logic", func(t *testing.T) {
+		ready := make(chan struct{})
+		handlerDone := make(chan struct{})
+		doneFired := make(chan struct{})
+
+		app := New(Wing())
+		app.Get("/ws", func(c *Ctx) error {
+			w := c.ResponseWriter()
+			hj, ok := w.(http.Hijacker)
+			if !ok {
+				return c.Text("no hijack")
+			}
+			nc, _, err := hj.Hijack()
+			if err != nil {
+				return nil
+			}
+			defer close(handlerDone)
+			d, ok := nc.(wsHijackDoner)
+			if !ok {
+				close(ready)
+				return fmt.Errorf("hijacked conn does not expose Done()")
+			}
+			close(ready)
+			// No socket call at all: only the conn-context cancel (Task 6 /
+			// commit bc5de18) can wake this handler.
+			select {
+			case <-d.Done():
+				close(doneFired)
+				return nil
+			case <-time.After(time.Hour):
+				return nil // test fails below on the doneFired/handlerDone assertions
+			}
+		}, Hijack)
+		app.Compile()
+		addr, _ := startWingHijackServer(t, app)
+
+		conn := dialRawHijack(t, addr)
+		defer conn.Close()
+
+		select {
+		case <-ready:
+		case <-time.After(2 * time.Second):
+			t.Fatal("handler never reached the blocked-app-logic state")
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), shutdownDeadline)
+		defer cancel()
+		start := time.Now()
+		err := app.transport.Shutdown(ctx)
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Errorf("Shutdown returned error: %v", err)
+		}
+		if elapsed > shutdownDeadline {
+			t.Errorf("Shutdown took %v, exceeding deadline %v", elapsed, shutdownDeadline)
+		}
+
+		select {
+		case <-doneFired:
+		case <-time.After(shutdownDeadline):
+			t.Fatal("conn.Done() did not fire within the shutdown deadline")
+		}
+		select {
+		case <-handlerDone:
+		case <-time.After(shutdownDeadline):
+			t.Fatal("handler blocked in app logic did not return within the shutdown deadline")
+		}
+	})
+}
+
+// TestWSOverWing_FdLifecycle churns hijack connections (open -> handshake ->
+// close) under -race and asserts the server survives cleanly, i.e. the taken-
+// over fd is closed exactly once per connection with no leak, double-close, or
+// recycle race (mirrors wing_shutdown_fd_test.go's finalizer-based technique,
+// scoped here to steady-state churn rather than shutdown).
+func TestWSOverWing_FdLifecycle(t *testing.T) {
+	const iterations = 40
+
+	handlerDone := make(chan struct{}, iterations)
+
+	app := New(Wing())
+	app.Get("/ws", func(c *Ctx) error {
+		w := c.ResponseWriter()
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return c.Text("no hijack")
+		}
+		nc, _, err := hj.Hijack()
+		if err != nil {
+			return nil
+		}
+		defer func() { handlerDone <- struct{}{} }()
+		buf := make([]byte, 16)
+		nc.Write([]byte("hello\n"))
+		nc.Read(buf) // returns once the client closes its side
+		nc.Close()
+		return nil
+	}, Hijack)
+	app.Compile()
+	addr, stop := startWingHijackServer(t, app)
+	defer stop()
+
+	for i := 0; i < iterations; i++ {
+		conn := dialRawHijack(t, addr)
+		conn.SetDeadline(time.Now().Add(2 * time.Second))
+		br := bufio.NewReader(conn)
+		line, err := br.ReadString('\n')
+		if err != nil || line != "hello\n" {
+			t.Fatalf("iter %d: unexpected handshake read: line=%q err=%v", i, line, err)
+		}
+		conn.Close() // triggers the server-side Read to return, closing the fd exactly once
+
+		select {
+		case <-handlerDone:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("iter %d: handler did not complete after client close", i)
+		}
+	}
+
+	// One more connection after the churn proves no fd leak/recycle race left
+	// the listener or worker in a bad state.
+	conn := dialRawHijack(t, addr)
+	conn.SetDeadline(time.Now().Add(2 * time.Second))
+	br := bufio.NewReader(conn)
+	line, err := br.ReadString('\n')
+	if err != nil || line != "hello\n" {
+		t.Fatalf("post-churn: unexpected handshake read: line=%q err=%v", line, err)
+	}
+	conn.Close()
+	select {
+	case <-handlerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("post-churn: handler did not complete after client close")
 	}
 }

--- a/wing_ws_wing_test.go
+++ b/wing_ws_wing_test.go
@@ -1,0 +1,73 @@
+//go:build linux || darwin
+
+package kruda
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// startWingHijackServer compiles app and serves it over a real Wing transport
+// on a loopback port, returning the dial address and a stop func. app MUST be
+// built with New(Wing()) so app.transport is the Wing transport. Mirrors the
+// bring-up idiom in startWingApp (wing_stream_integration_test.go); reused by
+// later WebSocket-on-Wing tasks.
+func startWingHijackServer(t *testing.T, app *App) (string, func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	addr := ln.Addr().String()
+	ln.Close() // let the transport bind so a successful dial means it is accepting
+	go func() { _ = app.transport.ListenAndServe(addr, app) }()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if derr == nil {
+			c.Close()
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return addr, func() { _ = app.transport.Shutdown(context.Background()) }
+}
+
+// TestWingHijack_RejectUpgradeWithBody verifies that a Hijack-preset route
+// (WebSocket upgrade) rejects a request carrying a body with a clean 400
+// instead of dispatching inline (where the accumulated-body writer is not an
+// http.Hijacker and Upgrade() would fail opaquely).
+func TestWingHijack_RejectUpgradeWithBody(t *testing.T) {
+	app := New(Wing()) // force Wing on every platform (kqueue on macOS, epoll on Linux)
+	app.Get("/ws", func(c *Ctx) error { return c.Text("unreachable") }, Hijack)
+	app.Compile()
+	addr, stop := startWingHijackServer(t, app)
+	defer stop()
+
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	// Split header/body across two writes so the server's first parse attempt
+	// sees an incomplete body and enters accumulation (beginBodyAccum /
+	// dispatchAccumulated) instead of parsing the whole request in one shot.
+	head := "GET /ws HTTP/1.1\r\nHost: x\r\nContent-Length: 5\r\n\r\n"
+	conn.Write([]byte(head))
+	time.Sleep(50 * time.Millisecond)
+	conn.Write([]byte("hello"))
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != 400 {
+		t.Errorf("expected 400 for hijack route with body, got %d", resp.StatusCode)
+	}
+}

--- a/wing_ws_wing_test.go
+++ b/wing_ws_wing_test.go
@@ -137,6 +137,14 @@ func TestWSOverWing_ShutdownDrainsBlockedHandlers(t *testing.T) {
 		case <-time.After(2 * time.Second):
 			t.Fatal("handler never reached the blocked-read state")
 		}
+		// Guard against a vacuous pass: the client sent nothing after the
+		// handshake, so the handler must still be parked in Read when we call
+		// Shutdown — only SHUT_RDWR can wake it.
+		select {
+		case <-handlerDone:
+			t.Fatal("read handler exited before Shutdown — Read did not block, drain is unproven")
+		default:
+		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), shutdownDeadline)
 		defer cancel()

--- a/wing_ws_wing_test.go
+++ b/wing_ws_wing_test.go
@@ -116,13 +116,16 @@ func TestWSOverWing_AsyncHijackOutlivesHandler(t *testing.T) {
 		if err != nil {
 			return nil
 		}
-		// Hand the connection to a goroutine and return immediately — the
-		// goroutine outlives this handler, then uses and closes the conn.
+		// Hand the connection to a goroutine that writes only AFTER this handler
+		// has returned (it blocks on handlerReturned, which the defer closes), so
+		// the after-return use is deterministic, not timing-dependent.
+		handlerReturned := make(chan struct{})
 		go func() {
-			time.Sleep(150 * time.Millisecond)
+			<-handlerReturned
 			_, _ = nc.Write([]byte("late"))
 			_ = nc.Close()
 		}()
+		defer close(handlerReturned)
 		return nil
 	}, Hijack)
 	app.Compile()

--- a/wing_ws_wing_test.go
+++ b/wing_ws_wing_test.go
@@ -97,6 +97,58 @@ func dialRawHijack(t *testing.T, addr string) net.Conn {
 	return conn
 }
 
+// TestWSOverWing_AsyncHijackOutlivesHandler proves the http.Hijacker ownership
+// fix: a handler may hijack, hand the connection to a goroutine, and RETURN,
+// with the goroutine still using the connection afterward. hijackTakeover must
+// hold the fd open until the app closes it — if it reclaimed the fd on
+// handler-return (and the kernel could recycle it), the goroutine's later write
+// would target the wrong fd. The goroutine writes AFTER the handler returns; the
+// client must receive those exact bytes.
+func TestWSOverWing_AsyncHijackOutlivesHandler(t *testing.T) {
+	app := New(Wing())
+	app.Get("/ws", func(c *Ctx) error {
+		w := c.ResponseWriter()
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return c.Text("no hijack")
+		}
+		nc, _, err := hj.Hijack()
+		if err != nil {
+			return nil
+		}
+		// Hand the connection to a goroutine and return immediately — the
+		// goroutine outlives this handler, then uses and closes the conn.
+		go func() {
+			time.Sleep(150 * time.Millisecond)
+			_, _ = nc.Write([]byte("late"))
+			_ = nc.Close()
+		}()
+		return nil
+	}, Hijack)
+	app.Compile()
+	addr, stop := startWingHijackServer(t, app)
+	defer stop()
+
+	conn := dialRawHijack(t, addr)
+	defer conn.Close()
+
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	got := make([]byte, 0, 8)
+	buf := make([]byte, 8)
+	for len(got) < 4 {
+		n, err := conn.Read(buf)
+		if n > 0 {
+			got = append(got, buf[:n]...)
+		}
+		if err != nil {
+			break
+		}
+	}
+	if string(got) != "late" {
+		t.Fatalf("async write after handler-return = %q, want \"late\" — fd was reclaimed early?", got)
+	}
+}
+
 // TestWSOverWing_ShutdownDrainsBlockedHandlers is the Phase 4 shutdown arbiter:
 // a hijacked handler blocked in read, in write, or in app logic (no socket call
 // at all) must ALL drain within the Shutdown deadline, proving cleanup()'s

--- a/wing_ws_wing_test.go
+++ b/wing_ws_wing_test.go
@@ -19,21 +19,22 @@ import (
 // later WebSocket-on-Wing tasks.
 func startWingHijackServer(t *testing.T, app *App) (string, func()) {
 	t.Helper()
+	// Serve the OPEN listener directly (no close-then-rebind port race, which is
+	// flaky on macOS): the port stays bound and a dial succeeds as soon as the
+	// transport accepts.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
 	addr := ln.Addr().String()
-	ln.Close() // let the transport bind so a successful dial means it is accepting
-	go func() { _ = app.transport.ListenAndServe(addr, app) }()
+	go func() { _ = app.transport.Serve(ln, app) }()
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		c, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond)
-		if derr == nil {
+		if c, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond); derr == nil {
 			c.Close()
 			break
 		}
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(5 * time.Millisecond)
 	}
 	return addr, func() { _ = app.transport.Shutdown(context.Background()) }
 }


### PR DESCRIPTION
## Summary

Makes WebSocket (RFC 6455) work on the **Wing** transport (Kruda's default on Linux), which previously rejected it. The existing `contrib/ws` protocol code is reused unchanged — the new code is a Wing-side adapter that hands a taken-over connection to `contrib/ws` as a `net.Conn` + `*bufio.ReadWriter`, plus the fd-lifecycle and shutdown coordination Wing's event-loop architecture requires.

> **Stacked on #160** (frame-parser hardening). Base is `fix/ws-frame-hardening`; it will retarget to `main` once #160 merges. Review #160 first.

## What it adds

- **`ws.HandleFunc(app, "/ws", handler)`** — one call, identical on every transport. Internally it registers the route with a new generic `kruda.Hijack` preset (`Preset{Dispatch: Takeover, ResponseMode: responseHijack}`), which gives the route's `c.ResponseWriter()` a standard `http.Hijacker`. net/http and fasthttp ignore route presets, so the preset is a harmless no-op there; only Wing acts on it. The existing `Upgrader.Upgrade` still works for manual control.
- **Wing hijack adapter** (`wing_ws.go`): `Hijack()` detaches the takeover fd (an `*os.File` on the runtime netpoller, exactly like the SSE/`kruda.Stream` path), wraps it in a minimal `net.Conn`, and seeds the returned reader with any bytes the client pipelined past the handshake, so a first WS frame in the same TCP segment is not lost.
- Dispatches via **Takeover** — the inline hot path is untouched (alloc guards stay green).

## Correctness / safety

- **fd lifecycle honors the `http.Hijacker` ownership contract.** After hijack the connection belongs to the caller, which may keep using it from a goroutine that outlives the route handler; `hijackTakeover` holds the fd open until the app closes the connection (or the server shuts down), then does the single physical close. A close-barrier synchronizes concurrent closers so a late `Conn.Close()` can never `Shutdown` a recycled fd.
- **Shutdown drain:** Wing wakes I/O-blocked handlers (`SHUT_RDWR`) and signals `conn.Done()` so a handler blocked in application logic can exit cooperatively.
- **Bodied / malformed upgrades:** a WS upgrade is a bodyless GET; a bodied upgrade is rejected consistently regardless of TCP packetization.
- **`c.Header("Connection")` fix:** Wing previously parsed `Connection` only for keep-alive and dropped the raw value, so `c.Header("Connection")` returned `""` — which broke the upgrade handshake on Wing. Now retained (first-wins, matching net/http's `http.Header.Get`) via the same zero-copy path as `Host`/`Accept`, so the hot path stays zero-alloc.
- net/http behavior is byte-for-byte unchanged (shared `upgradeHijacker` helper; all existing `contrib/ws` tests pass unmodified).

## Testing

- Real-Wing loopback integration (`New(kruda.Wing())`): handshake → echo, ping/pong, close handshake, pipelined-first-frame, and an async-hijack-outlives-handler test.
- Shutdown-drain gate: a handler blocked in read, write, and app-logic all drain within the deadline; fd-lifecycle churn under `-race`.
- Full core and `contrib/ws` suites pass under `-race`; alloc guards green.
- Reviewed per-task + a whole-branch review + four rounds of external (codex) review of the fd-lifecycle; final verdict SHIP.

## Note for release

`contrib/ws` now depends on the unreleased `kruda.Hijack`, so `contrib/ws/go.mod` carries a dev-only `replace => ../..` (documented inline). **Remove it and bump the `require` to the tagged core version before re-tagging `contrib/ws`** — same pattern `contrib/observability` used for v1.4.0.
