### PR TITLE
chore(release): contrib/ws requires core v1.6.0

### DIFF
--- a/contrib/ws/go.mod
+++ b/contrib/ws/go.mod
@@ -2,14 +2,7 @@ module github.com/go-kruda/kruda/contrib/ws
 
 go 1.25.11
 
-require github.com/go-kruda/kruda v1.2.0
-
-// DEV-ONLY: contrib/ws now uses kruda.Hijack, which is in unreleased core.
-// RELEASE CHECKLIST: after core is tagged, bump the require above to that
-// version and DELETE this replace before re-tagging contrib/ws (contrib is not
-// in the root go.work, so this replace — not the workspace — is what resolves
-// the local core during development; matches the contrib/observability pattern).
-replace github.com/go-kruda/kruda => ../..
+require github.com/go-kruda/kruda v1.6.0
 
 require (
 	github.com/andybalholm/brotli v1.2.0 // indirect

--- a/contrib/ws/go.sum
+++ b/contrib/ws/go.sum
@@ -12,8 +12,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-kruda/kruda v1.2.0 h1:7IjYlLkQZlF7Y2xhQBIIb/IqMJ2HIo84n77q5M+drmw=
-github.com/go-kruda/kruda v1.2.0/go.mod h1:UOhZJk+3v2r5xgu4bp/MeQ8r5fDj1IeulhkpK38dqyo=
+github.com/go-kruda/kruda v1.6.0 h1:zsRalIuHj+T0fxRUQdolTaUj7cOyaVAdFERU1kW4dfM=
+github.com/go-kruda/kruda v1.6.0/go.mod h1:dSfysslVBnQt/u+o5nVDEU587OK8zZKVT94jX4MgkTU=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
 github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=


### PR DESCRIPTION
Bump contrib/ws to require core v1.6.0 (which now ships WebSocket-on-Wing) and drop the dev-only replace => ../... Verified building/testing against the published core v1.6.0. Precedes the contrib/ws/v1.3.0 tag.