### PR TITLE
chore(release): date-stamp v1.6.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.6.0] — 2026-07-04
+
 ### Security
 
 - **`contrib/ws` frame-parser hardening (RFC 6455 §5).** `readFrame` now rejects


### PR DESCRIPTION
Rename the [Unreleased] section to [1.6.0] — 2026-07-04 ahead of tagging. CHANGELOG only.