### PR TITLE
fix: complete Wing 100-continue requests

### DIFF
--- a/wing_body_pipeline_test.go
+++ b/wing_body_pipeline_test.go
@@ -24,6 +24,151 @@ func echoLenHandler() transport.Handler {
 	})
 }
 
+// exerciseExpectContinue sends request headers and body in separate writes. The
+// second parsed response must be the final response, which also guards against
+// Wing emitting the interim response more than once.
+func exerciseExpectContinue(t *testing.T, conn net.Conn, reader *bufio.Reader, path, body string) {
+	t.Helper()
+
+	headers := fmt.Sprintf("POST %s HTTP/1.1\r\nHost: h\r\nExpect: 100-continue\r\nContent-Length: %d\r\n\r\n", path, len(body))
+	if _, err := conn.Write([]byte(headers)); err != nil {
+		t.Fatalf("write Expect headers: %v", err)
+	}
+
+	status, interimBody, err := readHTTPResponse(reader)
+	if err != nil {
+		t.Fatalf("read interim response: %v", err)
+	}
+	if status != "HTTP/1.1 100 Continue" || interimBody != "" {
+		t.Fatalf("interim response = (%q, %q), want exactly one 100 Continue with no body", status, interimBody)
+	}
+
+	if _, err := conn.Write([]byte(body)); err != nil {
+		t.Fatalf("write body after 100 Continue: %v", err)
+	}
+
+	status, responseBody, err := readHTTPResponse(reader)
+	if err != nil {
+		t.Fatalf("read final response: %v", err)
+	}
+	wantBody := fmt.Sprintf("POST %s len=%d", path, len(body))
+	if status != "HTTP/1.1 200 OK" || responseBody != wantBody {
+		t.Fatalf("final response = (%q, %q), want (HTTP/1.1 200 OK, %q)", status, responseBody, wantBody)
+	}
+}
+
+func TestWing_EventLoop_Expect100Continue(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing integration test in short mode")
+	}
+	body := strings.Repeat("e", 16*1024)
+	cfg := WingConfig{
+		Workers:              1,
+		ReadBufSize:          8192,
+		BodyLimit:            64 * 1024,
+		MaxInflightBodyBytes: len(body),
+	}
+	addr, stop := startWingServerWithConfig(t, cfg, echoLenHandler())
+	defer stop()
+
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	exerciseExpectContinue(t, conn, bufio.NewReader(conn), "/event-loop", body)
+}
+
+func TestWing_Takeover_Expect100Continue(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing integration test in short mode")
+	}
+	body := strings.Repeat("t", 16*1024)
+	cfg := WingConfig{
+		Workers:              1,
+		ReadBufSize:          8192,
+		BodyLimit:            64 * 1024,
+		MaxInflightBodyBytes: len(body),
+		DefaultPreset:        DB,
+	}
+	addr, stop := startWingServerWithConfig(t, cfg, echoLenHandler())
+	defer stop()
+
+	conn, reader := takeoverEstablish(t, addr)
+	defer conn.Close()
+
+	exerciseExpectContinue(t, conn, reader, "/takeover", body)
+}
+
+// TestWing_EventLoop_Expect100_EagerBodyDoesNotLeakContinue verifies that an
+// Expect request completed synchronously inside beginBodyAccum does not reuse
+// its stale Expect decision after reentrant parsing starts the next request's
+// non-Expect body accumulation. The 512-byte read buffer forces request 1 into
+// parseNeedBody; the same client write queues its remaining body plus request 2
+// headers and a partial body for the synchronous drain/reentrant parse.
+func TestWing_EventLoop_Expect100_EagerBodyDoesNotLeakContinue(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing integration test in short mode")
+	}
+	const (
+		bodyLen       = 1024
+		secondBodyNow = 64
+	)
+	cfg := WingConfig{
+		Workers:              1,
+		ReadBufSize:          512,
+		BodyLimit:            4 * 1024,
+		MaxInflightBodyBytes: 4 * 1024,
+	}
+	addr, stop := startWingServerWithConfig(t, cfg, echoLenHandler())
+	defer stop()
+
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	conn.SetDeadline(time.Now().Add(5 * time.Second))
+
+	firstBody := strings.Repeat("a", bodyLen)
+	secondBody := strings.Repeat("b", bodyLen)
+	queued := fmt.Sprintf("POST /first HTTP/1.1\r\nHost: h\r\nExpect: 100-continue\r\nContent-Length: %d\r\n\r\n", len(firstBody)) + firstBody +
+		fmt.Sprintf("POST /second HTTP/1.1\r\nHost: h\r\nConnection: close\r\nContent-Length: %d\r\n\r\n", len(secondBody)) + secondBody[:secondBodyNow]
+	if _, err := conn.Write([]byte(queued)); err != nil {
+		t.Fatalf("write eager Expect body and pipelined partial body: %v", err)
+	}
+
+	reader := bufio.NewReader(conn)
+	status, responseBody, err := readHTTPResponse(reader)
+	if err != nil {
+		t.Fatalf("read first interim response: %v", err)
+	}
+	if status != "HTTP/1.1 100 Continue" || responseBody != "" {
+		t.Fatalf("first interim response = (%q, %q), want exactly one 100 Continue", status, responseBody)
+	}
+
+	status, responseBody, err = readHTTPResponse(reader)
+	if err != nil {
+		t.Fatalf("read first final response: %v", err)
+	}
+	if status != "HTTP/1.1 200 OK" || responseBody != "POST /first len=1024" {
+		t.Fatalf("first final response = (%q, %q), want 200 for /first after its single 100", status, responseBody)
+	}
+
+	if _, err := conn.Write([]byte(secondBody[secondBodyNow:])); err != nil {
+		t.Fatalf("finish pipelined non-Expect body: %v", err)
+	}
+	status, responseBody, err = readHTTPResponse(reader)
+	if err != nil {
+		t.Fatalf("read second final response: %v", err)
+	}
+	if status != "HTTP/1.1 200 OK" || responseBody != "POST /second len=1024" {
+		t.Fatalf("second response = (%q, %q), want final 200 for /second with no leaked 100", status, responseBody)
+	}
+}
+
 // TestWing_EventLoop_PipelinedAfterAccumulatedBody verifies that a request
 // pipelined immediately after a body that required multi-read accumulation is
 // not dropped. The body (16KB) exceeds the 8KB read buffer, forcing the

