### PR TITLE
docs: add Cloudflare Web Analytics beacon to docs site

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -15,6 +15,8 @@ export default defineConfig({
     ['meta', { name: 'og:title', content: 'Kruda — Go Web Framework' }],
     ['meta', { name: 'og:description', content: 'Fast by default, type-safe by design. High-performance Go web framework with typed handlers, auto CRUD, and custom async I/O transport.' }],
     ['meta', { name: 'og:image', content: 'https://kruda.dev/kruda-og.jpg' }],
+    // Cloudflare Web Analytics (cookieless) — manual beacon: kruda.dev is DNS-only, not proxied, so it is not auto-injected.
+    ['script', { type: 'module', src: 'https://static.cloudflareinsights.com/beacon.min.js', 'data-cf-beacon': '{"token": "9d5d2aee2c6c41c8a4bcc3f355f8af96"}' }],
   ],
 
   themeConfig: {


### PR DESCRIPTION
Adds the cookieless [Cloudflare Web Analytics](https://www.cloudflare.com/web-analytics/) beacon to the VitePress `head`, so it loads on every docs page. Gives privacy-friendly traffic insight (pageviews, top pages, referrers, geography) for tracking documentation adoption — no cookies, no consent banner required.

### Why the manual beacon
`kruda.dev` is **DNS-only** (grey cloud) pointing straight at GitHub Pages, so Cloudflare never proxies the traffic and cannot auto-inject the beacon. The manual snippet is the supported path for non-proxied sites.

### Note on the token
The `data-cf-beacon` token is a **public site identifier** — it is embedded in the client-side HTML served to every visitor by design, not a secret. Committing it to the public repo is expected.

Verified locally: `npx vitepress build` succeeds; the beacon is present in both `index.html` and sub-pages (e.g. `guide/getting-started.html`).