### PR TITLE
fix: drain transport before container shutdown

### DIFF
--- a/kruda.go
+++ b/kruda.go
@@ -353,13 +353,13 @@ func (app *App) shutdown() error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
+	err := app.transport.Shutdown(ctx)
 	if app.container != nil {
 		if err := app.container.Shutdown(ctx); err != nil {
 			app.config.Logger.Error("container shutdown error", "error", err)
 		}
 	}
 
-	err := app.transport.Shutdown(ctx)
 	app.runShutdownHooks()
 	app.config.Logger.Info("shutdown complete")
 	return err
@@ -368,13 +368,13 @@ func (app *App) shutdown() error {
 // Shutdown initiates graceful shutdown programmatically (useful for tests).
 // Also runs OnShutdown hooks in LIFO order.
 func (app *App) Shutdown(ctx context.Context) error {
+	err := app.transport.Shutdown(ctx)
 	if app.container != nil {
 		if err := app.container.Shutdown(ctx); err != nil {
 			app.config.Logger.Error("container shutdown error", "error", err)
 		}
 	}
 
-	err := app.transport.Shutdown(ctx)
 	app.runShutdownHooks()
 	return err
 }

--- a/shutdown_lifecycle_test.go
+++ b/shutdown_lifecycle_test.go
@@ -1,0 +1,90 @@
+package kruda
+
+import (
+	"context"
+	"errors"
+	"net"
+	"slices"
+	"testing"
+
+	"github.com/go-kruda/kruda/transport"
+)
+
+var errShutdownLifecycleTransport = errors.New("shutdown lifecycle transport error")
+
+type shutdownLifecycleTransport struct {
+	service        *shutdownLifecycleService
+	events         *[]string
+	sawServiceLive bool
+}
+
+func (tr *shutdownLifecycleTransport) ListenAndServe(string, transport.Handler) error {
+	return nil
+}
+
+func (tr *shutdownLifecycleTransport) Serve(net.Listener, transport.Handler) error {
+	return nil
+}
+
+func (tr *shutdownLifecycleTransport) Shutdown(context.Context) error {
+	*tr.events = append(*tr.events, "transport")
+	tr.sawServiceLive = tr.service.live
+	return errShutdownLifecycleTransport
+}
+
+type shutdownLifecycleService struct {
+	live   bool
+	events *[]string
+}
+
+func (s *shutdownLifecycleService) OnShutdown(context.Context) error {
+	*s.events = append(*s.events, "container")
+	s.live = false
+	return nil
+}
+
+func TestPrivateShutdownLifecycleOrder(t *testing.T) {
+	assertShutdownLifecycleOrder(t, (*App).shutdown)
+}
+
+func TestPublicShutdownLifecycleOrder(t *testing.T) {
+	assertShutdownLifecycleOrder(t, func(app *App) error {
+		return app.Shutdown(context.Background())
+	})
+}
+
+func assertShutdownLifecycleOrder(t *testing.T, shutdown func(*App) error) {
+	t.Helper()
+
+	events := make([]string, 0, 3)
+	service := &shutdownLifecycleService{live: true, events: &events}
+	container := NewContainer()
+	if err := container.Give(service); err != nil {
+		t.Fatalf("register lifecycle service: %v", err)
+	}
+
+	tr := &shutdownLifecycleTransport{service: service, events: &events}
+	app := New(WithContainer(container), WithTransport(tr))
+	hookSawServiceStopped := false
+	app.OnShutdown(func() {
+		events = append(events, "hook")
+		hookSawServiceStopped = !service.live
+	})
+
+	err := shutdown(app)
+	if !errors.Is(err, errShutdownLifecycleTransport) {
+		t.Fatalf("shutdown error = %v, want %v", err, errShutdownLifecycleTransport)
+	}
+	if !tr.sawServiceLive {
+		t.Error("transport Shutdown should run while the lifecycle service is still live")
+	}
+	if service.live {
+		t.Error("container lifecycle service should be stopped despite the transport error")
+	}
+	if !hookSawServiceStopped {
+		t.Error("OnShutdown hook should run after the container lifecycle service stops")
+	}
+	if want := []string{"transport", "container", "hook"}; !slices.Equal(events, want) {
+		t.Errorf("shutdown order = %v, want %v", events, want)
+	}
+}


### PR DESCRIPTION
## Summary

- stop accepting and drain transport work before tearing down dependency-container services
- preserve the caller context, transport error return, container error logging, and LIFO shutdown hooks
- cover both internal and public shutdown paths with deterministic lifecycle-order regressions

## Validation

- `go test -race -tags kruda_stdjson ./...`
- `go test -race ./...`
- `go vet ./...`
- focused shutdown race tests in both JSON configurations
- independent QA and code review