### PR TITLE
docs: remove stale Wing setup guidance

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,9 +40,11 @@ jobs:
           go install github.com/mgechev/revive@v1.12.0
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
-      - name: Check exported API docs
+      - name: Check documentation
         if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25.11'
-        run: scripts/check-godoc.sh
+        run: |
+          scripts/check-docs.sh
+          scripts/check-godoc.sh
 
       - name: Go vet
         run: go vet -tags kruda_stdjson ./...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,7 @@ kruda/
 ├── *.go              # Core framework (minimal external deps)
 ├── wing_*.go          # Wing transport (epoll on Linux / kqueue on macOS) — flattened into core since v1.2.0
 ├── middleware/        # Built-in middleware (Logger, Recovery, CORS, etc.)
-├── transport/         # Transport adapter interfaces (nethttp, fasthttp)
-│   └── wing/          # Compatibility shim for the old Wing import path
+├── transport/         # Transport interfaces and net/http/fasthttp adapters
 ├── contrib/           # Optional modules (JWT, WebSocket, RateLimit, …)
 ├── json/              # JSON engine abstraction
 ├── examples/          # Example applications
@@ -69,16 +68,17 @@ cd contrib/ws && go test ./...
 cd contrib/ratelimit && go test ./...
 ```
 
-**Cross-module dev tip:** contrib `go.mod` files require the latest tagged
-core (e.g. `kruda v1.2.0`). When you change core and want a contrib package
-or the legacy Wing compatibility shim to see those changes locally — before
-the next core tag exists on the proxy — set up a Go workspace:
+**Cross-module dev tip:** contrib `go.mod` files require a tagged core release.
+When you change core and want a contrib package to see those changes locally —
+before the next core tag exists on the proxy — set up a Go workspace:
 
 ```bash
-go work init . transport/wing contrib/cache contrib/compress contrib/etag \
-              contrib/jwt contrib/otel contrib/prometheus contrib/ratelimit \
-              contrib/session contrib/swagger contrib/ws
+go work init . contrib/cache contrib/compress contrib/etag contrib/jwt \
+              contrib/observability contrib/otel contrib/prometheus \
+              contrib/ratelimit contrib/session contrib/swagger contrib/ws
 ```
+
+Wing is part of the core module and does not need a separate workspace entry.
 
 `go.work` is gitignored on purpose — it's a local-dev convenience and should
 not be committed. CI uses an ephemeral `go mod edit -replace=...` per

--- a/bench/go.mod
+++ b/bench/go.mod
@@ -2,10 +2,7 @@ module github.com/go-kruda/kruda/bench
 
 go 1.25.10
 
-replace (
-	github.com/go-kruda/kruda => ../
-	github.com/go-kruda/kruda/transport/wing => ../transport/wing
-)
+replace github.com/go-kruda/kruda => ../
 
 require (
 	github.com/go-kruda/kruda v0.0.0-00010101000000-000000000000

--- a/bench/reproducible/kruda/go.mod
+++ b/bench/reproducible/kruda/go.mod
@@ -73,6 +73,4 @@ require (
 
 replace github.com/go-kruda/kruda => ../../../
 
-replace github.com/go-kruda/kruda/transport/wing => ../../../transport/wing
-
 replace github.com/go-kruda/kruda/contrib/observability => ../../../contrib/observability

--- a/contrib/session/README.md
+++ b/contrib/session/README.md
@@ -10,12 +10,14 @@ go get github.com/go-kruda/kruda/contrib/session
 
 ## Usage
 
-**Important:** Requires `kruda.NetHTTP()` transport (Wing skips Set-Cookie headers in fast path).
+Session cookies work with Kruda's default transport. When `Set-Cookie` is
+present, Wing automatically leaves its header-minimal fast path, so no
+`NetHTTP` override is required.
 
 ```go
 import "github.com/go-kruda/kruda/contrib/session"
 
-app := kruda.New(kruda.NetHTTP())
+app := kruda.New()
 app.Use(session.New())
 
 app.Get("/login", func(c *kruda.Ctx) error {

--- a/examples/ratelimit/go.mod
+++ b/examples/ratelimit/go.mod
@@ -5,7 +5,6 @@ go 1.25.11
 replace (
 	github.com/go-kruda/kruda => ../../
 	github.com/go-kruda/kruda/contrib/ratelimit => ../../contrib/ratelimit
-	github.com/go-kruda/kruda/transport/wing => ../../transport/wing
 )
 
 require (

--- a/examples/session/go.mod
+++ b/examples/session/go.mod
@@ -5,7 +5,6 @@ go 1.25.11
 replace (
 	github.com/go-kruda/kruda => ../../
 	github.com/go-kruda/kruda/contrib/session => ../../contrib/session
-	github.com/go-kruda/kruda/transport/wing => ../../transport/wing
 )
 
 require (

--- a/examples/websocket/go.mod
+++ b/examples/websocket/go.mod
@@ -5,7 +5,6 @@ go 1.25.11
 replace (
 	github.com/go-kruda/kruda => ../../
 	github.com/go-kruda/kruda/contrib/ws => ../../contrib/ws
-	github.com/go-kruda/kruda/transport/wing => ../../transport/wing
 )
 
 require (

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -15,7 +15,13 @@ ok() { printf "\033[32m ✓\033[0m %s\n" "$*"; }
 current_docs=()
 while IFS= read -r file; do
   current_docs+=("$file")
-done < <(git ls-files 'docs/guide/*.md' 'docs/api/*.md' 'docs/release-process.md' 'README.md')
+done < <(git ls-files 'docs/guide/*.md' 'docs/api/*.md' 'docs/faq.md' 'docs/troubleshooting.md' \
+  'docs/release-process.md' 'contrib/*/README.md' 'README.md' 'CONTRIBUTING.md')
+
+module_files=()
+while IFS= read -r file; do
+  module_files+=("$file")
+done < <(git ls-files '*go.mod')
 
 if [[ ${#current_docs[@]} -eq 0 ]]; then
   fail "no current docs found to scan"
@@ -33,4 +39,14 @@ if hits=$(git grep -nE "$stale_wing_shim" -- "${current_docs[@]}" || true); [[ -
   fail "current docs describe transport/wing as a live compatibility shim"
 fi
 
-ok "current docs do not reference removed Wing APIs"
+if hits=$(git grep -nF 'transport/wing' -- CONTRIBUTING.md || true); [[ -n "$hits" ]]; then
+  echo "$hits"
+  fail "contributor setup references the removed transport/wing package"
+fi
+
+if hits=$(git grep -nF 'github.com/go-kruda/kruda/transport/wing' -- "${module_files[@]}" || true); [[ -n "$hits" ]]; then
+  echo "$hits"
+  fail "module configuration references the removed transport/wing module"
+fi
+
+ok "current docs and module configuration pass removed Wing checks"


### PR DESCRIPTION
## Summary

- update contributor workspace and session transport guidance now that Wing lives in core
- remove dead transport/wing replacements from benchmark and example modules
- scan current contrib docs and module files for removed Wing references on every pull request

## Verification

- bash scripts/check-docs.sh
- go test -race -tags kruda_stdjson ./...
- scripts/test-standalone-modules.sh for session, affected examples, and benchmark modules
- focused Wing security-header and cookie integration test
- independent QA and pre-merge review