### PR TITLE
Fix onboarding: kruda new produced a project that could not build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,16 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   accepted even with a validator configured and the limits visible in the
   source. Rules belong inside the `validate` tag. Guarded by
   `TestMCPDocsUseValidationRulesAsRules` and `TestMCPDocsReferenceRealCoreTypes`.
+- Docs: every upload sample documented `max_size=5mb` against the 4MB default
+  `BodyLimit`, so the rule could never fire. `BodyLimit` is enforced by the
+  transport before the handler runs, so anything larger is answered 413 and
+  never reaches validation — measured end to end, a 4.5MB upload returns 413,
+  not the 422 the docs describe, and the 5MB cap a reader thought they had set
+  was really a 4MB one with a different status code. The samples in `upload.go`,
+  `docs/guide/security.md` and the `kruda mcp` file-upload topic now raise
+  `WithBodyLimit` alongside the rule and state the ordering.
+  `TestDocumentedMaxSizeIsReachable` fails on any documented `max_size` above the
+  default `BodyLimit` that does not raise it.
 
 ## [1.6.2] — 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `kruda new` now produces a project that builds. All three templates wrote
+  `require github.com/go-kruda/kruda v0.0.0`, a placeholder no proxy can
+  resolve, so `go mod tidy` — the second step the CLI itself prints — failed,
+  and so did `go build` and `go run`. `go get github.com/go-kruda/kruda@latest`
+  failed too, because Go resolves the existing requirement before fetching
+  anything, leaving no recovery short of editing `go.mod` by hand. `kruda mcp`
+  prints the same steps and the scaffold ships `.mcp.json`, so AI-assisted users
+  hit the same wall. The templates no longer pin the core module at all: `go mod
+  tidy` resolves the current release, so nothing here goes stale at the next tag.
+  Broken since 2026-03-01, across v1.4.0 through v1.6.2.
+- The `api` and `fullstack` templates called `c.Status(204).Send(nil)`; `Send` is
+  unexported. They now use `c.NoContent()`.
+- `kruda --version` reported `dev` for anyone who installed the published
+  binary, since the version is only injected by `-ldflags` in a release build.
+  It now falls back to the module version recorded in the binary.
+- `kruda validate` printed the full usage block when a check failed, pushing the
+  message that says what to fix off the top of the output. Every CLI error was
+  also printed twice, once by cobra and once by the entry point.
+- `kruda dev` announced `Port: N / Listening on :N`, which was wrong for any app
+  that hardcodes its `Listen` address — it only passes `PORT` to the child
+  process. It now says exactly that.
+
+### Added
+
+- Startup warning when a typed route's input carries `validate:` tags but no
+  `Validator` is configured. Validation is opt-in, so those tags were silently
+  inert: the request was parsed, nothing was checked, and the handler received
+  whatever the client sent. The warning fires once per process at route
+  registration, naming a route and field, and says which option enables
+  validation. Nothing is added to the request path.
+
+### Changed
+
+- Docs: the README's typed-handler example now builds the app with
+  `kruda.WithValidator(kruda.NewValidator())` and states that validation is
+  opt-in — it previously showed `validate:` tags on a plain `kruda.New()`, which
+  is exactly the configuration in which they do nothing. `CLAUDE.md` no longer
+  describes `C[T].In` as validated input.
+
 ## [1.6.2] — 2026-07-19
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,15 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   enforced. `TestMCPDocsDoNotTeachAutomaticValidation` keeps the AI-facing
   guidance honest; it caught the file-upload topic, whose `max_size`/`mime` tags
   were presented as if they applied on their own.
+- Docs: the `kruda mcp` file-upload sample was broken in two further ways. It
+  named `*kruda.Upload`, a type the core does not export (it is
+  `kruda.FileUpload`), so the sample could not compile; and it wrote
+  `validate:"required" max_size:"5mb" mime:"image/*"`, putting two validation
+  rules into struct tags of their own. Only `required` compiles from that form —
+  `max_size` and `mime` are never read, so an upload of any size or type was
+  accepted even with a validator configured and the limits visible in the
+  source. Rules belong inside the `validate` tag. Guarded by
+  `TestMCPDocsUseValidationRulesAsRules` and `TestMCPDocsReferenceRealCoreTypes`.
 
 ## [1.6.2] — 2026-07-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,19 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
-- Docs: the README's typed-handler example now builds the app with
-  `kruda.WithValidator(kruda.NewValidator())` and states that validation is
-  opt-in — it previously showed `validate:` tags on a plain `kruda.New()`, which
-  is exactly the configuration in which they do nothing. `CLAUDE.md` no longer
-  describes `C[T].In` as validated input.
+- Docs: every place that described validation as automatic now states that it is
+  opt-in. This was wrong in the README, the `C[T]` package doc, `docs/api/handler.md`,
+  `docs/guide/handlers.md`, the four `coming-from-*` guides, the typed-handler
+  example's comments, `CLAUDE.md`, and — most consequentially — the `kruda mcp`
+  documentation topics, which told AI assistants "Kruda validates struct tags
+  automatically in typed handlers" and never mentioned `WithValidator` anywhere.
+  Since `kruda new` ships `.mcp.json`, that was the default guidance for
+  AI-assisted users. Samples that show `validate:` tags now build the app with
+  `kruda.WithValidator(kruda.NewValidator())`, and the docs note that the
+  generated OpenAPI schema advertises the constraints whether or not they are
+  enforced. `TestMCPDocsDoNotTeachAutomaticValidation` keeps the AI-facing
+  guidance honest; it caught the file-upload topic, whose `max_size`/`mime` tags
+  were presented as if they applied on their own.
 
 ## [1.6.2] — 2026-07-19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,10 +45,12 @@ Transport Layer (pluggable: Wing on Linux / fasthttp on macOS / net/http fallbac
 ```go
 type C[T any] struct {
     *Ctx
-    In T  // parsed, validated input
+    In T  // parsed input; validated only when a Validator is configured
 }
 
-// Usage: body + param + query parsed into one struct
+// Usage: body + param + query parsed into one struct.
+// validate: tags run ONLY with kruda.New(kruda.WithValidator(kruda.NewValidator())) —
+// without it they are silently inert (Kruda warns once at startup).
 kruda.Post[CreateUser, User](app, "/users", func(c *kruda.C[CreateUser]) (*User, error) {
     return &User{ID: "1", Name: c.In.Name, Email: c.In.Email}, nil
 })

--- a/README.md
+++ b/README.md
@@ -58,10 +58,18 @@ type User struct {
     Email string `json:"email"`
 }
 
+app := kruda.New(kruda.WithValidator(kruda.NewValidator()))
+
 kruda.Post[CreateUser, User](app, "/users", func(c *kruda.C[CreateUser]) (*User, error) {
     return &User{ID: "1", Name: c.In.Name, Email: c.In.Email}, nil
 })
 ```
+
+**Validation is opt-in.** Without `WithValidator`, `validate:` tags are inert —
+the request is parsed but not checked, and the handler receives whatever the
+client sent. Kruda logs a warning at startup if it finds `validate:` tags with
+no validator configured. When enabled, a failing request gets a 422 listing
+every field that failed and why.
 
 ## Auto CRUD
 