--- a/wing_bodylimit_test.go
+++ b/wing_bodylimit_test.go
@@ -36,6 +36,46 @@ func sendRaw(t *testing.T, addr, raw string) (status string, closed bool) {
 	return strings.TrimSpace(line), false
 }
 
+// readRawUntilClose collects a terminal response. Budget rejection closes the
+// connection, so a timeout indicates that the rejection path did not finish.
+func readRawUntilClose(t *testing.T, conn net.Conn, reader *bufio.Reader) string {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	var response bytes.Buffer
+	buf := make([]byte, 4096)
+	for {
+		n, err := reader.Read(buf)
+		if n > 0 {
+			response.Write(buf[:n])
+		}
+		if err != nil {
+			if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				t.Fatalf("timed out waiting for terminal response close: %q", response.String())
+			}
+			return response.String()
+		}
+	}
+}
+
+func requireBudgetRejectWithoutContinue(t *testing.T, conn net.Conn, reader *bufio.Reader, path string, bodyLen int) {
+	t.Helper()
+	headers := fmt.Sprintf("POST %s HTTP/1.1\r\nHost: h\r\nExpect: 100-continue\r\nContent-Length: %d\r\n\r\n", path, bodyLen)
+	if _, err := conn.Write([]byte(headers)); err != nil {
+		t.Fatalf("write Expect headers: %v", err)
+	}
+
+	response := readRawUntilClose(t, conn, reader)
+	if !strings.HasPrefix(response, "HTTP/1.1 503 Service Unavailable\r\n") {
+		t.Fatalf("first response must be 503 Service Unavailable, got %q", response)
+	}
+	if strings.Contains(response, "HTTP/1.1 100 Continue") {
+		t.Fatalf("budget rejection must never emit 100 Continue, got %q", response)
+	}
+	if got := strings.Count(response, "HTTP/1.1 "); got != 1 {
+		t.Fatalf("budget rejection emitted %d HTTP status lines, want exactly 1: %q", got, response)
+	}
+}
+
 func TestWingConfig_DerivesReadBufFromHeaderLimit(t *testing.T) {
 	c := WingConfig{HeaderLimit: 16384}
 	c.defaults()
@@ -107,6 +147,50 @@ func TestWing_Expect100_OversizedGets413BeforeBody(t *testing.T) {
 	if !strings.Contains(st, "413") {
 		t.Fatalf("expect+oversized: want 413, got %q", st)
 	}
+}
+
+func TestWing_EventLoop_Expect100_BudgetRejectedBeforeContinue(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing integration test in short mode")
+	}
+	const bodyLen = 16 * 1024
+	cfg := WingConfig{
+		Workers:              1,
+		ReadBufSize:          8192,
+		BodyLimit:            64 * 1024,
+		MaxInflightBodyBytes: bodyLen - 1,
+	}
+	addr, stop := startWingServerWithConfig(t, cfg, echoLenHandler())
+	defer stop()
+
+	conn, err := net.DialTimeout("tcp", addr, time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	requireBudgetRejectWithoutContinue(t, conn, bufio.NewReader(conn), "/event-loop-budget", bodyLen)
+}
+
+func TestWing_Takeover_Expect100_BudgetRejectedBeforeContinue(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Wing integration test in short mode")
+	}
+	const bodyLen = 16 * 1024
+	cfg := WingConfig{
+		Workers:              1,
+		ReadBufSize:          8192,
+		BodyLimit:            64 * 1024,
+		MaxInflightBodyBytes: bodyLen - 1,
+		DefaultPreset:        DB,
+	}
+	addr, stop := startWingServerWithConfig(t, cfg, echoLenHandler())
+	defer stop()
+
+	conn, reader := takeoverEstablish(t, addr)
+	defer conn.Close()
+
+	requireBudgetRejectWithoutContinue(t, conn, reader, "/takeover-budget", bodyLen)
 }
 
 // startBodyLimitWingServer starts a Wing server with the given body limit.

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -806,14 +806,7 @@ func (w *worker) tryParse(c *conn) {
 					w.writeAndClose(c, wingStatusClose(413))
 					return
 				case parseNeedBody:
-					if expectContinue {
-						c.sendBuf = append(c.sendBuf, wing100Continue...)
-						// Flush it immediately so the client sends the body.
-						if c.sendN < len(c.sendBuf) {
-							w.directSend(c) // non-blocking; rest of buf stays queued if partial
-						}
-					}
-					if !w.beginBodyAccum(c, need) {
+					if !w.beginBodyAccum(c, need, expectContinue) {
 						w.writeAndClose(c, wingStatusClose(503))
 						return
 					}
@@ -836,14 +829,7 @@ func (w *worker) tryParse(c *conn) {
 					w.writeAndClose(c, wingStatusClose(413))
 					return
 				case parseNeedBody:
-					if expectContinue {
-						c.sendBuf = append(c.sendBuf, wing100Continue...)
-						// Flush it immediately so the client sends the body.
-						if c.sendN < len(c.sendBuf) {
-							w.directSend(c) // non-blocking; rest of buf stays queued if partial
-						}
-					}
-					if !w.beginBodyAccum(c, need) {
+					if !w.beginBodyAccum(c, need, expectContinue) {
 						w.writeAndClose(c, wingStatusClose(503))
 						return
 					}
@@ -1090,9 +1076,9 @@ func accumBody(bodyBuf, src []byte, need int) (out, surplus []byte) {
 	return out, src[take:]
 }
 
-// beginBodyAccum starts body accumulation for a connection.
+// beginBodyAccum reserves and starts body accumulation for a connection.
 // Returns false if the per-worker in-flight budget would be exceeded.
-func (w *worker) beginBodyAccum(c *conn, need int) bool {
+func (w *worker) beginBodyAccum(c *conn, need int, expectContinue bool) bool {
 	if w.maxInflightBody > 0 {
 		newTotal := atomic.AddInt64(&w.inflightBody, int64(need))
 		if newTotal > int64(w.maxInflightBody) {
@@ -1127,6 +1113,17 @@ func (w *worker) beginBodyAccum(c *conn, need int) bool {
 		c.readN = copy(c.readBuf, surplus)
 	} else {
 		c.readN = 0
+	}
+	if expectContinue && len(c.bodyBuf) < c.bodyNeed {
+		c.sendBuf = append(c.sendBuf, wing100Continue...)
+		// Flush only after this request owns its body budget, but before draining
+		// can complete it and recursively parse a later pipelined request.
+		if c.sendN < len(c.sendBuf) {
+			w.directSend(c) // non-blocking; rest of buf stays queued if partial
+			if c.bodyNeed == 0 {
+				return true // directSend closed the connection on a hard write error
+			}
+		}
 	}
 	w.drainBodyAccum(c)
 	return true
@@ -1326,6 +1323,10 @@ func (w *worker) directSend(c *conn) {
 		syscall.Close(int(c.sendFileFd))
 		c.sendFileFd = 0
 	}
+	if c.bodyNeed > 0 {
+		// Body accumulation owns receive arming; do not apply final-response handling.
+		return
+	}
 	if !c.keepAlive {
 		w.closeConn(c.fd)
 		return
@@ -1486,9 +1487,6 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte, mod
 					keepAlive = false
 					goto done
 				case parseNeedBody:
-					if expectContinue {
-						f.Write(wing100Continue)
-					}
 					// Locate end of header block.
 					headerEnd := bytes.Index(buf[:readN], crlfcrlf)
 					if headerEnd < 0 {
@@ -1505,6 +1503,15 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte, mod
 						if atomic.AddInt64(&w.inflightBody, int64(need)) > int64(w.maxInflightBody) {
 							atomic.AddInt64(&w.inflightBody, -int64(need))
 							f.Write(wingStatusClose(503))
+							keepAlive = false
+							goto done
+						}
+					}
+					if expectContinue {
+						if _, werr := f.Write(wing100Continue); werr != nil {
+							if w.maxInflightBody > 0 {
+								atomic.AddInt64(&w.inflightBody, -int64(need))
+							}
 							keepAlive = false
 							goto done
 						}


### PR DESCRIPTION
## Summary

- reserve in-flight body budget before sending 100 Continue
- keep event-loop connections alive while awaiting the request body
- preserve interim/final ordering across partial writes and takeover mode
- prevent an eager pipelined request from leaking Expect state into the next request

## Testing

- go test -count=1 -race ./...
- go test -count=1 -race -tags kruda_stdjson ./...
- go vet ./...
- focused Expect regression suite under race, 20 repetitions per JSON engine
- TestParseFastPath_AllocBaseline