### PR TITLE
docs: prepare v1.6.2 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.6.2] — 2026-07-19
+
+### Security
+
+- `App.Static` now resolves files through a rooted filesystem, preventing
+  symlinked files, directories, directory indexes, and SPA fallback indexes from
+  serving content outside the configured root. Regular files and relative
+  in-root symlinks continue to work.
+
+### Changed
+
+- `App.Static` now opens its configured root when called, keeps it open until
+  `App.Shutdown`, and panics with the root path when the directory cannot be
+  opened.
+- Docs: updated `contrib/ws` examples and package documentation to register
+  WebSocket routes with `ws.HandleFunc`, which applies `kruda.Hijack` for Wing;
+  Wing and net/http are supported, while fasthttp remains unsupported.
+- Docs: corrected typed-handler validation, build-time JSON engine selection,
+  independent nested-module versioning, and unscoped performance claims.
+
 ## [1.6.1] — 2026-07-18
 
 ### Added


### PR DESCRIPTION
## Summary

- document `App.Static` root containment and fail-fast root opening
- include the documentation corrections shipped after v1.6.1
- record the user-facing scope without extending the claim to `StaticFS`

## Validation

- full `scripts/pre-release.sh` passed on main commit `4f7bff4`
- `scripts/check-docs.sh`
- `git diff --check`
- independent QA and code review

## Release plan

After this PR merges and the exact main commit passes both Tests and Benchmark, tag that commit as `v1.6.2` and `contrib/ws/v1.3.2`. The nested patch tag publishes the updated `contrib/ws` README and package documentation.