### PR TITLE
Harden correctness and protocol gates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,11 @@ jobs:
           fi
           go test -v -race -tags kruda_stdjson $COVER_FLAG ./...
 
+      - name: Run default JSON engine tests
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25.11'
+        shell: bash
+        run: CGO_ENABLED=1 go test -race ./...
+
       - name: Test contrib packages
         shell: bash
         # Dynamically discovers contrib modules so new modules cannot be missed

--- a/contrib/ws/conn.go
+++ b/contrib/ws/conn.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 )
 
 // Conn represents a WebSocket connection.
@@ -103,12 +104,21 @@ func (c *Conn) ReadMessage() (messageType int, data []byte, err error) {
 			continue
 		}
 
+		if f.opcode == 0x0 {
+			_ = c.Close(CloseProtocolError, "unexpected continuation frame")
+			return 0, nil, fmt.Errorf("ws: continuation frame without an active fragmented message")
+		}
+
 		// First frame of a message
 		messageType = int(f.opcode)
 		data = f.payload
 
 		if f.fin {
 			// Single-frame message — size already checked in readFrame
+			if messageType == TextMessage && !utf8.Valid(data) {
+				_ = c.Close(CloseInvalidPayload, "invalid UTF-8 text message")
+				return 0, nil, fmt.Errorf("ws: text message is not valid UTF-8")
+			}
 			return messageType, data, nil
 		}
 
@@ -157,6 +167,10 @@ func (c *Conn) ReadMessage() (messageType int, data []byte, err error) {
 			data = append(data, cont.payload...)
 
 			if cont.fin {
+				if messageType == TextMessage && !utf8.Valid(data) {
+					_ = c.Close(CloseInvalidPayload, "invalid UTF-8 text message")
+					return 0, nil, fmt.Errorf("ws: text message is not valid UTF-8")
+				}
 				return messageType, data, nil
 			}
 		}
@@ -285,6 +299,16 @@ func (c *Conn) handleControl(f *frame) error {
 		return nil
 
 	case 0x8: // Close
+		failureCode, err := validateClosePayload(f.payload)
+		if err != nil {
+			reason := "invalid close payload"
+			if failureCode == CloseInvalidPayload {
+				reason = "invalid UTF-8 close reason"
+			}
+			_ = c.Close(failureCode, reason)
+			return err
+		}
+
 		c.mu.Lock()
 		defer c.mu.Unlock()
 		if !c.closed.Load() {

--- a/contrib/ws/frame.go
+++ b/contrib/ws/frame.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"unicode/utf8"
 )
 
 // frame represents a single WebSocket frame per RFC 6455 §5.2.
@@ -183,4 +184,43 @@ func parseClosePayload(payload []byte) (code int, reason string) {
 		}
 	}
 	return
+}
+
+// validateClosePayload checks the message-level requirements for a received
+// Close frame. Frame-level FIN and size constraints are enforced by readFrame.
+func validateClosePayload(payload []byte) (failureCode int, err error) {
+	if len(payload) == 0 {
+		return 0, nil
+	}
+	if len(payload) == 1 {
+		return CloseProtocolError, fmt.Errorf("ws: close frame payload must be empty or at least 2 bytes")
+	}
+
+	code := int(binary.BigEndian.Uint16(payload[:2]))
+	if !validReceivedCloseCode(code) {
+		return CloseProtocolError, fmt.Errorf("ws: invalid close status code %d", code)
+	}
+	if !utf8.Valid(payload[2:]) {
+		return CloseInvalidPayload, fmt.Errorf("ws: close reason is not valid UTF-8")
+	}
+	return 0, nil
+}
+
+// validReceivedCloseCode accepts protocol-defined codes, the additional
+// codes registered in the 1000 range, and application/private-use ranges.
+// Codes reserved only as local sentinels and unassigned 1016-2999 codes are
+// not valid on the wire.
+func validReceivedCloseCode(code int) bool {
+	if code >= 3000 && code <= 4999 {
+		return true
+	}
+	if code < 1000 || code > 1014 {
+		return false
+	}
+	switch code {
+	case 1004, CloseNoStatusReceived, CloseAbnormalClosure:
+		return false
+	default:
+		return true
+	}
 }

