### PR TITLE
fix: honor Wing HTTP persistence semantics

### DIFF
--- a/integration_transport_test.go
+++ b/integration_transport_test.go
@@ -227,6 +227,75 @@ func TestTransportTakeoverKeepAlive_Wing(t *testing.T) {
 	}
 }
 
+// TestTransportHTTP10Persistence_Wing verifies the connection lifecycle only.
+// Wing still serializes HTTP/1.1 response lines; response-version negotiation is
+// intentionally outside this test and this persistence fix.
+func TestTransportHTTP10Persistence_Wing(t *testing.T) {
+	app := New(Wing())
+	app.Get("/event", func(c *Ctx) error { return c.Text("event") })
+	app.Get("/take", func(c *Ctx) error { return c.Text("take") }, DB)
+	app.Compile()
+
+	if app.transportType != "wing" {
+		t.Skipf("wing transport not selected on this platform (got %q)", app.transportType)
+	}
+
+	addr, shutdown := startSmokeApp(t, app, "/event")
+	defer shutdown()
+
+	for _, tt := range []struct {
+		name string
+		path string
+		body string
+	}{
+		{name: "event loop", path: "/event", body: "event"},
+		{name: "takeover", path: "/take", body: "take"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			conn, err := net.DialTimeout("tcp", addr, time.Second)
+			if err != nil {
+				t.Fatalf("dial: %v", err)
+			}
+			defer conn.Close()
+			conn.SetDeadline(time.Now().Add(5 * time.Second))
+			br := bufio.NewReader(conn)
+
+			readOK := func(step string) {
+				t.Helper()
+				resp, err := http.ReadResponse(br, nil)
+				if err != nil {
+					t.Fatalf("%s: read response: %v", step, err)
+				}
+				body, readErr := io.ReadAll(resp.Body)
+				_ = resp.Body.Close()
+				if readErr != nil {
+					t.Fatalf("%s: read body: %v", step, readErr)
+				}
+				if resp.StatusCode != http.StatusOK || string(body) != tt.body {
+					t.Fatalf("%s: got status %d body %q, want 200 %q", step, resp.StatusCode, body, tt.body)
+				}
+			}
+
+			keepAliveReq := fmt.Sprintf("GET %s HTTP/1.0\r\nConnection: keep-alive\r\n\r\n", tt.path)
+			if _, err := conn.Write([]byte(keepAliveReq)); err != nil {
+				t.Fatalf("write keep-alive request: %v", err)
+			}
+			readOK("keep-alive request")
+
+			defaultCloseReq := fmt.Sprintf("GET %s HTTP/1.0\r\n\r\n", tt.path)
+			if _, err := conn.Write([]byte(defaultCloseReq)); err != nil {
+				t.Fatalf("write default-close request: %v", err)
+			}
+			readOK("default-close request")
+
+			_ = conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+			if _, err := br.ReadByte(); err != io.EOF {
+				t.Fatalf("after HTTP/1.0 default-close response, want EOF from server, got %v", err)
+			}
+		})
+	}
+}
+
 // startSmokeApp binds the App's transport to a random TCP port, starts
 // Serve in a goroutine, and waits until the app serves an HTTP request.
 // Returns the bound addr and a shutdown closure that the caller must defer.

--- a/wing_http.go
+++ b/wing_http.go
@@ -94,7 +94,8 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 	if !isValidHTTPVersion(version) {
 		return nil, 0, false
 	}
-	requireHost := requiresHostHeader(version)
+	http11OrLater := requiresHostHeader(version)
+	http10 := version[5] == '1' && version[7] == '0'
 
 	// Method must be a valid RFC 7230 token (net/http's isToken rule); a
 	// method containing a delimiter/CTL byte (e.g. a quote) is rejected so
@@ -139,7 +140,9 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 	hostUnsafe := false
 	acceptUnsafe := false
 	connectionUnsafe := false
-	keepAlive := true // HTTP/1.1 default
+	connectionSeen := false
+	connectionClose := false
+	connectionKeepAlive := false
 	headerCount := 0
 	contentLengthSeen := false
 	hasTE := false
@@ -248,15 +251,16 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 			contentType = string(val)
 			continue
 		case headerConnection:
