### PR TITLE
docs: Wing protocol-support matrix, production TLS, and Use()-after-routes warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Startup warning when `Use()` is called after routes are registered (the
+  middleware would silently not apply to the already-registered routes).
+- Docs: Wing protocol support matrix (`docs/guide/wing-protocol-support.md`) and
+  production TLS deployment guidance (terminate in front of Wing).
+
+### Changed
+
+- Removed the stale `transport/wing v1.1.3` require from `go.mod` (the shim
+  directory was removed in v1.3.0; nothing imports it).
+- Docs: corrected the stale "Wing doesn't support SSE" transport limitation —
+  SSE works via the `kruda.Stream` preset since v1.5.0.
+
 ## [1.6.0] — 2026-07-04
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ These figures were measured at the v1.3.1 runtime and **revalidated at the v1.4.
 
 Wing transport uses raw `epoll` + `eventfd` on Linux and bypasses both fasthttp and net/http. macOS defaults to fasthttp.
 
+Production HTTPS: terminate TLS at a proxy/load balancer in front of Wing, or use direct `WithTLS` which serves via net/http (these benchmark numbers then do not apply) — see the [transport guide](docs/guide/transport.md#production-tls-terminate-in-front-of-wing).
+
 ## Documentation
 
 - [API Reference (pkg.go.dev)](https://pkg.go.dev/github.com/go-kruda/kruda)

--- a/contrib/ws/ws_wing_test.go
+++ b/contrib/ws/ws_wing_test.go
@@ -17,27 +17,43 @@ import (
 )
 
 // listenWingApp starts app on a real loopback listener via Wing and returns its
-// address + a stop func. It serves the OPEN listener via app.Serve, so there is
-// no close-then-rebind port race (which is flaky on macOS): the port stays bound
-// the whole time and a dial succeeds as soon as the transport accepts.
+// address + a stop func. It grabs a free port, releases it, and lets Wing bind
+// it; that re-bind can transiently lose the port on a loaded CI box, so it
+// retries a fresh port when app.Listen returns early (bind fails before serving,
+// so a retry is safe), and only returns once a dial actually SUCCEEDS — never an
+// address the server isn't accepting on yet.
 func listenWingApp(t *testing.T, app *kruda.App) (addr string, stop func()) {
 	t.Helper()
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr = ln.Addr().String()
-	go func() { _ = app.Serve(ln) }()
-	// Readiness: the listener is already bound, so this succeeds promptly.
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if c, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond); derr == nil {
-			c.Close()
-			break
+	for attempt := 0; attempt < 12; attempt++ {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatal(err)
 		}
-		time.Sleep(5 * time.Millisecond)
+		addr = ln.Addr().String()
+		_ = ln.Close()
+		errc := make(chan error, 1)
+		go func() { errc <- app.Listen(addr) }()
+
+		deadline := time.Now().Add(3 * time.Second)
+		for {
+			select {
+			case <-errc:
+				goto retry // bind failed before serving — retry a fresh port
+			default:
+			}
+			if c, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond); derr == nil {
+				c.Close()
+				return addr, func() { _ = app.Shutdown(context.Background()) }
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("listenWingApp: bound but never accepting on %s", addr)
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	retry:
 	}
-	return addr, func() { _ = app.Shutdown(context.Background()) }
+	t.Fatal("listenWingApp: bind kept failing after retries")
+	return "", func() {}
 }
 
 func TestWSOverWing_Echo(t *testing.T) {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -50,6 +50,7 @@ export default defineConfig({
             { text: 'Auto CRUD', link: '/guide/auto-crud' },
             { text: 'DI Container', link: '/guide/di-container' },
             { text: 'Transport', link: '/guide/transport' },
+            { text: 'Wing Protocol Support', link: '/guide/wing-protocol-support' },
             { text: 'Security', link: '/guide/security' },
             { text: 'Performance', link: '/guide/performance' },
           ],

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -43,6 +43,7 @@ See the [DI Container guide](/guide/di-container) for details.
 | HTTP/2 | No | No | Yes (via TLS) |
 | Set-Cookie | Limited (fast path skips) | Yes | Yes |
 | SSE | Yes (via `kruda.Stream`) | No | Yes |
+| Direct TLS | Auto-falls back to net/http | Yes | Yes |
 | WebSocket | Yes (`ws.HandleFunc`) | No | Yes (`contrib/ws`) |
 | Default on | Linux | macOS | Windows |
 

--- a/docs/guide/transport.md
+++ b/docs/guide/transport.md
@@ -43,12 +43,35 @@ KRUDA_TRANSPORT=fasthttp ./myapp   # force fasthttp
 - Wing on Windows → auto-falls back to net/http
 - Unsupported OS → defaults to fasthttp (macOS) or net/http (Windows)
 
+## Production TLS: terminate in front of Wing {#production-tls-terminate-in-front-of-wing}
+
+Wing does not implement TLS. When `WithTLS` is configured, Kruda automatically
+serves through the net/http transport instead — you keep HTTPS and gain HTTP/2,
+but you are **no longer running Wing**, so Wing benchmark numbers do not apply to
+a direct-TLS deployment.
+
+To keep Wing's performance in production, terminate TLS in front of the app —
+nginx, Caddy, HAProxy, or a cloud load balancer — and let Kruda serve plaintext
+HTTP/1.1 behind it. This is the standard deployment shape for epoll-based Go
+servers. Two things to set:
+
+```go
+app := kruda.New(
+    kruda.WithTrustProxy(true), // client IPs come from X-Forwarded-For
+)
+```
+
+and make the proxy strip/overwrite inbound `X-Forwarded-For` so clients cannot
+spoof it. If you need TLS directly on the app process (no proxy), use
+`kruda.WithTLS(...)` and accept the net/http transport — that is the supported
+and honest trade.
+
 ## Wing limitations
 
 Wing is optimized for raw throughput. It intentionally skips some HTTP features:
 
 - **Prebuilt static responses bypass middleware** — `StaticText` and `StaticJSON` write route-level prebuilt responses directly. Use normal handlers when a response needs middleware, lifecycle hooks, CORS, cookies, or `WithSecureHeaders()`.
-- **No `http.Flusher`** — SSE streaming requires flushing, which Wing doesn't support.
+- **Incremental responses need a preset** — plain handlers write fixed `Content-Length` responses. SSE and chunked streaming (`c.SSE()` / `c.Stream()`) work on Wing via the `kruda.Stream` route preset, and WebSocket via `ws.HandleFunc` (the `kruda.Hijack` preset) — but a default route does not stream.
 - **No HTTP/2** — Wing speaks HTTP/1.1 only. Use `kruda.NetHTTP()` with TLS for HTTP/2.
 - **No chunked transfer encoding** — Wing pre-computes Content-Length.
 

--- a/docs/guide/wing-protocol-support.md
+++ b/docs/guide/wing-protocol-support.md
@@ -1,0 +1,33 @@
+# Wing Protocol Support Matrix
+
+Wing is a deliberate, high-performance **HTTP/1.1 subset**. This page is the
+authoritative statement of what it speaks. Anything marked "via net/http"
+means Kruda automatically serves through the net/http transport in that
+configuration — you keep correctness, you are just not running Wing.
+
+| Capability | Wing | Notes |
+|---|---|---|
+| HTTP/1.1 keep-alive | ✅ | Default |
+| HTTP/1.1 pipelining | ✅ | Responses written in request order |
+| Request header retention | ✅ All headers | 8 inline slots + heap spill; spills observable via `WingHeaderSpills()` |
+| Request size limits | ✅ | `BodyLimit` → 413, `HeaderLimit` (8 KB default) → 431 |
+| `Expect: 100-continue` | ✅ | Interim 100 sent when the body must be awaited |
+| Chunked **request** bodies (`Transfer-Encoding`) | ❌ → 501 | Send `Content-Length`; chunked uploads need net/http |
+| Chunked **response** bodies | ❌ (by design) | Fixed responses use `Content-Length`; incremental responses use the `Stream` preset (close-delimited, SSE-style) |
+| Trailers | ❌ | Not parsed, not emitted |
+| SSE / incremental streaming | ✅ | `c.SSE()` / `c.Stream()` with the `kruda.Stream` route preset (v1.5.0+) |
+| WebSocket | ✅ | `ws.HandleFunc(app, "/ws", handler)` — Wing hands the connection to `contrib/ws` via the `kruda.Hijack` preset (v1.6.0+) |
+| TLS / HTTPS | via net/http | `WithTLS` auto-falls back — see [Production TLS](/guide/transport#production-tls-terminate-in-front-of-wing) |
+| HTTP/2 | via net/http | Negotiated by net/http under TLS |
+| HTTP/3 | ❌ | Cancelled from the roadmap (v1.5.0) |
+| Proxy client IPs | ✅ | `X-Forwarded-For` / `X-Real-IP` honored only under `WithTrustProxy(true)` |
+| Accept-side DoS limits | ✅ | Connection cap, per-IP cap, accept-rate bucket (v1.4.0) |
+
+## Deployment guidance
+
+- **Linux + plaintext HTTP/1.1** (typically behind a TLS-terminating proxy or
+  load balancer): Wing — this is the configuration all published benchmarks use.
+- **Direct HTTPS / HTTP/2 / Windows**: net/http transport, selected
+  automatically.
+- Anything this table calls unsupported fails **loudly** (501/413/431), never
+  silently.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.25.11
 
 require (
 	github.com/bytedance/sonic v1.15.0
-	github.com/go-kruda/kruda/transport/wing v1.1.3
 	github.com/valyala/fasthttp v1.69.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,6 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-kruda/kruda/transport/wing v1.1.3 h1:aQjT1xKShTflqWqKsVkmBjlMQUw1XIvt1oOVfkLl7f8=
-github.com/go-kruda/kruda/transport/wing v1.1.3/go.mod h1:OAGzF+IcyPOinK2TrN+8uiVS7vcXYY+4AdIqxZvB/RQ=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=
 github.com/klauspost/compress v1.18.2/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=
 github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=

--- a/kruda.go
+++ b/kruda.go
@@ -54,6 +54,9 @@ type App struct {
 	startupMu         sync.Mutex
 	openAPIRegistered bool
 	containerStarted  bool
+
+	routesRegistered bool // set by addRoute; powers the late-Use() warning
+	lateUseWarned    bool // the late-Use() warning fires once per app
 }
 
 // New creates a new App with default config and applies the provided options.
@@ -237,6 +240,7 @@ func (app *App) All(path string, handler HandlerFunc, opts ...RouteOption) *App 
 
 // addRoute builds the pre-built handler chain and registers the route.
 func (app *App) addRoute(method, path string, handler HandlerFunc, opts ...RouteOption) {
+	app.routesRegistered = true
 	chain := buildChain(app.middleware, nil, handler)
 	app.router.addRoute(method, path, chain)
 
@@ -263,8 +267,13 @@ func (app *App) addRoute(method, path string, handler HandlerFunc, opts ...Route
 
 // Use appends global middleware to the App.
 // Middleware added via Use() only applies to routes registered AFTER this call.
-// Routes registered before Use() will not have this middleware in their chain.
+// Routes registered before Use() will not have this middleware in their chain;
+// doing so logs a one-time warning because it is almost always a mistake.
 func (app *App) Use(middleware ...HandlerFunc) *App {
+	if app.routesRegistered && !app.lateUseWarned {
+		app.lateUseWarned = true
+		slog.Warn("kruda: Use() called after routes were registered; the new middleware does NOT apply to already-registered routes")
+	}
 	app.middleware = append(app.middleware, middleware...)
 	return app
 }

--- a/use_warning_test.go
+++ b/use_warning_test.go
@@ -1,0 +1,47 @@
+package kruda
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestUse_AfterRoutesWarnsOnce documents the middleware-ordering contract:
+// Use() only affects routes registered after it. Calling Use() once routes
+// exist is almost always a mistake, so Kruda warns — once per app.
+func TestUse_AfterRoutesWarnsOnce(t *testing.T) {
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(old)
+
+	app := New()
+	app.Get("/a", func(c *Ctx) error { return c.Text("a") })
+	app.Use(func(c *Ctx) error { return c.Next() })
+	app.Use(func(c *Ctx) error { return c.Next() })
+
+	out := buf.String()
+	if !strings.Contains(out, "Use() called after routes") {
+		t.Errorf("expected a late-Use warning, got: %q", out)
+	}
+	if n := strings.Count(out, "Use() called after routes"); n != 1 {
+		t.Errorf("warning should fire exactly once per app, fired %d times", n)
+	}
+}
+
+// TestUse_BeforeRoutesDoesNotWarn guards against false positives.
+func TestUse_BeforeRoutesDoesNotWarn(t *testing.T) {
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, nil)))
+	defer slog.SetDefault(old)
+
+	app := New()
+	app.Use(func(c *Ctx) error { return c.Next() })
+	app.Get("/a", func(c *Ctx) error { return c.Text("a") })
+
+	if out := buf.String(); strings.Contains(out, "Use() called after routes") {
+		t.Errorf("Use() before routes must not warn, got: %q", out)
+	}
+}

--- a/wing_ws_wing_test.go
+++ b/wing_ws_wing_test.go
@@ -19,24 +19,41 @@ import (
 // later WebSocket-on-Wing tasks.
 func startWingHijackServer(t *testing.T, app *App) (string, func()) {
 	t.Helper()
-	// Serve the OPEN listener directly (no close-then-rebind port race, which is
-	// flaky on macOS): the port stays bound and a dial succeeds as soon as the
-	// transport accepts.
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	addr := ln.Addr().String()
-	go func() { _ = app.transport.Serve(ln, app) }()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if c, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond); derr == nil {
-			c.Close()
-			break
+	// Grab a free port, release it, and let Wing bind it. That re-bind can
+	// transiently lose the port on a loaded CI box, so retry a fresh port when
+	// ListenAndServe returns early (bind fails BEFORE it starts serving, so a
+	// retry is safe). Crucially, only return once a dial actually SUCCEEDS —
+	// never hand back an address the server isn't accepting on yet.
+	for attempt := 0; attempt < 12; attempt++ {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen: %v", err)
 		}
-		time.Sleep(5 * time.Millisecond)
+		addr := ln.Addr().String()
+		_ = ln.Close()
+		errc := make(chan error, 1)
+		go func() { errc <- app.transport.ListenAndServe(addr, app) }()
+
+		deadline := time.Now().Add(3 * time.Second)
+		for {
+			select {
+			case <-errc:
+				goto retry // bind failed before serving — retry a fresh port
+			default:
+			}
+			if c, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond); derr == nil {
+				c.Close()
+				return addr, func() { _ = app.transport.Shutdown(context.Background()) }
+			}
+			if time.Now().After(deadline) {
+				t.Fatalf("startWingHijackServer: bound but never accepting on %s", addr)
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+	retry:
 	}
-	return addr, func() { _ = app.transport.Shutdown(context.Background()) }
+	t.Fatal("startWingHijackServer: bind kept failing after retries")
+	return "", func() {}
 }
 
 // TestWingHijack_RejectUpgradeWithBody verifies that a Hijack-preset route


### PR DESCRIPTION
## Summary

The docs-honesty bundle (KRUDA-45): make Kruda's docs an honest, explicit statement of what Wing does and does not speak, add a first-class production-TLS deployment story, warn on the `Use()`-after-routes footgun, and drop a stale go.mod require. Everything is corrected to **post-v1.6.0** reality (WebSocket now works on Wing; header retention is 8 inline slots + spill; SSE is supported).

## Changes

- **`Use()`-after-routes startup warning** (`kruda.go`) — `Use()` only applies to routes registered after it; calling it once routes exist is almost always a mistake, so Kruda now logs a one-time `slog.Warn`. Covered by `use_warning_test.go` (warns once after routes; never warns on the happy path).
- **Wing protocol support matrix** (`docs/guide/wing-protocol-support.md`, new) — the authoritative statement of what Wing speaks, including WebSocket ✅ (`ws.HandleFunc`), SSE ✅ (`kruda.Stream`), all-header retention (8 inline + spill), chunked-request → 501, and "via net/http" rows for TLS/HTTP/2. Registered in the sidebar.
- **Production TLS positioning** (`docs/guide/transport.md`, `docs/faq.md`, `README.md`) — terminate TLS in front of Wing (proxy/LB) to keep its performance; direct `WithTLS` auto-falls back to net/http and forfeits Wing's benchmark numbers — stated as the honest trade. Also **corrected the stale "Wing doesn't support SSE" limitation** (SSE works via `kruda.Stream` since v1.5.0).
- **Dropped the stale `transport/wing v1.1.3` require** from `go.mod` (the shim was removed in v1.3.0; nothing imports it — only a comment in `doc.go` mentions it, and `go mod why` confirms the module doesn't need it).

## Testing

- Full core suite passes under `-race`; builds on all tags + `GOOS=windows`.
- `scripts/check-docs.sh` and `scripts/check-godoc.sh` green.

Ships in the next release (post-v1.6.0).
