### PR TITLE
security(observability): require grpc v1.82.1 for GO-2026-6061

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- `contrib/observability` now requires `google.golang.org/grpc` v1.82.1, clearing
+  GO-2026-6061. The vulnerable v1.81.1 arrived indirectly through the OTLP gRPC
+  exporters, and govulncheck reported it as reachable from
+  `observability.buildSDK`. The weekly scan on 2026-07-26 was clean, so the
+  advisory landed after it; the finding came from the on-PR scan.
+
 ### Fixed
 
 - `kruda new` now produces a project that builds. All three templates wrote

--- a/contrib/observability/go.mod
+++ b/contrib/observability/go.mod
@@ -61,6 +61,6 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/contrib/observability/go.sum
+++ b/contrib/observability/go.sum
@@ -141,8 +141,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
govulncheck reports **GO-2026-6061** in `google.golang.org/grpc` v1.81.1 as
*reachable* from `contrib/observability`:

```
Vulnerability #1: GO-2026-6061
  Found in: google.golang.org/grpc@v1.81.1
  Fixed in: google.golang.org/grpc@v1.82.1
  #1: sdk.go:75:19: observability.buildSDK calls trace.TracerProvider.Shutdown,
      which eventually calls transport.ClientStream.Close
```

The vulnerable version arrives indirectly through the OTLP gRPC exporters.

**Timeline:** the weekly scan on 2026-07-26 was clean, so the advisory published
after it. It surfaced on #183 — an unrelated PR about benchmark reproduction —
because the workflow also runs whenever a PR touches a `go.mod`. That trigger
doing its job is the reason this was caught within days rather than at the next
weekly run.

## Verification

`govulncheck ./...` in `contrib/observability` no longer reports GO-2026-6061.
The remaining findings are stdlib advisories against my local go1.26.1
toolchain, cleared by the go1.26.5 CI uses; the repo floor already requires
1.26.4+. Build and tests pass.

## Note

Consumers pin `contrib/observability` by version, so this protects them only
once the module is tagged. Tagging is a separate decision.