### PR TITLE
docs(mcp): update AI-facing docs for streaming/WebSocket on Wing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   re-binds one `SO_REUSEPORT` socket per worker, so it cannot serve an inherited
   fd. The net/http and fasthttp transports serve the supplied fd directly; the
   doc comment and transport guide now say which transports honor fd-passing.
+- MCP server (`kruda mcp`): corrected stale AI-facing guidance that predated the
+  streaming/WebSocket presets. `kruda_docs` gains a `websocket` topic and its
+  `sse`/`wing` topics now document the `kruda.Stream` preset (v1.5.0+) instead of
+  claiming SSE/streaming has no Wing preset; `kruda_suggest_wing` now suggests
+  `kruda.Stream` for SSE/streaming routes and `kruda.Hijack` for WebSocket routes
+  instead of "none". Keeps AI-generated code aligned with real-time on Wing.
 
 ## [1.6.0] — 2026-07-04
 

--- a/cmd/kruda/cmd_mcp.go
+++ b/cmd/kruda/cmd_mcp.go
@@ -616,7 +616,8 @@ func toolSuggestWing(args map[string]any) (string, error) {
 	sb.WriteString("  kruda.JSON      — JSON serialization endpoints\n")
 	sb.WriteString("  kruda.DB        — DB/Redis read-style queries; benchmark write-heavy routes separately\n")
 	sb.WriteString("  kruda.Render    — HTML template rendering\n")
-	sb.WriteString("\nStreaming and SSE routes do not have a Wing route preset; keep them on a normal handler route and choose transport-level compatibility deliberately.\n")
+	sb.WriteString("  kruda.Stream    — SSE/streaming (c.SSE / c.Stream); flushes incrementally on Wing (v1.5.0+)\n")
+	sb.WriteString("  kruda.Hijack    — WebSocket / raw-conn takeover; ws.HandleFunc applies it automatically (v1.6.0+)\n")
 
 	return sb.String(), nil
 }