--- a/cmd/kruda/cmd_dev.go
+++ b/cmd/kruda/cmd_dev.go
@@ -49,7 +49,9 @@ func runDev(cmd *cobra.Command, args []string) error {
 	binPath := filepath.Join(dir, ".kruda-tmp")
 
 	fmt.Printf("%s[kruda dev]%s Watching %s for .go file changes\n", colorGreen, colorReset, dir)
-	fmt.Printf("%s[kruda dev]%s Port: %d\n", colorGreen, colorReset, port)
+	// PORT is what we hand the child; an app that hardcodes its Listen address
+	// ignores it, so do not claim to know where it ended up listening.
+	fmt.Printf("%s[kruda dev]%s PORT=%d passed to the app\n", colorGreen, colorReset, port)
 
 	// Initial build and start.
 	var proc *os.Process
@@ -60,7 +62,7 @@ func runDev(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			fmt.Printf("%s[error]%s Failed to start: %s\n", colorRed, colorReset, err)
 		} else {
-			fmt.Printf("%s[kruda dev]%s Listening on :%d\n", colorGreen, colorReset, port)
+			fmt.Printf("%s[kruda dev]%s Started (PORT=%d)\n", colorGreen, colorReset, port)
 		}
 	}
 
@@ -125,7 +127,7 @@ func runDev(cmd *cobra.Command, args []string) error {
 				fmt.Printf("%s[error]%s Failed to start: %s\n", colorRed, colorReset, err)
 				continue
 			}
-			fmt.Printf("%s[kruda dev]%s Listening on :%d\n", colorGreen, colorReset, port)
+			fmt.Printf("%s[kruda dev]%s Started (PORT=%d)\n", colorGreen, colorReset, port)
 		}
 	}
 }

