### PR TITLE
docs: correct App.Serve socket-activation claim for Wing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   directory was removed in v1.3.0; nothing imports it).
 - Docs: corrected the stale "Wing doesn't support SSE" transport limitation —
   SSE works via the `kruda.Stream` preset since v1.5.0.
+- Docs: corrected `App.Serve` — it claimed systemd socket activation
+  unconditionally, but Wing (default on Linux) closes the passed listener and
+  re-binds one `SO_REUSEPORT` socket per worker, so it cannot serve an inherited
+  fd. The net/http and fasthttp transports serve the supplied fd directly; the
+  doc comment and transport guide now say which transports honor fd-passing.
 
 ## [1.6.0] — 2026-07-04
 

--- a/docs/guide/transport.md
+++ b/docs/guide/transport.md
@@ -74,5 +74,6 @@ Wing is optimized for raw throughput. It intentionally skips some HTTP features:
 - **Incremental responses need a preset** — plain handlers write fixed `Content-Length` responses. SSE and chunked streaming (`c.SSE()` / `c.Stream()`) work on Wing via the `kruda.Stream` route preset, and WebSocket via `ws.HandleFunc` (the `kruda.Hijack` preset) — but a default route does not stream.
 - **No HTTP/2** — Wing speaks HTTP/1.1 only. Use `kruda.NetHTTP()` with TLS for HTTP/2.
 - **No chunked transfer encoding** — Wing pre-computes Content-Length.
+- **`App.Serve(listener)` re-binds on Wing** — Wing serves one `SO_REUSEPORT` socket per worker, so it adopts the listener's *address* and closes the passed file descriptor rather than serving it. For systemd socket activation or graceful-restart fd-passing, use `kruda.NetHTTP()` (or fasthttp on macOS), which serve the supplied fd directly.
 
 For apps that mix high-throughput API routes with session/SSE routes, run two instances or use net/http for the full app.

--- a/kruda.go
+++ b/kruda.go
@@ -318,12 +318,19 @@ func (app *App) Listen(addr string) error {
 }
 
 // Serve runs the app on a pre-created net.Listener instead of binding an address
-// itself. Useful for graceful restart, systemd socket activation, or tests that
-// need the bound address before the server starts accepting (avoiding a
-// close-then-rebind race). It compiles the routes and starts the DI container,
-// then serves until the transport is shut down via Shutdown, whose result it
-// returns. Unlike Listen it installs no OS signal handler — the caller owns the
-// lifecycle and calls Shutdown to stop.
+// itself. It compiles the routes and starts the DI container, then serves until
+// the transport is shut down via Shutdown, whose result it returns. Unlike Listen
+// it installs no OS signal handler — the caller owns the lifecycle and calls
+// Shutdown to stop.
+//
+// Transport caveat: the net/http and fasthttp transports serve the supplied
+// listener's file descriptor directly, so Serve honors an inherited or
+// externally-owned fd there — suitable for graceful restart and systemd socket
+// activation. Wing (the default on Linux) does not: it adopts only the listener's
+// address, closes the supplied fd, and re-binds one SO_REUSEPORT socket per worker.
+// On Wing, Serve is fine for "bind this address" uses (and for tests needing the
+// address before accept), but it cannot serve a passed-in fd — use kruda.NetHTTP()
+// for true fd-passing.
 func (app *App) Serve(ln net.Listener) error {
 	if err := app.compile(); err != nil {
 		return err


### PR DESCRIPTION
`App.Serve` claimed systemd socket activation unconditionally, but on **Wing** (the default transport on Linux) `Transport.Serve` closes the passed listener and re-binds one `SO_REUSEPORT` socket per worker (`wing_transport.go:162`) — so an inherited/externally-owned fd is **not** served. The **net/http** and **fasthttp** transports call `srv.Serve(ln)` directly and do honor the passed fd.

This corrects the public doc so users targeting systemd socket activation or graceful-restart fd-passing on Linux aren't silently misled into a rebind.

### Changes (docs-only, no behavior change)
- `App.Serve` doc comment: state which transports honor the passed fd; point fd-passing users to `kruda.NetHTTP()`.
- `docs/guide/transport.md`: add a Wing-limitations bullet.
- `CHANGELOG.md`: `[Unreleased]` entry.

Follows the v1.6.0 docs-honesty bundle (#164). Ships with the next tag under `[Unreleased]`.