### PR TITLE
ci: harden release preflight and security scan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           TAG_SHA="$(git rev-parse "${TAG_NAME}^{commit}")"
           echo "Tag ${TAG_NAME} points to ${TAG_SHA}"
 
-          git fetch origin main --depth=1
+          git fetch --no-tags origin main
           if ! git merge-base --is-ancestor "$TAG_SHA" origin/main; then
             echo "::error::Release tags must point to a commit that is already on origin/main."
             exit 1

--- a/scripts/govulncheck-modules.sh
+++ b/scripts/govulncheck-modules.sh
@@ -1,23 +1,23 @@
 #!/usr/bin/env bash
-# Run govulncheck against the root module and every nested contrib go.mod.
+# Run govulncheck against every released module: root, cmd/kruda, and contrib.
 # The root `govulncheck ./...` does not descend into nested modules, so each
-# standalone module (e.g. contrib/observability, which pins the OTel SDK) must
-# be scanned in its own module context to catch a regression to a vulnerable dep.
+# standalone module must be scanned in its own module context to catch a
+# regression to a vulnerable dependency.
 set -euo pipefail
 ROOT=$(git rev-parse --show-toplevel)
 cd "$ROOT"
 
 go install golang.org/x/vuln/cmd/govulncheck@latest
 GOVULN=$(go env GOPATH)/bin/govulncheck
+export GOWORK=off
 
 echo "== govulncheck (root) =="
 "$GOVULN" ./...
 
-# Nested contrib modules are excluded from the root go.work, so each scan runs
-# with GOWORK=off to resolve against the module's own go.mod (and its
-# `replace github.com/go-kruda/kruda => ../..`).
+# Every released module resolves against its own go.mod rather than a local
+# go.work, including the root scan above.
 while IFS= read -r modfile; do
   dir=$(dirname "$modfile")
   echo "== govulncheck ($dir) =="
-  ( cd "$dir" && GOWORK=off "$GOVULN" ./... )
-done < <(find contrib -mindepth 2 -maxdepth 2 -name go.mod -print | sort)
+  ( cd "$dir" && "$GOVULN" ./... )
+done < <(git ls-files 'cmd/kruda/go.mod' 'contrib/*/go.mod')


### PR DESCRIPTION
## Summary

- keep the release checkout's full history when refreshing `origin/main`, so valid main-ancestor tags are not rejected by a shallow boundary
- include the independently released `cmd/kruda` module in release vulnerability scans
- force every module scan to ignore local workspaces and resolve against its own `go.mod`
- enumerate tracked released modules so untracked directories and examples/bench remain out of scope

## Verification

- reproduced the old fetch turning a full clone shallow and returning a false ancestry result for `v1.6.1`
- verified the new fetch keeps full history and accepts the same valid ancestor
- passed Bash syntax and workflow YAML parsing
- passed Go 1.26.5 `govulncheck` for the root, `cmd/kruda`, and every contrib module