--- a/contrib/ws/ws_test.go
+++ b/contrib/ws/ws_test.go
@@ -540,7 +540,135 @@ func TestUpgrade_FragmentedMessage(t *testing.T) {
 	}
 }
 
+func TestUpgrade_FragmentedTextValidatesUTF8AfterAssembly(t *testing.T) {
+	app := kruda.New(kruda.NetHTTP())
+	upgrader := New(Config{})
+
+	app.Get("/ws", func(c *kruda.Ctx) error {
+		return upgrader.Upgrade(c, func(conn *Conn) {
+			msgType, data, err := conn.ReadMessage()
+			if err != nil {
+				return
+			}
+			_ = conn.WriteMessage(msgType, data)
+		})
+	})
+	app.Compile()
+
+	srv := httptest.NewServer(app)
+	defer srv.Close()
+
+	conn := dialWS(t, srv.URL+"/ws")
+	defer conn.Close()
+
+	// Split the three-byte UTF-8 encoding of € across frame boundaries.
+	sendClientFrame(t, conn, false, 0x1, []byte{0xE2})
+	sendClientFrame(t, conn, false, 0x0, []byte{0x82})
+	sendClientFrame(t, conn, true, 0x0, []byte{0xAC})
+
+	f := readServerFrame(t, conn, bufio.NewReader(conn))
+	if f.opcode != 0x1 || string(f.payload) != "€" {
+		t.Fatalf("echo = opcode 0x%X %q, want text €", f.opcode, f.payload)
+	}
+}
+
+func TestUpgrade_RejectUnexpectedContinuation(t *testing.T) {
+	srv := newReadOnceWSServer(t)
+	defer srv.Close()
+
+	conn := dialWS(t, srv.URL+"/ws")
+	defer conn.Close()
+
+	sendClientFrame(t, conn, true, 0x0, []byte("orphan"))
+	assertServerCloseCode(t, conn, CloseProtocolError)
+}
+
+func TestUpgrade_RejectInvalidTextUTF8(t *testing.T) {
+	tests := []struct {
+		name string
+		send func(*testing.T, net.Conn)
+	}{
+		{
+			name: "single frame",
+			send: func(t *testing.T, conn net.Conn) {
+				sendClientFrame(t, conn, true, 0x1, []byte{0xFF})
+			},
+		},
+		{
+			name: "fragmented message",
+			send: func(t *testing.T, conn net.Conn) {
+				sendClientFrame(t, conn, false, 0x1, []byte{0xF0, 0x9F})
+				sendClientFrame(t, conn, true, 0x0, []byte{0x92})
+			},
+		},
+	}
+
+	srv := newReadOnceWSServer(t)
+	defer srv.Close()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := dialWS(t, srv.URL+"/ws")
+			defer conn.Close()
+
+			tt.send(t, conn)
+			assertServerCloseCode(t, conn, CloseInvalidPayload)
+		})
+	}
+}
+
+func TestUpgrade_RejectInvalidClosePayload(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+		want    int
+	}{
+		{name: "one byte", payload: []byte{0x03}, want: CloseProtocolError},
+		{name: "reserved code", payload: []byte{0x03, 0xED}, want: CloseProtocolError},   // 1005
+		{name: "unassigned code", payload: []byte{0x07, 0xD0}, want: CloseProtocolError}, // 2000
+		{name: "invalid reason UTF-8", payload: []byte{0x03, 0xE8, 0xFF}, want: CloseInvalidPayload},
+	}
+
+	srv := newReadOnceWSServer(t)
+	defer srv.Close()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := dialWS(t, srv.URL+"/ws")
+			defer conn.Close()
+
+			sendClientFrame(t, conn, true, 0x8, tt.payload)
+			assertServerCloseCode(t, conn, tt.want)
+		})
+	}
+}
+
 // --- Test helpers ---