-			if asciiEqualFold(val, bClose) {
-				keepAlive = false
-			}
+			hasClose, hasKeepAlive := scanConnectionTokens(val)
+			connectionClose = connectionClose || hasClose
+			connectionKeepAlive = connectionKeepAlive || hasKeepAlive
 			// Retain the FIRST Connection value so Header("Connection") works
 			// (e.g. a WebSocket "Connection: Upgrade" check). First-wins matches
 			// net/http's http.Header.Get, so c.Header("Connection") is identical
-			// across transports; keep-alive detection above still scans every
+			// across transports; persistence detection above still scans every
 			// line. Zero-copy like host/accept.
-			if connection == "" {
+			if !connectionSeen {
+				connectionSeen = true
 				connection = copyOrUnsafeString(val, unsafePath)
 				connectionUnsafe = unsafePath && len(val) > 0
 			}
@@ -326,12 +330,13 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 		case headerContentType:
 			contentType = string(val)
 		case headerConnection:
-			if asciiEqualFold(val, bClose) {
-				keepAlive = false
-			}
+			hasClose, hasKeepAlive := scanConnectionTokens(val)
+			connectionClose = connectionClose || hasClose
+			connectionKeepAlive = connectionKeepAlive || hasKeepAlive
 			// Retain the FIRST Connection value (first-wins, matching net/http) —
 			// see the fast-path case above for the rationale.
-			if connection == "" {
+			if !connectionSeen {
+				connectionSeen = true
 				connection = copyOrUnsafeString(val, unsafePath)
 				connectionUnsafe = unsafePath && len(val) > 0
 			}
@@ -386,9 +391,14 @@ func parseHTTPRequestInternal(data []byte, limits parserLimits, unsafePath bool)
 			}
 		}
 	}
-	if requireHost && !hostSeen {
+	if http11OrLater && !hostSeen {
 		return nil, 0, false
 	}
+
+	// HTTP/1.0 closes by default and requires an explicit keep-alive token.
+	// HTTP/1.1 and later persist by default. A close token always wins,
+	// including when it appears on another Connection field line.
+	keepAlive := !connectionClose && (http11OrLater || http10 && connectionKeepAlive)
 
 	// Reject requests with both Transfer-Encoding and Content-Length (RFC 7230 §3.3.3).
 	if hasTE && hasCL {
@@ -511,6 +521,7 @@ var (
 	bContentType      = []byte("content-type")
 	bConnection       = []byte("connection")
 	bClose            = []byte("close")
+	bKeepAlive        = []byte("keep-alive")
 	bTransferEncoding = []byte("transfer-encoding")
 	bExpect           = []byte("expect")
 	bCookie           = []byte("cookie")
@@ -776,6 +787,29 @@ func asciiEqualFold(a []byte, b []byte) bool {
 		}
 	}
 	return true
+}
+
+// scanConnectionTokens reports persistence directives in a comma-separated
+// Connection field value. It compares byte slices in place so the request
+// parser's fast path remains allocation-free.
+func scanConnectionTokens(value []byte) (hasClose, hasKeepAlive bool) {
+	for {
+		comma := bytes.IndexByte(value, ',')
+		token := value
+		if comma >= 0 {
+			token = value[:comma]
+		}
+		token = trimHTTPSpaces(token)
+		if len(token) == len(bClose) {
+			hasClose = hasClose || asciiEqualFold(token, bClose)
+		} else if len(token) == len(bKeepAlive) {
+			hasKeepAlive = hasKeepAlive || asciiEqualFold(token, bKeepAlive)
+		}
+		if hasClose && hasKeepAlive || comma < 0 {
+			return hasClose, hasKeepAlive
+		}
+		value = value[comma+1:]
+	}
 }
 
 const maxContentLength = 10 << 20 // 10 MB — reject absurd values

--- a/wing_http_test.go
+++ b/wing_http_test.go
@@ -68,25 +68,95 @@ func TestParseHTTPRequest_WithBody(t *testing.T) {
 	}
 }
 