@@ -624,9 +625,14 @@ func toolSuggestWing(args map[string]any) (string, error) {
 func suggestPreset(r routeInfo) (string, string) {
 	lpath := strings.ToLower(r.Path)
 
+	// WebSocket
+	if strings.Contains(lpath, "/ws") || strings.Contains(lpath, "/websocket") {
+		return "kruda.Hijack", "WebSocket upgrade; ws.HandleFunc applies kruda.Hijack automatically"
+	}
+
 	// SSE / streaming
 	if strings.Contains(lpath, "/sse") || strings.Contains(lpath, "/stream") || strings.Contains(lpath, "/events") {
-		return "none", "streaming/SSE route; no Wing route preset"
+		return "kruda.Stream", "SSE/streaming route; kruda.Stream flushes incrementally on Wing"
 	}
 
 	// Health / ping / status
@@ -907,7 +913,9 @@ kruda.Spear.With(kruda.Dispatch(kruda.Spawn)).
 
 Presets are optional — routes work fine without them.
 Benchmark write-heavy routes with your DB pool, p99 target, and error gate before treating them as query-profile routes.
-Streaming and SSE routes do not have a Wing route preset; keep them on normal handlers and choose the transport for compatibility deliberately.`,
+Streaming, SSE, and WebSocket DO have Wing presets: kruda.Stream for c.SSE()/c.Stream() (v1.5.0+),
+and kruda.Hijack for WebSocket — applied automatically by ws.HandleFunc (v1.6.0+). See the "sse" and
+"websocket" doc topics.`,
 
 	"config": `# Configuration
 
@@ -978,19 +986,67 @@ source code context, similar to Next.js error pages.`,
 	"sse": `# Server-Sent Events (SSE)
 
 ` + "```" + `go
+// On Wing (default on Linux) add the kruda.Stream preset so the route can flush
+// incrementally. net/http streams with no preset; fasthttp does not stream.
 app.Get("/events", func(c *kruda.Ctx) error {
     return c.SSE(func(stream *kruda.SSEStream) error {
         for i := 0; i < 10; i++ {
-            stream.Event("counter", map[string]int{"value": i})
+            if err := stream.Event("counter", map[string]int{"value": i}); err != nil {
+                return err // client disconnected
+            }
             time.Sleep(time.Second)
         }
         return nil
     })
-})
+}, kruda.Stream)
 ` + "```" + `
 
-SSE automatically sets Content-Type: text/event-stream and flushes after each event.
-SSE does not have a Wing route hint. Keep it on a normal handler route and choose the transport for compatibility deliberately.`,
+SSE sets Content-Type: text/event-stream and flushes after each event.
+Transports: Wing needs the kruda.Stream preset (v1.5.0+); net/http works with no preset;
+fasthttp (default on macOS) does not support streaming — use kruda.NetHTTP() on macOS/dev.
+SSEStream methods: Event(name, data), Data(data), EventWithID(id, name, data), Comment(text),
+Retry(ms), Done() (closes when the client disconnects). c.Stream(io.Reader) streams raw bytes
+the same way (also needs kruda.Stream on Wing).`,
+
+	"websocket": `# WebSocket (contrib/ws)
+
+Needs the contrib/ws module (separate go.mod):
+` + "```" + `bash
+go get github.com/go-kruda/kruda/contrib/ws
+` + "```" + `
+
+` + "```" + `go
+import "github.com/go-kruda/kruda/contrib/ws"
+
+// One-liner registration. HandleFunc wires the kruda.Hijack preset automatically,
+// so the same code runs on Wing (Linux), fasthttp (macOS), and net/http.
+ws.HandleFunc(app, "/ws", func(conn *ws.Conn) {
+    defer conn.Close(ws.CloseNormalClosure, "bye")
+    for {
+        msgType, data, err := conn.ReadMessage()
+        if err != nil {
+            return // client disconnected
+        }
+        if err := conn.WriteMessage(msgType, data); err != nil {
+            return
+        }
+    }
+}, ws.Config{MaxMessageSize: 64 * 1024, AllowedOrigins: []string{"https://example.com"}})
+` + "```" + `
+
+Conn: ReadMessage() (msgType, data, err), WriteMessage(msgType, data), WriteText(s),
+WriteBinary(b), Close(code, reason), SetReadDeadline(t), SetWriteDeadline(t), Done().
+Message types: ws.TextMessage, ws.BinaryMessage. Close codes: ws.CloseNormalClosure, etc.
+Config: AllowedOrigins, StrictOrigin, MaxMessageSize, ReadTimeout, WriteTimeout,
+MessageTimeout, MaxPingPerSecond.
+
+Manual upgrade when you need the *kruda.Ctx first:
+` + "```" + `go
+upgrader := ws.New(ws.Config{MaxMessageSize: 64 * 1024})
+app.Get("/ws", func(c *kruda.Ctx) error {
+    return upgrader.Upgrade(c, func(conn *ws.Conn) { /* same loop as above */ })
+})
+` + "```",
 
 	"file-upload": `# File Upload
 

--- a/cmd/kruda/cmd_mcp_test.go
+++ b/cmd/kruda/cmd_mcp_test.go
@@ -5,18 +5,37 @@ import (
 	"testing"
 )
 
-func TestSuggestPresetStreamingRouteDoesNotInventWingStream(t *testing.T) {
+func TestSuggestPresetStreamingRouteUsesStreamPreset(t *testing.T) {
 	preset, reason := suggestPreset(routeInfo{Method: "GET", Path: "/events"})
-	if preset != "none" {
-		t.Fatalf("preset = %q, want none", preset)
+	if preset != "kruda.Stream" {
+		t.Fatalf("preset = %q, want kruda.Stream", preset)
 	}
+	// The streaming preset is kruda.Stream (v1.5.0+), never the fabricated
+	// "WingStream" name an earlier version could have invented.
 	if strings.Contains(preset, "WingStream") || strings.Contains(reason, "WingStream") {
 		t.Fatalf("streaming suggestion mentions WingStream: preset=%q reason=%q", preset, reason)
 	}
 }
 
+func TestSuggestPresetWebSocketRouteUsesHijackPreset(t *testing.T) {
+	preset, _ := suggestPreset(routeInfo{Method: "GET", Path: "/ws"})
+	if preset != "kruda.Hijack" {
+		t.Fatalf("preset = %q, want kruda.Hijack", preset)
+	}
+}
+
+func TestMCPDocsHaveWebSocketTopic(t *testing.T) {
+	doc, ok := krudaDocs["websocket"]
+	if !ok {
+		t.Fatal("missing 'websocket' doc topic")
+	}
+	if !strings.Contains(doc, "ws.HandleFunc") {
+		t.Fatalf("websocket topic missing ws.HandleFunc usage")
+	}
+}
+
 func TestMCPDocsDoNotMentionWingStream(t *testing.T) {
-	for _, topic := range []string{"wing", "sse"} {
+	for _, topic := range []string{"wing", "sse", "websocket"} {
 		if strings.Contains(krudaDocs[topic], "WingStream") {
 			t.Fatalf("topic %q mentions nonexistent WingStream API", topic)
 		}

--- a/docs/guide/ai-integration.md
+++ b/docs/guide/ai-integration.md
@@ -38,6 +38,8 @@ kruda mcp --test      # verify it works
 | `kruda_suggest_wing` | Suggest Wing route presets for routes |
 | `kruda_docs` | Look up Kruda docs and code examples by topic |
 
+`kruda_docs` topics: `typed-handlers`, `routing`, `middleware`, `di`, `resource`, `wing`, `config`, `error-handling`, `sse`, `websocket`, `file-upload`, `validation`, `testing`, `openapi` — including real-time on the Wing transport (SSE via the `kruda.Stream` preset, WebSocket via `ws.HandleFunc`).
+
 ## How It Works
 
 The MCP server runs locally on your machine as a stdio process. Your AI assistant communicates with it via JSON-RPC:
@@ -76,4 +78,4 @@ Kruda's typed API makes AI code generation more reliable:
 - **Typed handlers** — AI generates a struct, gets compile-time validation for free
 - **Auto CRUD** — AI says "create CRUD for Product" → one line of code
 - **Struct tags** — validation rules are explicit, not hidden in handler logic
-- **22 examples** — AI reads patterns and generates consistent code
+- **23 examples** — AI reads patterns and generates consistent code


### PR DESCRIPTION
The `kruda mcp` server (used by Claude Code / Cursor to scaffold and reason about Kruda projects) still described the pre-v1.5 world: it told an AI that SSE/streaming has **no Wing route preset** and offered **no WebSocket guidance at all**. That makes AI-assisted ("vibe") coding produce wrong code on the default Linux transport — the same docs-honesty class as #164/#165, but on the surface an assistant actually reads.

### What was stale
- `kruda_docs` `sse` topic: "SSE does not have a Wing route hint" — false since v1.5.0 (`kruda.Stream`).
- `kruda_docs` `wing` topic: "Streaming and SSE routes do not have a Wing route preset".
- `kruda_suggest_wing`: returned `none` for `/sse`,`/stream`,`/events` and had no WebSocket case.
- No `websocket` doc topic at all (WS-on-Wing shipped in v1.6.0).

### Changes (AI-facing docs/DX only — no framework behavior change)
- `kruda_docs`: new **`websocket`** topic (`ws.HandleFunc` one-liner + `Conn` API + `Config`); `sse`/`wing` topics now document the **`kruda.Stream`** preset and per-transport streaming support (Wing needs the preset, net/http works bare, fasthttp doesn't stream).
- `kruda_suggest_wing`: suggests **`kruda.Stream`** for SSE/streaming routes and **`kruda.Hijack`** for WebSocket routes.
- `ai-integration.md`: lists the doc topics (surfacing real-time coverage); example count 22 → 23.
- Tests updated/added to lock the streaming + WebSocket suggestions and the new topic.

All content verified against the real API (`contrib/ws` `HandleFunc`/`Conn`/`Config`, core `c.SSE`/`SSEStream`/`kruda.Stream`). Ships under `[Unreleased]`.