--- a/cmd/kruda/cmd_generate.go
+++ b/cmd/kruda/cmd_generate.go
@@ -87,6 +87,7 @@ import (
 type {{.FuncName}}Request struct {
 	// Add your request fields here with struct tags:
 	// Name string ` + "`" + `json:"name" validate:"required"` + "`" + `
+	// validate tags need kruda.New(kruda.WithValidator(kruda.NewValidator())).
 }
 
 // {{.FuncName}}Response defines the output for {{.Method}} {{.Path}}.

--- a/cmd/kruda/cmd_mcp.go
+++ b/cmd/kruda/cmd_mcp.go
@@ -717,9 +717,13 @@ type User struct {
     Email string ` + "`" + `json:"email"` + "`" + `
 }
 
+// validate tags are enforced only with a Validator — without this the input
+// reaches the handler unchecked.
+app := kruda.New(kruda.WithValidator(kruda.NewValidator()))
+
 // Register typed POST handler
 kruda.Post[CreateUser, User](app, "/users", func(c *kruda.C[CreateUser]) (*User, error) {
-    // c.In is already parsed and validated
+    // c.In is parsed, and validated because the app above has a Validator
     return &User{ID: "1", Name: c.In.Name, Email: c.In.Email}, nil
 })
 
@@ -737,6 +741,7 @@ kruda.Get[ListParams, []User](app, "/users", func(c *kruda.C[ListParams]) (*[]Us
 ` + "```" + `
 
 Input parsing pipeline: defaults → body → query → params → validate
+The validate step runs only when the app was built with kruda.WithValidator.
 Validation uses struct tags and returns structured ValidationError with []FieldError.`,
 
 	"routing": `# Routing
@@ -969,7 +974,7 @@ func handler(c *kruda.Ctx) error {
 // Custom error with details
 return kruda.NewError(403, "forbidden").WithDetail("insufficient permissions")
 
-// Structured validation errors (auto from typed handlers)
+// Structured validation errors (from typed handlers, when a Validator is set)
 // Response:
 // {
 //   "error": "validation failed",
@@ -1050,7 +1055,13 @@ app.Get("/ws", func(c *kruda.Ctx) error {
 
 	"file-upload": `# File Upload
 
+The validate/max_size/mime tags below are enforced only when the app has a
+Validator: kruda.New(kruda.WithValidator(kruda.NewValidator())). Without it an
+upload of any size or type reaches the handler.
+
 ` + "```" + `go
+app := kruda.New(kruda.WithValidator(kruda.NewValidator()))
+
 type UploadRequest struct {
     File   *kruda.Upload ` + "`" + `form:"file" validate:"required" max_size:"5mb" mime:"image/*"` + "`" + `
     Title  string        ` + "`" + `form:"title" validate:"required"` + "`" + `
@@ -1067,7 +1078,14 @@ Validation tags: max_size (e.g. "5mb", "500kb"), mime (e.g. "image/*", "applicat
 
 	"validation": `# Validation
 
-Kruda validates struct tags automatically in typed handlers.
+Validation is OPT-IN. Build the app with a Validator or the validate tags do nothing:
+
+    app := kruda.New(kruda.WithValidator(kruda.NewValidator()))
+
+Without it the request is parsed, nothing is checked, and the handler receives
+whatever the client sent — no error and no log line at request time (Kruda does
+warn once at startup). Always include WithValidator when generating code that
+uses validate tags.
 
 ` + "```" + `go
 type CreateUser struct {

--- a/cmd/kruda/cmd_mcp.go
+++ b/cmd/kruda/cmd_mcp.go
@@ -1057,11 +1057,19 @@ app.Get("/ws", func(c *kruda.Ctx) error {
 
 max_size and mime are validation RULES, so they go inside the validate tag as
 max_size=5mb and mime=image/*. Written as separate struct tags they are never
-read and the upload is unlimited. They are also enforced only when the app has a
-Validator — without one, an upload of any size or type reaches the handler.
+read and the upload is unlimited. They also need a Validator on the app —
+without one, an upload of any size or type reaches the handler.
+
+BodyLimit (default 4MB) is enforced by the transport BEFORE the handler runs, so
+a larger request gets a 413 and never reaches validation. A max_size above
+BodyLimit can never fire. Keep max_size under BodyLimit, or raise BodyLimit past
+it as below. max_size failures are 422; BodyLimit is 413.
 
 ` + "```" + `go
-app := kruda.New(kruda.WithValidator(kruda.NewValidator()))
+app := kruda.New(
+    kruda.WithValidator(kruda.NewValidator()), // max_size/mime need a Validator
+    kruda.WithBodyLimit(8<<20),                // else 5mb below is unreachable
+)
 
 type UploadRequest struct {
     File   *kruda.FileUpload ` + "`" + `form:"file" validate:"required,max_size=5mb,mime=image/*"` + "`" + `
@@ -1075,7 +1083,8 @@ kruda.Post[UploadRequest, Response](app, "/upload", func(c *kruda.C[UploadReques
 })
 ` + "```" + `
 
-Validation tags: max_size (e.g. "5mb", "500kb"), mime (e.g. "image/*", "application/pdf")`,
+Validation tags: max_size (e.g. "5mb", "500kb"), mime (e.g. "image/*", "application/pdf")
+max_size only fires below BodyLimit (default 4MB) — above it the transport returns 413 first.`,
 
 	"validation": `# Validation
 

--- a/cmd/kruda/cmd_mcp.go
+++ b/cmd/kruda/cmd_mcp.go
@@ -1055,16 +1055,17 @@ app.Get("/ws", func(c *kruda.Ctx) error {
 
 	"file-upload": `# File Upload
 
-The validate/max_size/mime tags below are enforced only when the app has a
-Validator: kruda.New(kruda.WithValidator(kruda.NewValidator())). Without it an
-upload of any size or type reaches the handler.
+max_size and mime are validation RULES, so they go inside the validate tag as
+max_size=5mb and mime=image/*. Written as separate struct tags they are never
+read and the upload is unlimited. They are also enforced only when the app has a
+Validator — without one, an upload of any size or type reaches the handler.
 
 ` + "```" + `go
 app := kruda.New(kruda.WithValidator(kruda.NewValidator()))
 
 type UploadRequest struct {
-    File   *kruda.Upload ` + "`" + `form:"file" validate:"required" max_size:"5mb" mime:"image/*"` + "`" + `
-    Title  string        ` + "`" + `form:"title" validate:"required"` + "`" + `
+    File   *kruda.FileUpload ` + "`" + `form:"file" validate:"required,max_size=5mb,mime=image/*"` + "`" + `
+    Title  string            ` + "`" + `form:"title" validate:"required"` + "`" + `
 }
 
 kruda.Post[UploadRequest, Response](app, "/upload", func(c *kruda.C[UploadRequest]) (*Response, error) {

--- a/cmd/kruda/cmd_mcp_test.go
+++ b/cmd/kruda/cmd_mcp_test.go
@@ -74,3 +74,38 @@ func TestMCPWingDocsKeepQueryAndWriteGuidanceSeparate(t *testing.T) {
 		t.Fatalf("wing docs missing write-heavy benchmark guidance")
 	}
 }
+
+// TestMCPDocsDoNotTeachAutomaticValidation guards the guidance AI assistants
+// read. Validation is opt-in, but krudaDocs used to state the opposite —
+// "Kruda validates struct tags automatically in typed handlers" — and never
+// mentioned WithValidator anywhere, so every assistant following it generated
+// apps whose validate tags did nothing. The scaffold ships .mcp.json, so this
+// is the default path for AI-assisted users.
+func TestMCPDocsDoNotTeachAutomaticValidation(t *testing.T) {
+	falseClaims := []string{
+		"validates struct tags automatically",
+		"validation runs automatically",
+		"automatically validated",
+		"auto-validation",
+		"auto-validate",
+		"already parsed and validated",
+	}
+	for topic, body := range krudaDocs {
+		for _, claim := range falseClaims {
+			if strings.Contains(strings.ToLower(body), claim) {
+				t.Errorf("krudaDocs[%q] tells assistants validation is automatic (%q); it is opt-in via WithValidator", topic, claim)
+			}
+		}
+	}
+
+	// Any topic that shows a validate tag has to say how to turn validation on,
+	// or it is teaching the trap.
+	for topic, body := range krudaDocs {
+		if !strings.Contains(body, `validate:"`) {
+			continue
+		}
+		if !strings.Contains(body, "WithValidator") {
+			t.Errorf("krudaDocs[%q] shows validate: tags without mentioning WithValidator", topic)
+		}
+	}
+}

--- a/cmd/kruda/cmd_mcp_test.go
+++ b/cmd/kruda/cmd_mcp_test.go
@@ -109,3 +109,39 @@ func TestMCPDocsDoNotTeachAutomaticValidation(t *testing.T) {
 		}
 	}
 }
+
+// TestMCPDocsUseValidationRulesAsRules guards a silent failure the file-upload
+// topic shipped: it wrote `validate:"required" max_size:"5mb" mime:"image/*"`,
+// putting two validation rules in struct tags of their own. Only `required`
+// compiles from that; max_size and mime are never read, so an upload of any
+// size or type is accepted — with a Validator configured and the tags sitting
+// right there in the source. Rules belong inside the validate tag, as
+// `validate:"required,max_size=5mb,mime=image/*"`.
+func TestMCPDocsUseValidationRulesAsRules(t *testing.T) {
+	// Rule names that read like plausible standalone struct tags. A rule used as
+	// its own tag is silently dropped, which is worse than a compile error.
+	rules := []string{"max_size", "mime", "min", "max", "email", "required", "oneof", "uuid"}
+	for topic, body := range krudaDocs {
+		for _, r := range rules {
+			if strings.Contains(body, r+`:"`) {
+				t.Errorf("krudaDocs[%q] uses the validation rule %q as its own struct tag; it must go inside validate:\"...\" or it is silently ignored", topic, r)
+			}
+		}
+	}
+}
+
+// TestMCPDocsReferenceRealCoreTypes catches samples naming types the core does
+// not export — the file-upload topic said *kruda.Upload, which does not exist
+// (it is kruda.FileUpload), so the sample never compiled for anyone who copied
+// it. The list is the set this test knows to be wrong; MCP samples are not
+// compiled anywhere, so this is a floor, not a guarantee.
+func TestMCPDocsReferenceRealCoreTypes(t *testing.T) {
+	nonexistent := []string{"kruda.Upload{", "*kruda.Upload ", "*kruda.Upload`"}
+	for topic, body := range krudaDocs {
+		for _, bad := range nonexistent {
+			if strings.Contains(body, bad) {
+				t.Errorf("krudaDocs[%q] references %q, which the core does not export (did you mean kruda.FileUpload?)", topic, bad)
+			}
+		}
+	}
+}

--- a/cmd/kruda/cmd_new_test.go
+++ b/cmd/kruda/cmd_new_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -108,5 +110,71 @@ func TestIsNonEmptyDirEmpty(t *testing.T) {
 func TestIsNonEmptyDirNonExistent(t *testing.T) {
 	if isNonEmptyDir("/nonexistent/path/that/does/not/exist") {
 		t.Error("expected isNonEmptyDir to return false for non-existent path")
+	}
+}
+
+// templateNames are the templates `kruda new -t` accepts.
+var templateNames = []string{"minimal", "api", "fullstack"}
+
+// TestTemplatesDoNotPinCoreVersion guards the scaffolder's central promise: the
+// project it writes has to build.
+//
+// The templates used to carry `require github.com/go-kruda/kruda v0.0.0`, a
+// placeholder that no proxy can resolve, so `go mod tidy` — step two of the
+// instructions the CLI itself prints — failed for every template, and `go get
+// ...@latest` failed too because Go resolves the bad requirement first. It
+// shipped that way for five months because the tests below only checked that
+// files existed.
+//
+// Leaving the requirement out entirely is what keeps this fixed: `go mod tidy`
+// resolves the current release on its own, so there is no pinned version here
+// to go stale at the next tag.
+func TestTemplatesDoNotPinCoreVersion(t *testing.T) {
+	for _, name := range templateNames {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			data := templateData{ProjectName: "probe", ModuleName: "probe"}
+			if err := scaffoldFromFS(templateFS, "templates/"+name, dir, data); err != nil {
+				t.Fatalf("scaffoldFromFS: %v", err)
+			}
+			b, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+			if err != nil {
+				t.Fatalf("read go.mod: %v", err)
+			}
+			if strings.Contains(string(b), "github.com/go-kruda/kruda") {
+				t.Errorf("template pins the core module; let `go mod tidy` resolve it instead:\n%s", b)
+			}
+		})
+	}
+}
+
+// TestScaffoldedProjectBuilds runs what a new user runs. It needs the module
+// proxy, so it is skipped under -short.
+func TestScaffoldedProjectBuilds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("needs the module proxy")
+	}
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("no go toolchain on PATH")
+	}
+	for _, name := range templateNames {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			data := templateData{ProjectName: "probe", ModuleName: "probe"}
+			if err := scaffoldFromFS(templateFS, "templates/"+name, dir, data); err != nil {
+				t.Fatalf("scaffoldFromFS: %v", err)
+			}
+			for _, args := range [][]string{{"mod", "tidy"}, {"build", "./..."}} {
+				cmd := exec.Command("go", args...)
+				cmd.Dir = dir
+				// A go.work above the temp dir would pull in this repo and mask
+				// what a user outside it actually gets.
+				cmd.Env = append(os.Environ(), "GOWORK=off", "GOFLAGS=")
+				if out, err := cmd.CombinedOutput(); err != nil {
+					t.Fatalf("go %v in a fresh %s project failed: %v\n%s", args, name, err, out)
+				}
+			}
+		})
 	}
 }

--- a/cmd/kruda/cmd_validate.go
+++ b/cmd/kruda/cmd_validate.go
@@ -24,7 +24,10 @@ Validates:
   • Project structure is correct
 
 Exit code 0 on success, 1 on failure (CI-friendly).`,
-	RunE: runValidate,
+	// A failing check is a result, not a usage mistake — printing the usage
+	// block would bury the message that says what to fix.
+	SilenceUsage: true,
+	RunE:         runValidate,
 }
 
 // validationResult tracks a single check.

--- a/cmd/kruda/main.go
+++ b/cmd/kruda/main.go
@@ -5,19 +5,35 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 
 	"github.com/spf13/cobra"
 )
 
-// version is set at build time via -ldflags.
+// version is set at build time via -ldflags by the release build.
 var version = "dev"
+
+// resolveVersion falls back to the version the module was installed at, so a
+// binary from `go install github.com/go-kruda/kruda/cmd/kruda@latest` reports
+// that version instead of "dev" — otherwise "which version are you on?" has no
+// answer for anyone who did not build from source.
+func resolveVersion() string {
+	if version != "dev" {
+		return version
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok || info.Main.Version == "" || info.Main.Version == "(devel)" {
+		return version
+	}
+	return info.Main.Version
+}
 
 func main() {
 	rootCmd := &cobra.Command{
 		Use:     "kruda",
 		Short:   "Kruda — Type-safe Go web framework CLI",
 		Long:    "CLI tool for the Kruda web framework. Scaffold projects, run dev servers, generate code, and validate configuration.",
-		Version: version,
+		Version: resolveVersion(),
 	}
 
 	rootCmd.AddCommand(newCmd)
@@ -31,8 +47,11 @@ func main() {
 	pgoCmd.AddCommand(pgoStripCmd)
 	rootCmd.AddCommand(pgoCmd)
 
+	// Cobra already prints the error; printing it again here just doubled every
+	// failure message.
+	rootCmd.SilenceErrors = true
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, "Error:", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/kruda/templates/api/go.mod.tmpl
+++ b/cmd/kruda/templates/api/go.mod.tmpl
@@ -1,5 +1,3 @@
 module {{.ModuleName}}
 
 go 1.25.11
-
-require github.com/go-kruda/kruda v0.0.0

--- a/cmd/kruda/templates/api/handlers/user.go.tmpl
+++ b/cmd/kruda/templates/api/handlers/user.go.tmpl
@@ -105,5 +105,5 @@ func (h *UserHandler) Delete(c *kruda.Ctx) error {
 	}
 
 	delete(h.users, id)
-	return c.Status(204).Send(nil)
+	return c.NoContent()
 }

--- a/cmd/kruda/templates/fullstack/go.mod.tmpl
+++ b/cmd/kruda/templates/fullstack/go.mod.tmpl
@@ -1,5 +1,3 @@
 module {{.ModuleName}}
 
 go 1.25.11
-
-require github.com/go-kruda/kruda v0.0.0

--- a/cmd/kruda/templates/fullstack/handlers/user.go.tmpl
+++ b/cmd/kruda/templates/fullstack/handlers/user.go.tmpl
@@ -105,5 +105,5 @@ func (h *UserHandler) Delete(c *kruda.Ctx) error {
 	}
 
 	delete(h.users, id)
-	return c.Status(204).Send(nil)
+	return c.NoContent()
 }

--- a/cmd/kruda/templates/minimal/go.mod.tmpl
+++ b/cmd/kruda/templates/minimal/go.mod.tmpl
@@ -1,5 +1,3 @@
 module {{.ModuleName}}
 
 go 1.25.11
-
-require github.com/go-kruda/kruda v0.0.0

--- a/docs/api/handler.md
+++ b/docs/api/handler.md
@@ -40,11 +40,11 @@ type C[T any] struct {
 }
 ```
 
-`C[T]` extends `Ctx` with a typed `In` field. The request body, route parameters, and query parameters are automatically parsed and validated into `T` before the handler runs.
+`C[T]` extends `Ctx` with a typed `In` field. The request body, route parameters, and query parameters are parsed into `T` before the handler runs. They are validated too when a validator is configured — see [Validation](#validation).
 
 ## Typed Handler Registration
 
-Package-level generic functions register typed handlers with pre-compiled binding and validation:
+Package-level generic functions register typed handlers with binding, and validators, compiled at registration time:
 
 ```go
 func Get[In any, Out any](app *App, path string, handler func(*C[In]) (*Out, error), opts ...RouteOption)
@@ -166,7 +166,7 @@ Binding order:
 
 ## Validation
 
-After binding, validation runs automatically using `validate` struct tags:
+After binding, `validate` struct tags are checked:
 
 ```go
 type Input struct {
@@ -176,3 +176,5 @@ type Input struct {
 ```
 
 Validation failures return HTTP 422 with structured error details.
+
+**Validation is opt-in.** It runs only when the app is built with `kruda.New(kruda.WithValidator(kruda.NewValidator()))`. Without it the `validate` tags are inert: the request is parsed, nothing is checked, and the handler receives whatever the client sent. Kruda logs a warning at startup if it finds `validate` tags with no validator configured. Note that the generated OpenAPI schema advertises the constraints either way — only enforcement is gated.

--- a/docs/guide/coming-from-echo.md
+++ b/docs/guide/coming-from-echo.md
@@ -121,7 +121,7 @@ app.Post("/users", func(c *kruda.Ctx) error {
 // kruda.Post[CreateUser, User](app, "/users", handler)
 ```
 
-No separate bind + validate steps. No global validator registration. Validation is built into the type system.
+No separate bind + validate steps — binding and validation are one declaration on the input type. Validation itself is opt-in: build the app with `kruda.New(kruda.WithValidator(kruda.NewValidator()))` and the `validate` tags are enforced; without it they are inert.
 
 ### 3. Pluggable Transport
 

--- a/docs/guide/coming-from-fiber.md
+++ b/docs/guide/coming-from-fiber.md
@@ -174,7 +174,7 @@ app.Group("/api/v1").
 ## What You Gain
 
 - **Wing transport** — raw epoll+eventfd on Linux: +27-35% RPS on CPU-bound routes (825K vs 641K req/s plaintext throughput) and +7% on `/fortunes`, both with far better p99; on the pool-bound `/db` and `/queries` it matches Fiber's RPS at the pgx ceiling while beating its p99 (see `bench/reproducible/results/2026-06-13-v1-3-1-consolidated-evidence.md`)
-- **Type-safe handlers** — no more `BodyParser` + manual validation
+- **Type-safe handlers** — no more `BodyParser` + manual validation (validation is opt-in via `kruda.WithValidator`)
 - **No context reuse bugs** — safe string copies by default
 - **HTTP/2 support** — switch to net/http when needed
 - **Auto OpenAPI** — generated from typed handlers

--- a/docs/guide/coming-from-gin.md
+++ b/docs/guide/coming-from-gin.md
@@ -168,6 +168,6 @@ app.Group("/api/v1").
 - **Benchmark evidence** — versioned results and reproduction commands are documented in the [performance guide](/guide/performance)
 - **Type-safe handlers** — no more manual `ShouldBindJSON`
 - **Pluggable transport** — Wing (default on Linux), fasthttp (default on macOS), or net/http (HTTP/2)
-- **Less binding boilerplate** — typed inputs combine binding and validation before handler execution
+- **Less binding boilerplate** — typed inputs declare binding and validation together, both applied before the handler runs (validation once `kruda.WithValidator` is set)
 - **Auto OpenAPI** — generated from your typed handlers
 - **Built-in DI** — optional dependency injection without codegen

--- a/docs/guide/coming-from-stdlib.md
+++ b/docs/guide/coming-from-stdlib.md
@@ -215,7 +215,7 @@ You can use `kruda.NetHTTP()` to keep the exact same transport as stdlib while g
 
 - **Benchmark evidence** — versioned results and reproduction commands are documented in the [performance guide](/guide/performance)
 - **Error-returning handlers** — no more silent failures or forgotten `return`
-- **Type-safe handlers** — `C[T]` with auto-bind, auto-validate, auto-OpenAPI
+- **Type-safe handlers** — `C[T]` with auto-bind, auto-OpenAPI, and tag-driven validation (opt in with `kruda.WithValidator`)
 - **Built-in middleware** — Logger, CORS, Recovery, RequestID, RateLimit
 - **Route groups** — with scoped middleware via `Guard()`
 - **Auto CRUD** — `kruda.Resource[Product, string](app, "/products", service)` generates full REST

--- a/docs/guide/handlers.md
+++ b/docs/guide/handlers.md
@@ -101,7 +101,7 @@ Supported tag types:
 
 ## Validation
 
-Validation runs automatically after binding. Use `validate` struct tags:
+After binding, `validate` struct tags are checked. Use them like this:
 
 ```go
 type Input struct {
@@ -110,6 +110,11 @@ type Input struct {
     Age   int    `json:"age"   validate:"min=0,max=150"`
 }
 ```
+
+
+::: warning Validation is opt-in
+Validation runs only when the app is built with `kruda.New(kruda.WithValidator(kruda.NewValidator()))`. Without it the `validate` tags do nothing — the request is parsed, nothing is checked, and the handler receives whatever the client sent. Kruda warns at startup when it finds `validate` tags and no validator. The generated OpenAPI schema advertises the constraints either way; only enforcement is gated.
+:::
 
 When validation fails, Kruda returns a structured error response:
 

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -391,7 +391,16 @@ ws.New(ws.Config{
 
 Uploaded filenames are automatically sanitized with `filepath.Base()` to strip directory components. Validate extensions in your handler:
 
+::: warning `max_size` above `BodyLimit` never fires
+`BodyLimit` (default **4MB**) is enforced by the transport before the handler runs, so a larger request is rejected with **413** and never reaches validation. A `max_size` above it is dead configuration. Keep `max_size` under `BodyLimit`, or raise `BodyLimit` past it as below. `max_size` failures surface as **422**, `BodyLimit` as **413**.
+:::
+
 ```go
+app := kruda.New(
+    kruda.WithValidator(kruda.NewValidator()), // max_size/mime need a Validator
+    kruda.WithBodyLimit(8<<20),                // BodyLimit defaults to 4MB
+)
+
 type UploadReq struct {
     Avatar *kruda.FileUpload `form:"avatar" validate:"required,max_size=5mb,mime=image/*"`
 }

--- a/examples/typed-handlers/main.go
+++ b/examples/typed-handlers/main.go
@@ -3,14 +3,19 @@
 // This example demonstrates Kruda's typed handler system using C[T] — the
 // generic typed context. Typed handlers auto-parse request inputs from
 // multiple sources (path params, query strings, JSON body) into a single
-// struct, then auto-validate using struct tags.
+// struct, and validate it against struct tags.
+//
+// Validation is opt-in: it runs because main() below builds the app with
+// kruda.WithValidator(kruda.NewValidator()). Without that option the validate
+// tags are inert and c.In reaches the handler unchecked.
 //
 // Key concepts:
 //   - C[T] typed context with auto-parsed c.In field
 //   - `param` tag — binds from URL path parameters (:id, :slug)
 //   - `query` tag — binds from query string (?page=1&limit=10)
 //   - `json`  tag — binds from JSON request body
-//   - `validate` tag — auto-validation (required, min, max, email, etc.)
+//   - `validate` tag — validation rules (required, min, max, email, etc.),
+//     enforced only when a Validator is configured
 //   - Multiple input sources combined in one struct
 //
 // Endpoints:

--- a/handler.go
+++ b/handler.go
@@ -3,7 +3,9 @@ package kruda
 import "reflect"
 
 // C is the generic typed context that embeds *Ctx with a parsed input field.
-// c.In contains the parsed + validated input from all sources (param, query, body).
+// c.In holds the input parsed from every source (param, query, body). It is
+// validated against the validate tags only when the App has a Validator; see
+// WithValidator. Without one the tags are inert and c.In is unchecked.
 type C[T any] struct {
 	*Ctx
 	In T // parsed input from request

--- a/handler.go
+++ b/handler.go
@@ -80,6 +80,8 @@ func buildTypedHandler[In any, Out any](
 	var validators []fieldValidator
 	if app.config.Validator != nil {
 		validators = buildValidators[In](app.config.Validator)
+	} else {
+		warnIfValidateTagsIgnored(reflect.TypeOf((*In)(nil)).Elem(), method, path)
 	}
 
 	// Apply route options

--- a/upload.go
+++ b/upload.go
@@ -8,9 +8,19 @@ import (
 
 // FileUpload represents an uploaded file from a multipart form.
 //
+//	app := kruda.New(
+//	    kruda.WithValidator(kruda.NewValidator()), // max_size/mime need a Validator
+//	    kruda.WithBodyLimit(8<<20),                // BodyLimit defaults to 4MB
+//	)
+//
 //	type UploadReq struct {
 //	    Avatar *kruda.FileUpload `form:"avatar" validate:"required,max_size=5mb,mime=image/*"`
 //	}
+//
+// BodyLimit is enforced by the transport before the handler runs, so a request
+// larger than it gets a 413 and never reaches validation. A max_size above
+// BodyLimit can therefore never fire; keep max_size under it, or raise it as
+// above. max_size failures are reported as 422, BodyLimit as 413.
 type FileUpload struct {
 	Name        string
 	Size        int64

--- a/upload_doc_test.go
+++ b/upload_doc_test.go
@@ -1,32 +1,140 @@
 package kruda
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 )
 
-var maxSizeRuleRe = regexp.MustCompile(`max_size=([0-9]+(?:[kKmMgG][bB])?)`)
+var (
+	maxSizeRuleRe   = regexp.MustCompile(`max_size=([0-9]+(?:[kKmMgG][bB])?)`)
+	withBodyLimitRe = regexp.MustCompile(`WithBodyLimit\(([^)]*)\)`)
+	shiftExprRe     = regexp.MustCompile(`^(\d+)\s*<<\s*(\d+)$`)
+	mulExprRe       = regexp.MustCompile(`^\d+(?:\s*\*\s*\d+)*$`)
+)
+
+// evalByteExpr evaluates the literal forms a WithBodyLimit sample realistically
+// uses: 8<<20, 8 * 1024 * 1024, 4194304. Anything else — a named constant, a
+// variable, an API table's WithBodyLimit(bytes) — returns an error, and the
+// caller skips it rather than crediting the file with a limit it never states.
+func evalByteExpr(expr string) (int64, error) {
+	e := strings.TrimSpace(expr)
+	if m := shiftExprRe.FindStringSubmatch(e); m != nil {
+		base, err := strconv.ParseInt(m[1], 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		shift, err := strconv.ParseInt(m[2], 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		if shift > 62 {
+			return 0, fmt.Errorf("shift %d out of range", shift)
+		}
+		return base << uint(shift), nil
+	}
+	if mulExprRe.MatchString(e) {
+		total := int64(1)
+		for _, part := range strings.Split(e, "*") {
+			n, err := strconv.ParseInt(strings.TrimSpace(part), 10, 64)
+			if err != nil {
+				return 0, err
+			}
+			total *= n
+		}
+		return total, nil
+	}
+	return 0, fmt.Errorf("unrecognized byte expression %q", e)
+}
+
+// effectiveBodyLimit is the largest BodyLimit a file's samples establish, or the
+// framework default when a file sets none. Taking the largest is deliberate: it
+// is the most generous reading, so a max_size this test still rejects is
+// unreachable under every configuration the file shows.
+//
+// Checking the value rather than the mere presence of WithBodyLimit matters: the
+// first version of this guard passed any file that mentioned the option at all,
+// so a sample raising the limit to 1MB while documenting max_size=5mb would have
+// sailed through it.
+//
+// Mentions that are prose rather than samples — an API table's
+// WithBodyLimit(bytes) — carry no value and are skipped. Granularity is the
+// file, not the individual snippet: a file that raises the limit anywhere is
+// credited for it everywhere, which is the limit of what a text scan can claim.
+func effectiveBodyLimit(body string, def int64) int64 {
+	limit := def
+	for _, m := range withBodyLimitRe.FindAllStringSubmatch(body, -1) {
+		n, err := evalByteExpr(m[1])
+		if err != nil {
+			continue
+		}
+		if n > limit {
+			limit = n
+		}
+	}
+	return limit
+}
+
+// shippedFilesMentioning returns the tracked documentation and source carrying a
+// needle. Discovery rather than a hard-coded list: the first version of this
+// guard named four files, and so never checked cmd/kruda/cmd_mcp.go — which
+// carried the very sample that prompted writing it.
+//
+// Tracked files only. Untracked working-tree material (local design notes under
+// .kiro, a stale draft) is not what anyone ships or copies, and failing on it
+// would make the guard noise the next person silences.
+func shippedFilesMentioning(t *testing.T, needle string) []string {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("needs git to tell shipped files from local ones")
+	}
+	out, err := exec.Command("git", "ls-files", "-z", "*.go", "*.md", "*.tmpl").Output()
+	if err != nil {
+		t.Skipf("git ls-files: %v", err)
+	}
+	var found []string
+	for _, path := range strings.Split(strings.TrimRight(string(out), "\x00"), "\x00") {
+		if path == "" {
+			continue
+		}
+		// The changelog records the defect verbatim; tests are not samples a
+		// user copies, and this one states the defect in its own comments.
+		if path == "CHANGELOG.md" || strings.HasSuffix(path, "_test.go") {
+			continue
+		}
+		b, readErr := os.ReadFile(path)
+		if readErr != nil {
+			continue
+		}
+		if strings.Contains(string(b), needle) {
+			found = append(found, path)
+		}
+	}
+	return found
+}
 
 // TestDocumentedMaxSizeIsReachable guards a limit that reads as if it works and
 // cannot. BodyLimit is enforced by the transport before the handler runs, so a
 // request larger than it is answered 413 and never reaches validation. Every
-// sample in the tree documented `max_size=5mb` against the 4MB default, which
-// means the rule could not fire for any request that got far enough to be
-// validated — measured end to end: a 4.5MB upload returns 413, not the 422 the
-// docs describe.
+// upload sample in the tree documented max_size=5mb against the 4MB default,
+// which means the rule could not fire for any request that got far enough to be
+// validated — measured end to end, a 4.5MB upload returns 413, not the 422 the
+// validation docs describe.
 //
-// A sample is acceptable if its max_size fits under the default BodyLimit, or
-// if the same file raises WithBodyLimit alongside it.
+// A sample passes when its max_size fits under the BodyLimit its own file
+// establishes, whether that is the framework default or one the file raises.
 func TestDocumentedMaxSizeIsReachable(t *testing.T) {
-	files := []string{
-		"upload.go",
-		"validation.go",
-		"docs/guide/security.md",
-		"README.md",
-	}
 	defaultLimit := int64(New().config.BodyLimit)
+
+	files := shippedFilesMentioning(t, "max_size=")
+	if len(files) == 0 {
+		t.Fatal("found no files documenting max_size=; the guard is scanning the wrong tree")
+	}
+	t.Logf("checking %d file(s): %s", len(files), strings.Join(files, ", "))
 
 	for _, f := range files {
 		b, err := os.ReadFile(f)
@@ -34,16 +142,19 @@ func TestDocumentedMaxSizeIsReachable(t *testing.T) {
 			t.Fatalf("read %s: %v", f, err)
 		}
 		body := string(b)
-		raises := strings.Contains(body, "WithBodyLimit")
+
+		limit := effectiveBodyLimit(body, defaultLimit)
+
 		for _, m := range maxSizeRuleRe.FindAllStringSubmatch(body, -1) {
 			n, err := parseSize(m[1])
 			if err != nil {
 				t.Errorf("%s: max_size=%s is not a size parseSize accepts, so the rule always fails", f, m[1])
 				continue
 			}
-			if n > defaultLimit && !raises {
-				t.Errorf("%s documents max_size=%s (%d bytes) above the default BodyLimit (%d bytes) without raising WithBodyLimit — the rule can never fire; such a request is rejected 413 before validation",
-					f, m[1], n, defaultLimit)
+			if n > limit {
+				t.Errorf("%s documents max_size=%s (%d bytes) above the BodyLimit its samples establish (%d bytes) — "+
+					"the rule can never fire, because a request that large is rejected 413 before validation runs",
+					f, m[1], n, limit)
 			}
 		}
 	}

--- a/upload_doc_test.go
+++ b/upload_doc_test.go
@@ -1,0 +1,50 @@
+package kruda
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var maxSizeRuleRe = regexp.MustCompile(`max_size=([0-9]+(?:[kKmMgG][bB])?)`)
+
+// TestDocumentedMaxSizeIsReachable guards a limit that reads as if it works and
+// cannot. BodyLimit is enforced by the transport before the handler runs, so a
+// request larger than it is answered 413 and never reaches validation. Every
+// sample in the tree documented `max_size=5mb` against the 4MB default, which
+// means the rule could not fire for any request that got far enough to be
+// validated — measured end to end: a 4.5MB upload returns 413, not the 422 the
+// docs describe.
+//
+// A sample is acceptable if its max_size fits under the default BodyLimit, or
+// if the same file raises WithBodyLimit alongside it.
+func TestDocumentedMaxSizeIsReachable(t *testing.T) {
+	files := []string{
+		"upload.go",
+		"validation.go",
+		"docs/guide/security.md",
+		"README.md",
+	}
+	defaultLimit := int64(New().config.BodyLimit)
+
+	for _, f := range files {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		body := string(b)
+		raises := strings.Contains(body, "WithBodyLimit")
+		for _, m := range maxSizeRuleRe.FindAllStringSubmatch(body, -1) {
+			n, err := parseSize(m[1])
+			if err != nil {
+				t.Errorf("%s: max_size=%s is not a size parseSize accepts, so the rule always fails", f, m[1])
+				continue
+			}
+			if n > defaultLimit && !raises {
+				t.Errorf("%s documents max_size=%s (%d bytes) above the default BodyLimit (%d bytes) without raising WithBodyLimit — the rule can never fire; such a request is rejected 413 before validation",
+					f, m[1], n, defaultLimit)
+			}
+		}
+	}
+}

--- a/validation.go
+++ b/validation.go
@@ -2,14 +2,48 @@ package kruda
 
 import (
 	"fmt"
+	"log/slog"
 	"net/mail"
 	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
+	"sync/atomic"
 
 	krudajson "github.com/go-kruda/kruda/json"
 )
+
+// warnedValidateTagsIgnored keeps the warning below to one per process: an app
+// with fifty typed routes has one mistake, not fifty.
+var warnedValidateTagsIgnored atomic.Bool
+
+func resetValidateTagWarningForTest() { warnedValidateTagsIgnored.Store(false) }
+
+// warnIfValidateTagsIgnored warns once when a typed route's input carries
+// validate: tags and no Validator is configured.
+//
+// Validation is opt-in, so without a Validator those tags do nothing at all —
+// no error, no log line, and the handler receives whatever the client sent. The
+// tag looks like it is working, which makes this the one default worth being
+// loud about: the README's own typed-handler example shows validate: tags, and
+// a reader who copies it gets unvalidated input reaching their handler.
+//
+// It scans only top-level fields, matching what buildValidators compiles.
+func warnIfValidateTagsIgnored(t reflect.Type, method, path string) {
+	if t.Kind() != reflect.Struct {
+		return
+	}
+	for i := 0; i < t.NumField(); i++ {
+		if t.Field(i).Tag.Get("validate") == "" {
+			continue
+		}
+		if warnedValidateTagsIgnored.CompareAndSwap(false, true) {
+			slog.Warn("kruda: validate: tags found but no Validator is configured — input is NOT being validated. Pass kruda.WithValidator(kruda.NewValidator()) to kruda.New",
+				"route", method+" "+path, "field", t.Field(i).Name)
+		}
+		return
+	}
+}
 
 // ValidatorFunc is the signature for validation rule functions.
 // value is the field value to validate, param is the rule parameter

--- a/validation_optin_test.go
+++ b/validation_optin_test.go
@@ -1,0 +1,96 @@
+package kruda
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+type optInInput struct {
+	Name  string `json:"name" validate:"required,min=2"`
+	Email string `json:"email" validate:"required,email"`
+}
+
+type optInPlain struct {
+	Name string `json:"name"`
+}
+
+type optInOut struct {
+	ID string `json:"id"`
+}
+
+func captureValidateWarning(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	resetValidateTagWarningForTest()
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() {
+		slog.SetDefault(prev)
+		resetValidateTagWarningForTest()
+	})
+	return &buf
+}
+
+// TestWarnsWhenValidateTagsHaveNoValidator covers the quietest way to ship a
+// security bug with this framework: validation is opt-in, so validate: tags
+// without a Validator are inert and nothing says so. The request succeeds and
+// the handler gets whatever the client sent.
+func TestWarnsWhenValidateTagsHaveNoValidator(t *testing.T) {
+	buf := captureValidateWarning(t)
+
+	app := New()
+	Post[optInInput, optInOut](app, "/users", func(c *C[optInInput]) (*optInOut, error) {
+		return &optInOut{ID: "1"}, nil
+	})
+
+	out := buf.String()
+	if !strings.Contains(out, "no Validator is configured") {
+		t.Fatalf("no warning for ignored validate: tags: %q", out)
+	}
+	if !strings.Contains(out, "WithValidator") {
+		t.Errorf("warning does not say how to fix it: %q", out)
+	}
+	if !strings.Contains(out, "POST /users") {
+		t.Errorf("warning does not name the route: %q", out)
+	}
+}
+
+func TestWarnsOncePerProcessNotPerRoute(t *testing.T) {
+	buf := captureValidateWarning(t)
+
+	app := New()
+	for _, p := range []string{"/a", "/b", "/c"} {
+		Post[optInInput, optInOut](app, p, func(c *C[optInInput]) (*optInOut, error) {
+			return &optInOut{ID: "1"}, nil
+		})
+	}
+	if n := strings.Count(buf.String(), "no Validator is configured"); n != 1 {
+		t.Fatalf("warned %d times across 3 routes, want 1", n)
+	}
+}
+
+func TestNoWarningWhenValidatorConfigured(t *testing.T) {
+	buf := captureValidateWarning(t)
+
+	app := New(WithValidator(NewValidator()))
+	Post[optInInput, optInOut](app, "/users", func(c *C[optInInput]) (*optInOut, error) {
+		return &optInOut{ID: "1"}, nil
+	})
+	if buf.Len() != 0 {
+		t.Fatalf("warned even though a Validator is configured: %s", buf.String())
+	}
+}
+
+func TestNoWarningWithoutValidateTags(t *testing.T) {
+	buf := captureValidateWarning(t)
+
+	app := New()
+	Post[optInPlain, optInOut](app, "/users", func(c *C[optInPlain]) (*optInOut, error) {
+		return &optInOut{ID: "1"}, nil
+	})
+	if buf.Len() != 0 {
+		t.Fatalf("warned for a type with no validate: tags: %s", buf.String())
+	}
+}


### PR DESCRIPTION
Found by walking the documented path as a new user — installed the CLI from the
published module (`go install github.com/go-kruda/kruda/cmd/kruda@latest`,
resolving `kruda v1.6.2`) and ran the steps the tool prints. Every finding below
was reproduced in a pristine `mktemp -d` with `env -u GOFLAGS -u GOWORK`.

## `kruda new` produced a project that could not build

All three templates wrote `require github.com/go-kruda/kruda v0.0.0` — a
placeholder no proxy can resolve.

```
$ kruda new probe && cd probe && go mod tidy
go: probe imports
        github.com/go-kruda/kruda: reading .../go.mod at revision v0.0.0: unknown revision v0.0.0
$ go build .
main.go:4:2: missing go.sum entry for module providing package github.com/go-kruda/kruda
```

The recovery a user would reach for fails too — `go get github.com/go-kruda/kruda@latest`
resolves the bad requirement before fetching anything — so the only way out was
editing `go.mod` by hand. `kruda mcp` prints the same three steps and the
scaffold ships `.mcp.json` and `.cursor/mcp.json`, so AI-assisted users were
walked into the same wall.

Broken since `40c4ebe` (2026-03-01), through v1.4.0, v1.5.0, v1.6.0, v1.6.1 and
v1.6.2. `cmd_new_test.go` only `os.Stat`-ed that files existed, so nothing ever
built a scaffold.

**Fix:** leave the requirement out. `go mod tidy` resolves the current release on
its own, so there is no pinned version left to go stale at the next tag.

`TestScaffoldedProjectBuilds` now runs `go mod tidy` and `go build ./...` on a
real scaffold of every template — and it immediately found a second break the
go.mod fix had been hiding: `api` and `fullstack` called
`c.Status(204).Send(nil)`, but `Send` is unexported. They now use `c.NoContent()`.
The test needs the module proxy so it skips under `-short`;
`TestTemplatesDoNotPinCoreVersion` keeps the requirement out cheaply.

## `validate:` tags were silently ignored

Validation is opt-in (`handler.go:81`). Without a `Validator` the tags do nothing
— no error, no log line — and the handler receives whatever the client sent:

```
POST /users {"name":"T","email":"nope","age":5}   # violates min=2, email, gte=18
→ 200 {"id":"1","name":"T","email":"nope"}
```

Nothing about the code says so, and our own docs set the trap: the README's
typed-handler example showed `validate:` tags on a plain `kruda.New()`, and
`CLAUDE.md` — which every AI assistant working in this repo reads — described
`C[T].In` as "parsed, validated input".

**Fix:** warn once per process at route registration, naming a route and field
and saying which option enables validation. Registration-time only; nothing is
added to the request path.

The docs were wrong in more places than the README. Corrected across the `C[T]`
package doc, `docs/api/handler.md`, `docs/guide/handlers.md`, the four
`coming-from-*` guides, the typed-handlers example, `CLAUDE.md`, the `kruda
generate` template hint, and — the one that matters most — the `kruda mcp`
documentation topics.

`kruda mcp` told AI assistants "Kruda validates struct tags automatically in
typed handlers", described `c.In` as "already parsed and validated", and never
mentioned `WithValidator` anywhere. `kruda new` ships `.mcp.json` and
`.cursor/mcp.json`, so that was the guidance behind AI-generated Kruda code. Its
file-upload topic was the worst case: `max_size` and `mime` were presented as if
an oversized or wrong-typed upload would be rejected on the strength of the tag.

`coming-from-echo.md` claimed "no global validator registration" as an advantage
over Echo, which inverted the actual difference.

Where relevant the docs now also note that the generated OpenAPI schema carries
the constraints whether or not a Validator enforces them — the spec advertises
rules the server may not apply.

`TestMCPDocsDoNotTeachAutomaticValidation` fails on the old phrasings and on any
topic showing a `validate:` tag without `WithValidator`. It caught the
file-upload topic on its first run.

### The file-upload sample was broken twice over

Reviewing that topic turned up two defects the prose fix had walked past:

```go
File *kruda.Upload `form:"file" validate:"required" max_size:"5mb" mime:"image/*"`
```

`kruda.Upload` does not exist — the type is `kruda.FileUpload` — so the sample
never compiled. And `max_size` and `mime` are validation *rules*, not struct tags
of their own. Written that way only `required` compiles; measured directly:

```
separate max_size:/mime: tags → rules compiled: [required]
inside validate:"..."         → rules compiled: [required max_size=5mb mime=image/*]
```

So an upload of any size or MIME type was accepted, with a validator configured
and the limits visible in the source. No compile error, no warning — the failure
only appears as an upload that should have been rejected. Corrected to
`validate:"required,max_size=5mb,mime=image/*"`, which is what `upload.go` and
`docs/guide/security.md` already showed.

`TestMCPDocsUseValidationRulesAsRules` rejects any rule name used as a standalone
struct tag, and `TestMCPDocsReferenceRealCoreTypes` rejects `kruda.Upload`. Both
were checked against the shipped text and fail on it. Swept the tree for both
patterns — this topic was the only place.

**Gap flagged, not closed:** the `kruda mcp` samples are not compiled anywhere,
which is how a non-existent type survived in them. The guards are a floor.

### And the corrected sample still taught a limit that cannot fire

Every upload sample in the tree paired `max_size=5mb` with the default **4MB**
`BodyLimit`. `BodyLimit` is enforced by the transport before the handler runs, so
a larger request is answered 413 and never reaches validation. Measured against
the documented sample:

```
3MB   -> 422  (validation ran)
4.5MB -> 413  (BodyLimit; validation never ran)
6MB   -> 413
```

So the 5MB rule could not fire for any request that got far enough to be
validated. A reader who copied it believed they had a 5MB cap; the real cap was
4MB, with a different status code and none of the structured field errors the
validation docs promise.

`upload.go`, `docs/guide/security.md` and the `kruda mcp` topic now raise
`WithBodyLimit` past the `max_size` and state the ordering and both status codes.
`TestDocumentedMaxSizeIsReachable` parses each documented `max_size` through the
same `parseSize` the rule uses and compares it against the `BodyLimit` that
file's own samples establish — checked against the shipped docs, it fails on
them.

Its first version had two holes, both since closed and both confirmed by
reopening them:

- It named four files, so it never checked `cmd/kruda/cmd_mcp.go` — the file
  carrying the sample that prompted writing it. It now discovers files, over
  tracked paths only (untracked local notes under `.kiro` are not shipped, and
  failing on them would make the guard noise).
- It credited any file that merely *mentioned* `WithBodyLimit`, so a sample
  raising the limit to 1MB alongside `max_size=5mb` would have passed. It now
  parses the literal and compares; value-free mentions like the security guide's
  `WithBodyLimit(bytes)` API-table row are skipped rather than failing the file.

Granularity is the file, not the snippet — a file raising the limit anywhere is
credited everywhere. That is the limit of what a text scan can claim, and the
code says so.

This does **not** turn validation on by default — that would change behaviour for
existing apps, and belongs in its own decision.

## Smaller CLI fixes

| | |
|---|---|
| `kruda --version` printed `dev` for anyone who installed the published binary (the version is only injected by `-ldflags` in a release build) — now falls back to the module version in the binary | |
| `kruda validate` dumped the whole usage block on a failing check, pushing the message saying what to fix off the top | |
| Every CLI error printed twice, once by cobra and once by the entry point | |
| `kruda dev` claimed `Listening on :3000` while the app served on its own port — it only passes `PORT` to the child, and now says so | |

## Verification

```
go test -race -skip TestPlaintextPerformanceGuard ./...                      PASS
go test -race -tags kruda_stdjson -skip TestPlaintextPerformanceGuard ./...  PASS
go test -run TestPlaintextPerformanceGuard .                                 PASS
cd cmd/kruda && go test ./...                                                PASS
GOOS=windows/linux/darwin go vet ./...                                       clean
gofmt -l                                                                     clean
```

End to end, with a CLI built from this branch:

```
$ kruda new myapp && cd myapp && go mod tidy && go run .
go: found github.com/go-kruda/kruda in github.com/go-kruda/kruda v1.6.2
$ curl localhost:3000/
{"message":"Hello from myapp!"}
```

## Not in this PR

- `cmd/kruda` has no semver tag, so `@latest` resolves to a pseudo-version. With
  the `--version` fix that now at least reports something traceable, but tagging
  the module is a release decision.
- Whether validation should be on by default.