+
+func newReadOnceWSServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	app := kruda.New(kruda.NetHTTP())
+	upgrader := New(Config{})
+	app.Get("/ws", func(c *kruda.Ctx) error {
+		return upgrader.Upgrade(c, func(conn *Conn) {
+			_, _, _ = conn.ReadMessage()
+		})
+	})
+	app.Compile()
+	return httptest.NewServer(app)
+}
+
+func assertServerCloseCode(t *testing.T, conn net.Conn, want int) {
+	t.Helper()
+	f := readServerFrame(t, conn, bufio.NewReader(conn))
+	if f.opcode != 0x8 {
+		t.Fatalf("expected close frame, got opcode 0x%X", f.opcode)
+	}
+	code, _ := parseClosePayload(f.payload)
+	if code != want {
+		t.Fatalf("close code = %d, want %d", code, want)
+	}
+}
 
 // dialWS performs a WebSocket handshake and returns the raw TCP connection.
 func dialWS(t *testing.T, rawURL string) net.Conn {

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -26,7 +26,7 @@ fix, or feature that is worth asking them to upgrade for.
 Before opening the release PR, run `./scripts/pre-release.sh` for local release validation. The script covers local checks; CI provides the required cross-platform and benchmark evidence:
 
 - [ ] Working tree clean (`git status` shows nothing to commit)
-- [ ] All tests pass on the host platform: `go test -race -tags kruda_stdjson ./...`
+- [ ] All tests pass with both JSON engines: `go test -race -tags kruda_stdjson ./...` and `go test -race ./...`
 - [ ] Cross-platform builds: `GOOS=linux go build ./...`, `GOOS=windows go build ./...`, `GOOS=darwin go build ./...`
 - [ ] Wing tests pass: covered by the same `go test ./...` since v1.2.0 (flattened into core)
 - [ ] Native fuzz tests don't crash within 30s each: `go test -fuzz=FuzzRouterPattern -fuzztime=30s -run=^$ .` (and FuzzRouterMatch, FuzzBindJSON, FuzzValidateString)

--- a/examples/websocket/go.mod
+++ b/examples/websocket/go.mod
@@ -9,7 +9,7 @@ replace (
 )
 
 require (
-	github.com/go-kruda/kruda v1.2.0
+	github.com/go-kruda/kruda v1.6.0
 	github.com/go-kruda/kruda/contrib/ws v0.0.0
 )
 

--- a/health.go
+++ b/health.go
@@ -60,38 +60,43 @@ func discoverHealthCheckers(c *Container) []namedChecker {
 	defer c.mu.RUnlock()
 	var checkers []namedChecker
 	seen := make(map[any]bool)
-	addChecker := func(t reflect.Type, inst any) {
-		if seen[inst] {
+	addChecker := func(t reflect.Type, name string, inst any) {
+		hc, ok := inst.(HealthChecker)
+		if !ok {
 			return
 		}
-		seen[inst] = true
-		if hc, ok := inst.(HealthChecker); ok {
-			name := t.String()
+		// Interface values whose dynamic type is a slice, map, function, or a
+		// struct containing one cannot be map keys. Most services are pointers
+		// and remain deduplicated; non-comparable checker values are still valid
+		// and must not make the health endpoint panic.
+		instType := reflect.TypeOf(inst)
+		if instType != nil && instType.Comparable() {
+			if seen[inst] {
+				return
+			}
+			seen[inst] = true
+		}
+		if name == "" {
+			name = t.String()
 			if t.Kind() == reflect.Pointer {
 				name = t.Elem().Name()
 			}
 			if name == "" {
 				name = t.String()
 			}
-			checkers = append(checkers, namedChecker{name: name, checker: hc})
 		}
+		checkers = append(checkers, namedChecker{name: name, checker: hc})
 	}
 	for t, inst := range c.singletons {
-		addChecker(t, inst)
+		addChecker(t, "", inst)
 	}
 	for t, entry := range c.lazies {
 		if entry.done.Load() {
-			addChecker(t, entry.instance)
+			addChecker(t, "", entry.instance)
 		}
 	}
 	for name, inst := range c.named {
-		if seen[inst] {
-			continue
-		}
-		seen[inst] = true
-		if hc, ok := inst.(HealthChecker); ok {
-			checkers = append(checkers, namedChecker{name: name, checker: hc})
-		}
+		addChecker(reflect.TypeOf(inst), name, inst)
 	}
 	return checkers
 }

--- a/health_extra_test.go
+++ b/health_extra_test.go
@@ -15,6 +15,10 @@ type namedHealthService struct {
 
 func (s *namedHealthService) Check(_ context.Context) error { return nil }
 
+type nonComparableHealthService []string
+
+func (nonComparableHealthService) Check(_ context.Context) error { return nil }
+
 func TestDiscoverHealthCheckers_WithLazySingleton(t *testing.T) {
 	c := NewContainer()
 	_ = c.GiveLazy(func() (*healthyDB, error) {
@@ -101,5 +105,40 @@ func TestDiscoverHealthCheckers_NonHealthChecker(t *testing.T) {
 	checkers := discoverHealthCheckers(c)
 	if len(checkers) != 0 {
 		t.Errorf("expected 0 checkers for non-HealthChecker, got %d", len(checkers))
+	}
+}
+
+func TestDiscoverHealthCheckers_NonComparableServices(t *testing.T) {
+	c := NewContainer()
+	if err := c.Give(nonComparableHealthService{"worker", "scheduler"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.GiveNamed("metadata", map[string]string{"region": "local"}); err != nil {
+		t.Fatal(err)
+	}
+
+	checkers := discoverHealthCheckers(c)
+	if len(checkers) != 1 {
+		t.Fatalf("expected the non-comparable health service only, got %d checkers", len(checkers))
+	}
+	if _, ok := checkers[0].checker.(nonComparableHealthService); !ok {
+		t.Fatalf("checker type = %T, want nonComparableHealthService", checkers[0].checker)
+	}
+}
+
+func TestDiscoverHealthCheckers_NonComparableLazyInterfaceService(t *testing.T) {
+	c := NewContainer()
+	if err := c.GiveLazy(func() (HealthChecker, error) {
+		return nonComparableHealthService{"queue"}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Use[HealthChecker](c); err != nil {
+		t.Fatal(err)
+	}
+
+	checkers := discoverHealthCheckers(c)
+	if len(checkers) != 1 {
+		t.Fatalf("expected the resolved lazy health service, got %d checkers", len(checkers))
 	}
 }

--- a/json/std_pbt_test.go
+++ b/json/std_pbt_test.go
@@ -1,5 +1,3 @@
-//go:build kruda_stdjson || !cgo
-
 package json
 
 import (

--- a/json/std_test.go
+++ b/json/std_test.go
@@ -1,5 +1,3 @@
-//go:build kruda_stdjson || !cgo
-
 package json
 
 import (

--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -42,7 +42,9 @@ ok "no replace directives in released go.mod"
 
 section "tests (host platform)"
 go test -race -tags kruda_stdjson ./...
-ok "tests passed"
+ok "stdlib JSON tests passed"
+go test -race ./...
+ok "default JSON engine tests passed"
 
 section "standalone module tests"
 scripts/test-standalone-modules.sh


### PR DESCRIPTION
## Summary

- prevent health-check discovery from panicking on non-comparable service values, including resolved lazy services returned through interfaces
- exercise the JSON package with both the default Sonic engine and the `kruda_stdjson` fallback in CI and pre-release validation
- reject orphan WebSocket continuation frames, validate UTF-8 after complete message assembly, and validate close payloads, status codes, and reasons
- align the standalone WebSocket example with the core version required by `contrib/ws`

## Root causes

- health-check deduplication used service values as map keys before checking interface support and dynamic comparability
- JSON tests were build-tagged out of the default CGO/Sonic build
- WebSocket message handling did not enforce continuation sequencing or message-level UTF-8 and echoed malformed close payloads
- the WebSocket example still required core v1.2.0 while the local contrib module requires v1.6.0

## Impact

No public API changes. Health endpoints remain safe with non-comparable DI values, the default JSON engine now has regression coverage, and malformed WebSocket clients receive RFC-appropriate close codes.

## Validation

- `GOTOOLCHAIN=go1.25.11 ./scripts/pre-release.sh`
- race tests with default Sonic and `kruda_stdjson`
- all standalone contrib modules and CLI tests
- Linux, macOS, and Windows cross-platform builds
- six 30-second fuzz suites
- documentation, godoc, and example build checks
