### PR TITLE
docs: migrate documentation site to custom domain kruda.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,12 @@ Production HTTPS: terminate TLS at a proxy/load balancer in front of Wing, or us
 
 ## Documentation
 
+- [Full Documentation (kruda.dev)](https://kruda.dev/) — guides, API reference, migration docs
 - [API Reference (pkg.go.dev)](https://pkg.go.dev/github.com/go-kruda/kruda)
 - [Examples](examples/) — 23 runnable examples
 - [Contributing](CONTRIBUTING.md)
 - [Security Policy](SECURITY.md)
-- [Benchmark Charts](https://go-kruda.github.io/kruda/benchmarks/)
+- [Benchmark Charts](https://kruda.dev/benchmarks/)
 
 ## AI Integration
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -4,17 +4,17 @@ export default defineConfig({
   title: 'Kruda',
   description: 'Fast by default, type-safe by design — Go web framework',
   lang: 'en-US',
-  base: '/kruda/',
+  base: '/',
 
   head: [
-    ['link', { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/kruda/favicon-32x32.png' }],
-    ['link', { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/kruda/favicon-16x16.png' }],
-    ['link', { rel: 'apple-touch-icon', sizes: '180x180', href: '/kruda/apple-touch-icon.png' }],
+    ['link', { rel: 'icon', type: 'image/png', sizes: '32x32', href: '/favicon-32x32.png' }],
+    ['link', { rel: 'icon', type: 'image/png', sizes: '16x16', href: '/favicon-16x16.png' }],
+    ['link', { rel: 'apple-touch-icon', sizes: '180x180', href: '/apple-touch-icon.png' }],
     ['meta', { name: 'theme-color', content: '#e44d26' }],
     ['meta', { name: 'og:type', content: 'website' }],
     ['meta', { name: 'og:title', content: 'Kruda — Go Web Framework' }],
     ['meta', { name: 'og:description', content: 'Fast by default, type-safe by design. High-performance Go web framework with typed handlers, auto CRUD, and custom async I/O transport.' }],
-    ['meta', { name: 'og:image', content: 'https://go-kruda.github.io/kruda/kruda-og.jpg' }],
+    ['meta', { name: 'og:image', content: 'https://kruda.dev/kruda-og.jpg' }],
   ],
 
   themeConfig: {
@@ -23,7 +23,7 @@ export default defineConfig({
     nav: [
       { text: 'Guide', link: '/guide/getting-started' },
       { text: 'API', link: '/api/app' },
-      { text: 'Benchmarks', link: 'https://go-kruda.github.io/kruda/benchmarks/' },
+      { text: 'Benchmarks', link: 'https://kruda.dev/benchmarks/' },
       { text: 'GitHub', link: 'https://github.com/go-kruda/kruda' },
     ],
 

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,0 +1,1 @@
+kruda.dev


### PR DESCRIPTION
Switches the VitePress docs site from `go-kruda.github.io/kruda/` to the root of the newly registered `kruda.dev`.

### Changes
- `docs/.vitepress/config.mts`: `base` from `/kruda/` to `/`; favicon/apple-touch-icon hrefs and `og:image` updated to root paths / new domain; benchmarks nav link updated.
- `docs/public/CNAME` (new): contains `kruda.dev`. VitePress copies `public/` verbatim into the build output, so the custom domain survives every GitHub Actions Pages deploy regardless of the repo Settings UI state.
- `README.md`: benchmark link updated to the new domain; added a direct link to the full guide site under **Documentation** (previously the repo had no entry point to the guide/API docs site, only pkg.go.dev and a benchmarks sub-page).

Verified locally: `npx vitepress build` succeeds, built HTML has no leftover `/kruda/`-prefixed asset paths, `CNAME` lands in `dist/` root, `og:image`/benchmarks links point at `kruda.dev`.

### Still required (outside this PR, cannot be done via code)
- DNS: 4 `A` records for `kruda.dev` → GitHub Pages IPs (185.199.108/109/110/111.153).
- GitHub repo Settings → Pages → Custom domain → `kruda.dev` (or `gh api -X PUT repos/go-kruda/kruda/pages -f cname=kruda.dev`).

The old `go-kruda.github.io/kruda/` URL will auto-redirect to the custom domain once configured, so no existing links break.