### PR TITLE
ci: simplify release notes and refresh docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,47 +89,17 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: stable
-          
+
       - name: Extract version
         id: version
         run: |
           VERSION=${GITHUB_REF#refs/tags/}
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "is_prerelease=$(echo $VERSION | grep -qE '(alpha|beta|rc)' && echo true || echo false)" >> "$GITHUB_OUTPUT"
-          
-      - name: Generate changelog
-        id: changelog
-        run: |
-          VERSION=${{ steps.version.outputs.version }}
-          
-          # Get previous tag
-          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          
-          # Generate changelog
-          if [ -n "$PREV_TAG" ]; then
-            echo "## Changes since $PREV_TAG" > CHANGELOG_CURRENT.md
-            git log --oneline --no-merges ${PREV_TAG}..HEAD >> CHANGELOG_CURRENT.md
-          else
-            echo "## Initial Release" > CHANGELOG_CURRENT.md
-            git log --oneline --no-merges >> CHANGELOG_CURRENT.md
-          fi
-          
-          # Add benchmark info if available
-          echo "" >> CHANGELOG_CURRENT.md
-          echo "## Performance" >> CHANGELOG_CURRENT.md
-          echo "Run benchmarks: \`go test -bench=. -benchmem -count=5 -tags kruda_stdjson ./bench/...\`" >> CHANGELOG_CURRENT.md
-          
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          body_path: CHANGELOG_CURRENT.md
           generate_release_notes: true
           prerelease: ${{ steps.version.outputs.is_prerelease == 'true' }}
           files: |

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Fast by default, type-safe by design.
 
 ## Why Kruda?
 
-- Typed handlers `C[T]` — body + param + query parsed into one struct, validated at compile time
+- Typed handlers `C[T]` — compiler-checked handler types with request input bound and validated before execution
 - Auto CRUD — implement `ResourceService[T]`, get 5 REST endpoints
 - Built-in DI — optional, no codegen, type-safe generics
 - Pluggable transport — Wing in core (Linux, epoll+eventfd), fasthttp, or net/http
-- Single-tag releases — one `vX.Y.Z` covers core and contrib (no more sub-module coordination)
+- Independent module versions — core uses `vX.Y.Z`; changed nested modules use prefixed tags
 - Minimal deps — Sonic JSON (opt-out via `kruda_stdjson`), pluggable transport
-- AI-friendly — typed API + 23 examples = AI generates correct code on first try
+- AI-friendly — built-in MCP documentation plus 23 runnable examples
 
 ## Quick Start
 

--- a/contrib/ws/README.md
+++ b/contrib/ws/README.md
@@ -11,19 +11,22 @@ go get github.com/go-kruda/kruda/contrib/ws
 ## Usage
 
 ```go
-import "github.com/go-kruda/kruda/contrib/ws"
+import (
+    "github.com/go-kruda/kruda"
+    "github.com/go-kruda/kruda/contrib/ws"
+)
 
-upgrader := ws.New(ws.Config{})
+app := kruda.New()
 
-app.Get("/ws", func(c *kruda.Ctx) error {
-    return upgrader.Upgrade(c, func(conn *ws.Conn) {
-        msg, err := conn.ReadMessage()
-        if err == nil {
-            _ = conn.WriteMessage(ws.TextMessage, msg)
-        }
-    })
-})
+ws.HandleFunc(app, "/ws", func(conn *ws.Conn) {
+    msg, err := conn.ReadMessage()
+    if err == nil {
+        _ = conn.WriteMessage(ws.TextMessage, msg)
+    }
+}, ws.Config{})
 ```
+
+`ws.HandleFunc` works with Wing and net/http. It applies the `kruda.Hijack` route preset required by Wing; fasthttp does not support WebSocket upgrades.
 
 ## Config
 

--- a/contrib/ws/doc.go
+++ b/contrib/ws/doc.go
@@ -5,29 +5,28 @@
 //
 // # Usage
 //
-//	import "github.com/go-kruda/kruda/contrib/ws"
+//	import (
+//	    "github.com/go-kruda/kruda"
+//	    "github.com/go-kruda/kruda/contrib/ws"
+//	)
 //
 //	app := kruda.New()
-//	upgrader := ws.New()
-//	app.Get("/echo", func(c *kruda.Ctx) error {
-//	    return upgrader.Upgrade(c, func(conn *ws.Conn) {
-//	        defer conn.Close()
-//	        for {
-//	            mt, msg, err := conn.ReadMessage()
-//	            if err != nil { return }
-//	            _ = conn.WriteMessage(mt, msg)
-//	        }
-//	    })
+//	ws.HandleFunc(app, "/echo", func(conn *ws.Conn) {
+//	    defer conn.Close()
+//	    for {
+//	        mt, msg, err := conn.ReadMessage()
+//	        if err != nil { return }
+//	        _ = conn.WriteMessage(mt, msg)
+//	    }
 //	})
 //
 // # Transport compatibility
 //
 //   - net/http: supported (via http.Hijacker)
+//   - Wing:     supported via [HandleFunc], which applies the kruda.Hijack
+//     route preset before upgrading the connection.
 //   - fasthttp: not supported in v1 — the upgrade returns an error directing
 //     callers to net/http (avoids pulling fasthttp into the hijack path).
-//   - Wing:     not supported in v1 — Wing manages the fd directly via
-//     epoll/kqueue and does not expose a hijack API. Routes that
-//     need WebSocket should run under net/http.
 //
 // # What it does
 //

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,13 +4,13 @@
 
 Kruda fills the gap between raw performance frameworks (Fiber, Fasthttp) and type-safe but verbose frameworks (standard net/http). It gives you:
 
-- Type-safe handlers with `C[T]` — body, params, and query in one struct, validated at compile time
+- Type-safe handlers with `C[T]` — compiler-checked handler types with body, params, and query bound and validated before execution
 - Auto-everything — validation, error mapping, OpenAPI generation, CRUD endpoints
 - Pluggable transport — Wing (epoll+eventfd) on Linux, fasthttp, or net/http
 - Built-in DI — no codegen, no reflection, just `Give` and `Use`
-- 60-70% less boilerplate than Gin or Fiber
+- Less repetitive binding, validation, and CRUD wiring than manual handler code
 
-Think of it as the Go equivalent of tRPC — maximum DX without sacrificing performance.
+Think of it as a tRPC-style typed workflow adapted to Go.
 
 ## How does the DI container work?
 
@@ -39,9 +39,9 @@ See the [DI Container guide](/guide/di-container) for details.
 | | Wing | fasthttp | net/http |
 |---|------|---------|----------|
 | Platform | Linux & macOS | All platforms | All platforms |
-| Performance | Highest (846K req/s) | High | Good |
+| Performance | Highest-throughput Kruda option for benchmarked plaintext HTTP/1.1 workloads | High | Standard library |
 | HTTP/2 | No | No | Yes (via TLS) |
-| Set-Cookie | Limited (fast path skips) | Yes | Yes |
+| Set-Cookie | Yes (normal handlers) | Yes | Yes |
 | SSE | Yes (via `kruda.Stream`) | No | Yes |
 | Direct TLS | Auto-falls back to net/http | Yes | Yes |
 | WebSocket | Yes (`ws.HandleFunc`) | No | Yes (`contrib/ws`) |
@@ -79,7 +79,7 @@ See the [Test Client API](/api/test-client) for the full builder API.
 
 ## Do I need CGO for Sonic JSON?
 
-Sonic uses SIMD instructions and requires CGO on some platforms. If CGO is not available, Kruda automatically falls back to `encoding/json`.
+Kruda selects Sonic when CGO is enabled and selects `encoding/json` when CGO is disabled. The engine is chosen at build time.
 
 To force stdlib JSON (no CGO required):
 
@@ -94,7 +94,7 @@ Go 1.25.11+ or Go 1.26.4+ is required for generic type aliases used by `C[T]` ty
 
 ## Is Kruda production-ready?
 
-Kruda has completed Phases 1-6 (Foundation through Security Hardening). The core framework, type system, performance optimization, ecosystem (DI, CRUD), security hardening, and Wing transport are all implemented and tested. Phase 7 (Launch) is the v1.0.0 release milestone.
+Kruda is released and actively maintained on the v1.x line. Releases pass cross-platform tests, benchmark gates, security scans, and downstream module verification. Review the [changelog](https://github.com/go-kruda/kruda/blob/main/CHANGELOG.md), [transport guide](/guide/transport), and [Wing protocol matrix](/guide/wing-protocol-support) for the exact guarantees that apply to your deployment.
 
 ## How do I contribute?
 

--- a/docs/guide/ai-integration.md
+++ b/docs/guide/ai-integration.md
@@ -75,7 +75,7 @@ No data leaves your machine. No remote server required.
 
 Kruda's typed API makes AI code generation more reliable:
 
-- **Typed handlers** — AI generates a struct, gets compile-time validation for free
-- **Auto CRUD** — AI says "create CRUD for Product" → one line of code
+- **Typed handlers** — the compiler checks generated handler types, while Kruda validates struct tags at request time
+- **Auto CRUD** — a resource service registers the standard CRUD routes in one call
 - **Struct tags** — validation rules are explicit, not hidden in handler logic
 - **23 examples** — AI reads patterns and generates consistent code

--- a/docs/guide/coming-from-echo.md
+++ b/docs/guide/coming-from-echo.md
@@ -128,7 +128,7 @@ No separate bind + validate steps. No global validator registration. Validation 
 Echo uses net/http exclusively. Kruda offers both:
 
 ```go
-// Wing (default on Linux) — epoll+eventfd, 846K req/s
+// Wing (default on Linux) — epoll+eventfd
 app := kruda.New()
 
 // fasthttp — broad compatibility
@@ -199,7 +199,7 @@ app.Group("/api/v1").
 
 ## What You Gain
 
-- **846K req/s** — Wing transport (epoll+eventfd) by default on Linux
+- **Benchmark evidence** — versioned results and reproduction commands are documented in the [performance guide](/guide/performance)
 - **Type-safe handlers** — no more bind + validate dance
 - **Concrete context** — no interface overhead, better inlining
 - **Pluggable transport** — Wing, fasthttp, or net/http, auto-selected

--- a/docs/guide/coming-from-gin.md
+++ b/docs/guide/coming-from-gin.md
@@ -165,9 +165,9 @@ app.Group("/api/v1").
 
 ## What You Gain
 
-- **3x faster** than Gin in benchmarks (416ns vs 1318ns per request)
+- **Benchmark evidence** — versioned results and reproduction commands are documented in the [performance guide](/guide/performance)
 - **Type-safe handlers** — no more manual `ShouldBindJSON`
 - **Pluggable transport** — Wing (default on Linux), fasthttp (default on macOS), or net/http (HTTP/2)
-- **Zero boilerplate** — 60-70% less code than Gin
+- **Less binding boilerplate** — typed inputs combine binding and validation before handler execution
 - **Auto OpenAPI** — generated from your typed handlers
 - **Built-in DI** — optional dependency injection without codegen

--- a/docs/guide/coming-from-stdlib.md
+++ b/docs/guide/coming-from-stdlib.md
@@ -199,7 +199,7 @@ app.Group("/api/v1").
 stdlib is locked to `net/http`. Kruda auto-selects the fastest transport for your platform:
 
 ```go
-// Wing (default on Linux) — epoll+eventfd, 846K req/s
+// Wing (default on Linux) — epoll+eventfd
 app := kruda.New()
 
 // net/http — same engine as stdlib, with Kruda's ergonomics
@@ -213,7 +213,7 @@ You can use `kruda.NetHTTP()` to keep the exact same transport as stdlib while g
 
 ## What You Gain
 
-- **846K req/s** — Wing transport (epoll+eventfd) by default on Linux
+- **Benchmark evidence** — versioned results and reproduction commands are documented in the [performance guide](/guide/performance)
 - **Error-returning handlers** — no more silent failures or forgotten `return`
 - **Type-safe handlers** — `C[T]` with auto-bind, auto-validate, auto-OpenAPI
 - **Built-in middleware** — Logger, CORS, Recovery, RequestID, RateLimit

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -59,10 +59,10 @@ Route registration order doesn't affect lookup performance.
 
 | Engine | CGO Required | Performance |
 |--------|-------------|-------------|
-| Sonic | Yes | ~2-3x faster than encoding/json (SIMD) |
-| encoding/json | No | Standard Go performance |
+| Sonic | Yes in Kruda's default build | SIMD-accelerated; benchmark with your payloads |
+| encoding/json | No | Portable standard-library baseline |
 
-Sonic is used automatically via build tags. Falls back to `encoding/json` transparently.
+The engine is selected at build time: CGO-enabled builds use Sonic by default, while `CGO_ENABLED=0` or the `kruda_stdjson` tag selects `encoding/json`.
 
 ## Zero-Allocation Hot Path
 

--- a/docs/guide/transport.md
+++ b/docs/guide/transport.md
@@ -7,10 +7,10 @@ Kruda ships with three transports. The default is **Wing** on Linux, **fasthttp*
 | Feature needed | Transport | Why |
 |---------------|-----------|-----|
 | Maximum throughput (plaintext, JSON, DB) | **Wing** (default on Linux) | epoll+eventfd, zero-copy, no goroutine-per-conn |
-| SSE (Server-Sent Events) | **net/http** | SSE requires `http.Flusher` streaming |
+| SSE (Server-Sent Events) | **Wing** or **net/http** | Wing requires the `kruda.Stream` route preset |
 | Session cookies / Set-Cookie headers | **Wing** or **net/http** | Wing keeps headers by falling back from its zero-copy fast path when needed |
 | HTTP/2, TLS termination | **net/http** | Wing is HTTP/1.1 only |
-| WebSocket | **net/http** | WebSocket upgrade needs full HTTP semantics |
+| WebSocket | **Wing** or **net/http** | Use `ws.HandleFunc`; fasthttp does not support the upgrade |
 | Battle-tested HTTP/1.1 (chunked, expect-100) | **fasthttp** | Mature, widely deployed |
 
 ## Usage
@@ -19,7 +19,7 @@ Kruda ships with three transports. The default is **Wing** on Linux, **fasthttp*
 // Default: Wing on Linux, fasthttp on macOS, net/http on Windows
 app := kruda.New()
 
-// Explicit net/http (for SSE, sessions, HTTP/2, TLS)
+// Explicit net/http (for direct TLS, HTTP/2, or stdlib compatibility)
 app := kruda.New(kruda.NetHTTP())
 
 // Explicit fasthttp
@@ -76,4 +76,4 @@ Wing is optimized for raw throughput. It intentionally skips some HTTP features:
 - **No chunked transfer encoding** — Wing pre-computes Content-Length.
 - **`App.Serve(listener)` re-binds on Wing** — Wing serves one `SO_REUSEPORT` socket per worker, so it adopts the listener's *address* and closes the passed file descriptor rather than serving it. For systemd socket activation or graceful-restart fd-passing, use `kruda.NetHTTP()` (or fasthttp on macOS), which serve the supplied fd directly.
 
-For apps that mix high-throughput API routes with session/SSE routes, run two instances or use net/http for the full app.
+Wing apps can mix normal handlers with streaming and WebSocket routes by applying `kruda.Stream` or registering WebSockets with `ws.HandleFunc`. Choose net/http when you need direct TLS, HTTP/2, chunked request bodies, or exact stdlib transport semantics.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,19 +19,19 @@ hero:
 features:
   - icon: 🔒
     title: Typed Handlers C[T]
-    details: Body, params, and query parsed into one struct. Validated at compile time. No manual binding.
+    details: Compiler-checked handler types. Body, params, and query are bound and validated before execution.
   - icon: ⚡
     title: Auto CRUD
     details: Implement ResourceService[T] and get 5 REST endpoints. One line of code.
   - icon: 🚀
     title: Wing Transport
-    details: Custom epoll+eventfd on Linux, kqueue on macOS. 846K req/s plaintext — beats Fiber by 26%.
+    details: Custom epoll+eventfd on Linux and kqueue on macOS, backed by versioned reproducible benchmarks.
   - icon: 📦
     title: Built-in DI
     details: Optional dependency injection with Go generics. No codegen, no reflection.
   - icon: 🤖
     title: AI-Friendly
-    details: Built-in MCP server for AI coding assistants. Typed API means AI generates correct code on first try.
+    details: Built-in MCP documentation and runnable examples for coding assistants.
   - icon: 🛡
     title: Minimal Dependencies
     details: Sonic JSON (opt-out via build tag). 11 contrib modules. Pluggable transport.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -38,7 +38,7 @@ Before opening the release PR, run `./scripts/pre-release.sh` for local release 
 - [ ] Any `ns/op` movement is reviewed against `B/op`, `allocs/op`, same-runner `main`, and whether the changed code is on the default hot path
 - [ ] CHANGELOG.md has a section for the new version with date
 - [ ] No `replace` directives left in `cmd/kruda/go.mod` or any `contrib/*/go.mod`
-- [ ] Every released submodule's `go.mod` requires the intended core version
+- [ ] Every released submodule's `go.mod` requires a compatible published core version; bump it only when the submodule needs newer core APIs or behavior
 - [ ] Every changed nested module has an independently incremented prefixed tag
       planned; unchanged nested modules are not retagged
 - [ ] Public API surface diff reviewed — additions OK; removals require a major bump or an accepted ADR (see docs/decisions/0001-break-api-in-v1-minor.md for the v1.3.0 exception)
@@ -50,37 +50,57 @@ Before opening the release PR, run `./scripts/pre-release.sh` for local release 
 git fetch origin main --tags
 git switch main
 git pull --ff-only origin main
-git tag v1.6.1 -m "Release v1.6.1"
 
-# only when contrib/ws changed; nested modules keep independent versions
-git tag contrib/ws/v1.3.1 -m "contrib/ws v1.3.1"
+export CORE_VERSION=vX.Y.Z
+# export WS_VERSION=vA.B.C # only when contrib/ws changed
 
-git push origin v1.6.1 contrib/ws/v1.3.1
+git tag "$CORE_VERSION" -m "Release $CORE_VERSION"
+TAGS=("$CORE_VERSION")
+
+if [[ -n "${WS_VERSION:-}" ]]; then
+  WS_TAG="contrib/ws/$WS_VERSION"
+  git tag "$WS_TAG" -m "contrib/ws $WS_VERSION"
+  TAGS+=("$WS_TAG")
+fi
+
+git push origin "${TAGS[@]}"
 ```
 
 The release workflow and GitHub release are triggered by the core `v*` tag.
 Prefixed nested-module tags make those module versions available to the Go
-proxy without creating extra GitHub releases.
+proxy without creating extra GitHub releases. GitHub generates the release
+notes by comparing the new core release with the previous core release, so
+nested-module tags do not change that comparison range.
 
 ## Verification
 
 After pushing the tag, wait ~30s for the proxy, then verify the new version is fetchable in a fresh module:
 
 ```bash
-mkdir /tmp/kruda-verify && cd /tmp/kruda-verify
+VERIFY_DIR="$(mktemp -d)"
+cd "$VERIFY_DIR"
+export GOWORK=off
+
 go mod init verify
-go get github.com/go-kruda/kruda@v1.6.1
-go get github.com/go-kruda/kruda/contrib/ws@v1.3.1 # when released
-go build ./...
+go get "github.com/go-kruda/kruda@$CORE_VERSION"
+printf 'package main\n\nimport _ "github.com/go-kruda/kruda"\n\nfunc main() {}\n' > main.go
+go build .
+
+if [[ -n "${WS_VERSION:-}" ]]; then
+  go get "github.com/go-kruda/kruda/contrib/ws@$WS_VERSION"
+  go test github.com/go-kruda/kruda/contrib/ws
+fi
 ```
 
-If that succeeds, the GitHub release created by the release workflow is ready to publish.
+After GitHub Actions completes, confirm the Release workflow is green, the
+generated notes compare the expected core releases, and `LICENSE` plus
+`README.md` are attached to the published release.
 
 ## Hotfix flow
 
-For a v1.2.x patch:
+For a patch release:
 
-1. `git switch -c hotfix/v1.2.1 origin/main`
+1. `git switch -c hotfix/vX.Y.Z origin/main`
 2. Apply the fix + tests
 3. Update CHANGELOG.md
 4. Run `./scripts/pre-release.sh`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -89,14 +89,14 @@ Option 2 — Use stdlib JSON (no CGO):
 go build -tags kruda_stdjson ./...
 ```
 
-### Sonic fallback to encoding/json
+### Selecting the encoding/json fallback
 
-If Sonic can't initialize (missing CPU features, CGO disabled), Kruda silently falls back to `encoding/json`. This is safe — the API is identical, only performance differs.
+Kruda selects the JSON engine at build time. Disabling CGO selects `encoding/json` automatically; the `kruda_stdjson` tag selects it explicitly. Kruda does not switch engines at runtime after the binary has been built.
 
-To force stdlib JSON explicitly:
+Either of these builds uses stdlib JSON:
 
 ```bash
-export CGO_ENABLED=0
+CGO_ENABLED=0 go build ./...
 go build -tags kruda_stdjson ./...
 ```
 

--- a/scripts/pre-release.sh
+++ b/scripts/pre-release.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Pre-release validation for Kruda v1.2.0+ single-tag flow.
+# Pre-release validation for Kruda core and independently versioned modules.
 # Run this from the repo root before tagging. Exits non-zero on any failure.
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

- rely on GitHub-generated release notes to avoid duplicate notes and nested-module tag ranges
- make release commands version-agnostic and compile real downstream imports during verification
- align transport, WebSocket, JSON engine, typed-handler, and benchmark wording with the current implementation

## Validation

- `npm run build` in `docs/`
- parsed `.github/workflows/release.yml` as YAML
- `./scripts/pre-release.sh` with Go 1.25.11 (`ALL PRE-RELEASE CHECKS PASSED`)