-func TestParseHTTPRequest_ConnectionClose(t *testing.T) {
-	raw := "GET / HTTP/1.1\r\nHost: h\r\nConnection: close\r\n\r\n"
-	req, _, ok := parseHTTPRequest([]byte(raw), noLimits)
-	if !ok {
-		t.Fatal("parse failed")
+func TestParseHTTPRequest_ConnectionPersistence(t *testing.T) {
+	tests := []struct {
+		name           string
+		raw            string
+		wantKeepAlive  bool
+		wantConnection string
+	}{
+		{
+			name:          "http11 defaults persistent",
+			raw:           "GET / HTTP/1.1\r\nHost: h\r\n\r\n",
+			wantKeepAlive: true,
+		},
+		{
+			name:           "http11 close case insensitive",
+			raw:            "GET / HTTP/1.1\r\nHost: h\r\nCONNECTION: CLOSE\r\n\r\n",
+			wantConnection: "CLOSE",
+		},
+		{
+			name:           "http11 comma close",
+			raw:            "GET / HTTP/1.1\r\nHost: h\r\nConnection: upgrade, close\r\n\r\n",
+			wantConnection: "upgrade, close",
+		},
+		{
+			name:           "http11 repeated close wins",
+			raw:            "GET / HTTP/1.1\r\nHost: h\r\nConnection: keep-alive\r\nConnection: close\r\n\r\n",
+			wantConnection: "keep-alive",
+		},
+		{
+			name: "http10 defaults close",
+			raw:  "GET / HTTP/1.0\r\n\r\n",
+		},
+		{
+			name:           "http00 ignores keep-alive extension",
+			raw:            "GET / HTTP/0.0\r\nConnection: keep-alive\r\n\r\n",
+			wantConnection: "keep-alive",
+		},
+		{
+			name:           "http10 keep-alive token",
+			raw:            "GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n",
+			wantKeepAlive:  true,
+			wantConnection: "keep-alive",
+		},
+		{
+			name:           "http10 comma keep-alive case insensitive",
+			raw:            "GET / HTTP/1.0\r\nConnection: upgrade, Keep-Alive\r\n\r\n",
+			wantKeepAlive:  true,
+			wantConnection: "upgrade, Keep-Alive",
+		},
+		{
+			name:           "http10 close wins in one field",
+			raw:            "GET / HTTP/1.0\r\nConnection: keep-alive, close\r\n\r\n",
+			wantConnection: "keep-alive, close",
+		},
+		{
+			name:           "http10 close wins across repeated fields",
+			raw:            "GET / HTTP/1.0\r\nConnection: keep-alive\r\nConnection: close\r\n\r\n",
+			wantConnection: "keep-alive",
+		},
+		{
+			name:          "first empty value retained while later token applies",
+			raw:           "GET / HTTP/1.0\r\nConnection:\r\nConnection: keep-alive\r\n\r\n",
+			wantKeepAlive: true,
+		},
 	}
-	if req.keepAlive {
-		t.Error("keepAlive should be false when Connection: close")
-	}
-}
 
-func TestParseHTTPRequest_ConnectionCloseCaseInsensitive(t *testing.T) {
-	raw := "GET / HTTP/1.1\r\nHost: h\r\nCONNECTION: CLOSE\r\n\r\n"
-	req, _, ok := parseHTTPRequest([]byte(raw), noLimits)
-	if !ok {
-		t.Fatal("parse failed")
+	parsers := []struct {
+		name  string
+		parse func([]byte, parserLimits) (*wingRequest, int, bool)
+	}{
+		{name: "safe", parse: parseHTTPRequest},
+		{name: "fast", parse: parseHTTPRequestFast},
 	}
-	if req.keepAlive {
-		t.Error("keepAlive should be false when CONNECTION: CLOSE")
+
+	for _, parser := range parsers {
+		for _, tt := range tests {
+			t.Run(parser.name+"/"+tt.name, func(t *testing.T) {
+				req, _, ok := parser.parse([]byte(tt.raw), noLimits)
+				if !ok {
+					t.Fatal("parse failed")
+				}
+				defer releaseRequest(req)
+				if req.keepAlive != tt.wantKeepAlive {
+					t.Fatalf("keepAlive = %v, want %v", req.keepAlive, tt.wantKeepAlive)
+				}
+				if got := req.Header("Connection"); got != tt.wantConnection {
+					t.Fatalf("Header(Connection) = %q, want %q", got, tt.wantConnection)
+				}
+			})
+		}
 	}
 }
 
@@ -1500,11 +1570,10 @@ func TestPipelining_PUTandPATCHWithBody(t *testing.T) {
 	}
 }
 
-// TestPipelining_HTTP10KeepAliveDefault verifies that HTTP/1.0 requests
-// default to keepAlive=true in our parser (same as HTTP/1.1). The parser
-// is version-agnostic; connection management is the caller's responsibility.
-// This test documents the current behavior for pipelining correctness.
-func TestPipelining_HTTP10KeepAliveDefault(t *testing.T) {
+// TestPipelining_HTTP10DefaultClose verifies that an HTTP/1.0 request consumes
+// only its own bytes but tells the transport not to process a pipelined request
+// unless persistence was explicitly requested.
+func TestPipelining_HTTP10DefaultClose(t *testing.T) {
 	req1 := "GET /a HTTP/1.0\r\n\r\n"
 	req2 := "GET /b HTTP/1.1\r\nHost: h\r\n\r\n"
 	buf := []byte(req1 + req2)
@@ -1513,10 +1582,10 @@ func TestPipelining_HTTP10KeepAliveDefault(t *testing.T) {
 	if !ok {
 		t.Fatal("HTTP/1.0 request should parse")
 	}
-	// Document current behavior: parser treats keepAlive as true regardless
-	// of HTTP version (HTTP/1.1 default). The transport layer is responsible
-	// for enforcing HTTP/1.0 connection semantics.
-	_ = r1.keepAlive // just ensure it doesn't panic
+	defer releaseRequest(r1)
+	if r1.keepAlive {
+		t.Fatal("HTTP/1.0 request without Connection: keep-alive must close")
+	}
 
 	// Second request (HTTP/1.1) must still be parseable.
 	buf = buf[c1:]
@@ -1524,6 +1593,7 @@ func TestPipelining_HTTP10KeepAliveDefault(t *testing.T) {
 	if !ok {
 		t.Fatal("HTTP/1.1 after HTTP/1.0 should parse")
 	}
+	defer releaseRequest(r2)
 	if r2.Path() != "/b" {
 		t.Errorf("Path = %q, want /b", r2.Path())
 	}

--- a/wing_parser_differential_test.go
+++ b/wing_parser_differential_test.go
@@ -58,6 +58,10 @@ func FuzzParserDifferential(f *testing.F) {
 	f.Add([]byte("GET / HTTP/1.1\r\nHost: bad host\r\n\r\n"))
 	f.Add([]byte("GET / HTTP/1.1\r\nHost:\r\n\r\n"))
 	f.Add([]byte("GET / HTTP/1.0\r\n\r\n"))
+	f.Add([]byte("GET / HTTP/0.0\r\nConnection: keep-alive\r\n\r\n"))
+	f.Add([]byte("GET / HTTP/1.0\r\nConnection: keep-alive\r\n\r\n"))
+	f.Add([]byte("GET / HTTP/1.0\r\nConnection: keep-alive, close\r\n\r\n"))
+	f.Add([]byte("GET / HTTP/1.1\r\nHost: a\r\nConnection: upgrade, close\r\n\r\n"))
 	f.Add([]byte("GET / HTTP/2.0\r\n\r\n"))
 	// leading CRLF before the request-line, on what a real server would
 	// treat as a fresh/non-POST-preceded connection — not a framing
@@ -133,6 +137,9 @@ func FuzzParserDifferential(f *testing.F) {
 		}
 		if wingReq.Method() != stdReq.Method {
 			t.Errorf("method disagrees: wing=%q std=%q for %q", wingReq.Method(), stdReq.Method, data)
+		}
+		if wantKeepAlive := !stdReq.Close; wingReq.keepAlive != wantKeepAlive {
+			t.Errorf("connection persistence disagrees: wing keepAlive=%v std keepAlive=%v for %q", wingReq.keepAlive, wantKeepAlive, data)
 		}
 		stdBody, _ := io.ReadAll(stdReq.Body)
 		wingBody, _ := wingReq.Body()


### PR DESCRIPTION
## Summary

- close HTTP/1.0 connections by default and allow explicit keep-alive
- keep HTTP/1.1 and later persistent by default while making any close token win
- scan case-insensitive comma-separated and repeated Connection fields without allocations
- preserve the first raw Connection value exposed to handlers, including an empty value
- verify event-loop and takeover lifecycle behavior against net/http semantics

## Scope

Response status lines remain serialized as HTTP/1.1. This change is limited to socket reuse and closure decisions.

## Testing

- go test -count=1 -race ./...
- go test -count=1 -race -tags kruda_stdjson ./...
- go vet ./...
- focused parser and lifecycle race tests with repeated runs
- 30-second differential fuzz against net/http Request.Close
- TestParseFastPath_AllocBaseline