### PR TITLE
Fix the JSON engine signal, and the docs that described it wrongly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,21 @@ jobs:
         shell: bash
         run: CGO_ENABLED=1 go test -race ./...
 
+      # Sonic accelerates amd64 and arm64 only; on other 64-bit architectures it
+      # routes its own API to encoding/json, and Kruda's json package takes a
+      # different code path there (see json/sonic_noaccel.go). The test matrix is
+      # amd64 and arm64, so nothing else covers that path — this at least keeps it
+      # compiling. Build-only: there is no runner for these.
+      - name: Build the Sonic-fallback architectures
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25.11'
+        shell: bash
+        run: |
+          for arch in ppc64le s390x riscv64; do
+            echo "== linux/$arch =="
+            GOOS=linux GOARCH="$arch" go build ./...
+            GOOS=linux GOARCH="$arch" go vet ./...
+          done
+
       - name: Test contrib packages
         shell: bash
         # Dynamically discovers contrib modules so new modules cannot be missed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,16 @@ jobs:
             GOOS=linux GOARCH="$arch" go vet ./...
           done
 
+          # 32-bit is not a fallback case: sonic refuses to compile there, so the
+          # default build fails and kruda_stdjson is the documented way to build
+          # for linux/arm. Pin it, since nothing else checks it.
+          #
+          # linux/386 is deliberately absent: it cannot be built at all, with or
+          # without the tag, because wing_engine_linux.go uses
+          # syscall.SYS_ACCEPT4, which Go does not define for 386.
+          echo "== linux/arm, kruda_stdjson =="
+          GOOS=linux GOARCH=arm go build -tags kruda_stdjson ./...
+
       - name: Test contrib packages
         shell: bash
         # Dynamically discovers contrib modules so new modules cannot be missed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,8 +179,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `listening` startup log line now reports the active JSON engine as
   `json=sonic`, `json=encoding/json`, or `json=sonic (fallback: encoding/json)`,
   naming what is actually encoding. The third is genuinely distinct: Sonic's API
-  is still in front so the bytes are Sonic's, while the standard library does the
-  work so the speed is not — only cost changes on a fallback, not output. Sonic applies its own platform and Go-version constraints on top of
+  is still in front, so its `EscapeHTML` setting is honoured and the HTML-escaping
+  divergence between the engines does not appear, while the standard library does
+  the work, so the speed is not Sonic's. Output beyond escaping is untested on a
+  fallback rather than guaranteed identical — no build target can produce one
+  today, as Sonic does not compile on 32-bit and Go 1.27 does not exist yet. Sonic applies its own platform and Go-version constraints on top of
   Kruda's tag and can route its API to `encoding/json` — an architecture it has no
   assembly for, or a Go version it has not validated, such as go1.27 and newer for
   sonic v1.15.0. `json.ActiveEngine` resolves that, and Kruda now selects its JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,8 +182,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   is still in front, so its `EscapeHTML` setting is honoured and the HTML-escaping
   divergence between the engines does not appear, while the standard library does
   the work, so the speed is not Sonic's. Output beyond escaping is untested on a
-  fallback rather than guaranteed identical — no build target can produce one
-  today, as Sonic does not compile on 32-bit and Go 1.27 does not exist yet. Sonic applies its own platform and Go-version constraints on top of
+  fallback rather than guaranteed identical. A fallback is reachable today, not
+  hypothetical: `linux/ppc64le`, `s390x`, `riscv64`, `mips64` and `loong64` build
+  and take it, while 32-bit reaches neither path because Sonic does not compile
+  there. CI covers amd64 and arm64 only, so none of it is exercised. Sonic applies its own platform and Go-version constraints on top of
   Kruda's tag and can route its API to `encoding/json` — an architecture it has no
   assembly for, or a Go version it has not validated, such as go1.27 and newer for
   sonic v1.15.0. `json.ActiveEngine` resolves that, and Kruda now selects its JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,8 +184,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   the work, so the speed is not Sonic's. Output beyond escaping is untested on a
   fallback rather than guaranteed identical. A fallback is reachable today, not
   hypothetical: `linux/ppc64le`, `s390x`, `riscv64`, `mips64` and `loong64` build
-  and take it, while 32-bit reaches neither path because Sonic does not compile
-  there. CI covers amd64 and arm64 only, so none of it is exercised. Sonic applies its own platform and Go-version constraints on top of
+  and take it; CI covers amd64 and arm64 only, so none of it is exercised. On
+  32-bit the default build does not compile at all, because Sonic refuses to; on
+  `linux/arm` the `kruda_stdjson` tag drops the dependency and builds, while
+  `linux/386` cannot be built at all for an unrelated reason — Wing's Linux
+  engine uses `syscall.SYS_ACCEPT4`, undefined for 386. Sonic applies its own platform and Go-version constraints on top of
   Kruda's tag and can route its API to `encoding/json` — an architecture it has no
   assembly for, or a Go version it has not validated, such as go1.27 and newer for
   sonic v1.15.0. `json.ActiveEngine` resolves that, and Kruda now selects its JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,8 +177,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   is fixed at compile time, and measure unchanged at ~165 ns/op. Map marshalling
   costs roughly 13% more for a 4-key map and 65% for a 50-key map.
 - The `listening` startup log line now reports the active JSON engine as
-  `json=sonic` or `json=encoding/json`, reporting the engine actually doing the
-  work. Sonic applies its own platform and Go-version constraints on top of
+  `json=sonic`, `json=encoding/json`, or `json=sonic (fallback: encoding/json)`,
+  naming what is actually encoding. The third is genuinely distinct: Sonic's API
+  is still in front so the bytes are Sonic's, while the standard library does the
+  work so the speed is not — only cost changes on a fallback, not output. Sonic applies its own platform and Go-version constraints on top of
   Kruda's tag and can route its API to `encoding/json` — an architecture it has no
   assembly for, or a Go version it has not validated, such as go1.27 and newer for
   sonic v1.15.0. `json.ActiveEngine` resolves that, and Kruda now selects its JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,10 +177,14 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   is fixed at compile time, and measure unchanged at ~165 ns/op. Map marshalling
   costs roughly 13% more for a 4-key map and 65% for a 50-key map.
 - The `listening` startup log line now reports the active JSON engine as
-  `json=sonic` or `json=encoding/json`. It reports which of the two files
-  compiled, which is the tag's effect — not whether Sonic ends up doing the work.
-  Sonic applies its own platform and Go-version constraints on top and can fall
-  back to `encoding/json` itself while this line still reads `json=sonic`.
+  `json=sonic` or `json=encoding/json`, reporting the engine actually doing the
+  work. Sonic applies its own platform and Go-version constraints on top of
+  Kruda's tag and can route its API to `encoding/json` — an architecture it has no
+  assembly for, or a Go version it has not validated, such as go1.27 and newer for
+  sonic v1.15.0. `json.ActiveEngine` resolves that, and Kruda now selects its JSON
+  response path from it too, so a fallback build takes the path that suits
+  `encoding/json` instead of the one that suits Sonic. `json.EncoderName` still
+  names what the tag selected, for callers that want that.
 - The Sonic JSON engine no longer requires CGO. `json/sonic.go` was gated on the
   `cgo` build constraint, so any `CGO_ENABLED=0` build — the common setting for
   static binaries and `scratch`/`distroless` container images — silently fell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,15 +177,20 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   is fixed at compile time, and measure unchanged at ~165 ns/op. Map marshalling
   costs roughly 13% more for a 4-key map and 65% for a 50-key map.
 - The `listening` startup log line now reports the active JSON engine as
-  `json=sonic` or `json=encoding/json`. The engine is selected by build tag, so
-  this is the only way to confirm from a running binary which one a build got.
+  `json=sonic` or `json=encoding/json`. It reports which of the two files
+  compiled, which is the tag's effect — not whether Sonic ends up doing the work.
+  Sonic applies its own platform and Go-version constraints on top and can fall
+  back to `encoding/json` itself while this line still reads `json=sonic`.
 - The Sonic JSON engine no longer requires CGO. `json/sonic.go` was gated on the
   `cgo` build constraint, so any `CGO_ENABLED=0` build — the common setting for
   static binaries and `scratch`/`distroless` container images — silently fell
   back to `encoding/json` while still reporting a default build. Sonic is pure
-  Go plus assembly and has no cgo dependency; on platforms it does not
-  accelerate, Sonic's own build constraints already route its API to
-  `encoding/json`. The engine now depends only on the `kruda_stdjson` tag.
+  Go plus assembly and has no cgo dependency. CGO no longer takes part in the
+  choice: the `kruda_stdjson` tag selects `encoding/json`, and without it Kruda
+  selects Sonic, which then applies its own constraints — amd64/arm64 on Go
+  versions it has validated — and routes to `encoding/json` itself outside them.
+  Sonic v1.15.0 excludes Go 1.27 and newer, so a toolchain upgrade can still
+  change the engine without any change to build flags.
 
   This changes behavior for existing `CGO_ENABLED=0` builds, which now get
   Sonic: JSON decoding is about 6× faster (78.1 → 13.0 µs for a 100-item

--- a/bench/reproducible/README.md
+++ b/bench/reproducible/README.md
@@ -138,11 +138,14 @@ roughly one write/send syscall per response.
 
 ## Kruda JSON Encoder Mode
 
-The harness builds Kruda with `KRUDA_GO_TAGS=kruda_stdjson` by default so
-portable CPU-bound evidence does not depend on CGO availability. For JSON
-handler profile investigation, set `KRUDA_GO_TAGS=default` or an empty
-`KRUDA_GO_TAGS` value to build Kruda without explicit Go build tags. On
-CGO-enabled systems, that selects the default Sonic encoder path.
+The harness builds Kruda with `KRUDA_GO_TAGS=kruda_stdjson` by default so that
+CPU-bound evidence measures the same encoder everywhere. For JSON handler
+profile investigation, set `KRUDA_GO_TAGS=default` or an empty `KRUDA_GO_TAGS`
+value to build Kruda without explicit Go build tags, which selects Sonic.
+
+CGO does not enter into it: Sonic is pure Go plus assembly. (Before v1.7.0 a
+`CGO_ENABLED=0` build silently got `encoding/json`, which is why older notes here
+tied the engine to CGO availability.)
 
 Compare the JSON serialization route with stdlib JSON:
 

--- a/bench/reproducible/kruda/go.mod
+++ b/bench/reproducible/kruda/go.mod
@@ -1,6 +1,6 @@
 module bench-kruda
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/go-kruda/kruda v1.4.0
@@ -67,7 +67,7 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
 

--- a/bench/reproducible/kruda/go.sum
+++ b/bench/reproducible/kruda/go.sum
@@ -151,8 +151,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/bench/reproducible/kruda/main.go
+++ b/bench/reproducible/kruda/main.go
@@ -85,7 +85,10 @@ func main() {
 		dsn = "postgres://benchmarkdbuser:benchmarkdbpass@localhost:5433/hello_world?pool_max_conns=64&pool_min_conns=8"
 	}
 
-	fmt.Printf("[kruda] JSON encoder: %s\n", krudajson.EncoderName)
+	// ActiveEngine, not EncoderName: this line labels the evidence a run
+	// produces, and the tag can name sonic on a build where sonic has fallen
+	// back to encoding/json.
+	fmt.Printf("[kruda] JSON encoder: %s\n", krudajson.ActiveEngine())
 
 	cpuDispatchMode, err := normalizeBenchDispatch(os.Getenv("BENCH_KRUDA_CPU_DISPATCH"), "inline")
 	if err != nil {

--- a/ctx_response.go
+++ b/ctx_response.go
@@ -695,8 +695,16 @@ func init() {
 	}
 }
 
+// shouldUseWingJSONStream selects the streaming responder, which is the better
+// path when encoding/json is doing the work and not when sonic is.
+//
+// It asks which engine is actually active, not which one the build tag named.
+// Those differ when sonic routes its own API to the standard library — an
+// architecture it has no assembly for, or a Go version it has not validated — and
+// keying on the tag there picked sonic's path while encoding/json ran, losing the
+// stream lane on exactly the builds that want it.
 func shouldUseWingJSONStream() bool {
-	return krudajson.EncoderName == "encoding/json"
+	return krudajson.EngineIsStdlib
 }
 
 func contentLengthString(length int) string {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -79,14 +79,25 @@ See the [Test Client API](/api/test-client) for the full builder API.
 
 ## Do I need CGO for Sonic JSON?
 
-Kruda selects Sonic when CGO is enabled and selects `encoding/json` when CGO is disabled. The engine is chosen at build time.
+No. Sonic is pure Go plus assembly and has never needed a C compiler. The engine
+is chosen at build time by the `kruda_stdjson` tag and nothing else, so
+`CGO_ENABLED=0` builds — static binaries, `scratch` and `distroless` images —
+get Sonic like any other build.
 
-To force stdlib JSON (no CGO required):
+Before v1.7.0 that was not the case: `json/sonic.go` carried a `cgo` build
+constraint, so every `CGO_ENABLED=0` build silently got `encoding/json` while
+still reporting a default build. If you build without CGO and want the behaviour
+you thought you had, upgrade.
+
+To select the standard library explicitly:
 
 ```bash
 go build -tags kruda_stdjson ./...
 go test -tags kruda_stdjson ./...
 ```
+
+The `listening` startup log line reports which engine a running binary got
+(`json=sonic` or `json=encoding/json`).
 
 ## What Go version do I need?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -79,10 +79,16 @@ See the [Test Client API](/api/test-client) for the full builder API.
 
 ## Do I need CGO for Sonic JSON?
 
-No. Sonic is pure Go plus assembly and has never needed a C compiler. The engine
-is chosen at build time by the `kruda_stdjson` tag and nothing else, so
-`CGO_ENABLED=0` builds — static binaries, `scratch` and `distroless` images —
-get Sonic like any other build.
+No. Sonic is pure Go plus assembly and has never needed a C compiler, so
+`CGO_ENABLED=0` builds — static binaries, `scratch` and `distroless` images — are
+not excluded from it.
+
+CGO is not what selects the engine. The `kruda_stdjson` tag always selects
+`encoding/json`; without it Kruda selects Sonic, and Sonic then applies its own
+constraints (amd64/arm64, on Go versions it has validated — v1.15.0 excludes
+Go 1.27+) and falls back to `encoding/json` itself outside them. See
+[Performance](/guide/performance#json-performance) for the full rule and the
+caveat that the startup log reports the tag, not the outcome.
 
 Before v1.7.0 that was not the case: `json/sonic.go` carried a `cgo` build
 constraint, so every `CGO_ENABLED=0` build silently got `encoding/json` while

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -68,19 +68,12 @@ CGO** — Sonic is pure Go plus assembly, so `CGO_ENABLED=0` builds get Sonic to
 platforms Sonic does not accelerate, its own build constraints route its API to
 `encoding/json`.
 
-How much the engine is worth depends entirely on payload shape. Measured on an
-8-core linux/amd64 host, `wrk -t4 -c256`, Sonic against `encoding/json`:
-
-| route | payload | delta |
-|---|---|---|
-| encode ~30 B (the TFB `/json` shape) | small | no measurable change |
-| encode ~8 KB | array of 100 structs | +23% req/s |
-| decode ~8 KB request body | POST | +160% req/s |
-
-Small responses do not move because the kernel's per-request TCP cost dominates
-— at ~700k req/s a worker spends ~11 µs per request and encoding 30 bytes is a
-rounding error against that. Bodies of any size are where the engine shows up.
-Reproduce with `bench/reproducible/jsonthroughput/`.
+How much the engine is worth depends on payload shape. On the encoder and
+decoder themselves, measured on linux/amd64 with `json/engine_bench_test.go`,
+Sonic is roughly 35% faster to encode a 100-item payload and about 6× faster to
+decode one. How much of that reaches request throughput is a separate question —
+a small response spends most of its budget in the kernel, not the encoder — so
+benchmark your own payload shapes rather than assuming either figure carries over.
 
 Cold start is the trade: Sonic's JIT warm-up costs about +3 ms and +7 MB RSS per
 process, a fixed cost that does not scale with route count. Set `kruda_stdjson`

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -59,7 +59,7 @@ Route registration order doesn't affect lookup performance.
 
 | Engine | Selected by | Performance |
 |--------|-------------|-------------|
-| Sonic | default | SIMD-accelerated on amd64/arm64; benchmark with your payloads |
+| Sonic | default | Assembly-accelerated; clearly ahead on amd64, mixed on arm64 (see below) |
 | encoding/json | `kruda_stdjson` build tag | Portable standard-library baseline |
 
 The engine is selected at build time by that tag alone. **Neither engine needs
@@ -81,6 +81,11 @@ How much of that reaches request throughput is a separate question, and the
 answer is often "none": a small response spends most of its per-request budget in
 the kernel rather than in the encoder. Benchmark your own payload shapes rather
 than assuming either ratio carries over.
+
+Those ratios are **amd64**. On darwin/arm64 the same encode benchmark inverts —
+Sonic 17,970 ns against `encoding/json` 10,940 ns — while decode stays about 4.3×
+in Sonic's favour. If you develop on an arm64 Mac and deploy to amd64 Linux, the
+two are not interchangeable for encode-heavy profiling.
 
 Cold start is the trade: Sonic's JIT warm-up costs about +3 ms and +7 MB RSS per
 process, a fixed cost that does not scale with route count. Set `kruda_stdjson`

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -93,11 +93,21 @@ substitutes U+FFFD on its own. Error text and types come from `encoding/json`
 there.
 
 The fallback is reachable today rather than hypothetical: `linux/ppc64le`,
-`s390x`, `riscv64`, `mips64` and `loong64` all build and take it. (32-bit is a
-different case — Sonic does not compile on `386` or `arm` at all, so those reach
-neither path.) Kruda's CI runs on amd64 and arm64 only, so nothing exercises the
-fallback. If you deploy to one of those architectures, benchmark and test there
-rather than relying on figures from this page.
+`s390x`, `riscv64`, `mips64` and `loong64` all build and take it. Kruda's CI runs
+on amd64 and arm64 only, so nothing exercises it. If you deploy to one of those
+architectures, benchmark and test there rather than relying on figures from this
+page.
+
+::: warning 32-bit: `arm` needs `kruda_stdjson`, `386` does not build at all
+Sonic refuses to compile on 32-bit, from a deliberate guard in its own internals,
+so the default build fails there. On `linux/arm`, `-tags kruda_stdjson` works
+around it by dropping the Sonic dependency.
+
+`linux/386` cannot be built at all, and not because of JSON: Wing's Linux engine
+calls `syscall.SYS_ACCEPT4`, which Go does not define for 386. No build tag helps.
+Both are build failures rather than fallbacks — the engine choice never gets a
+chance to matter.
+:::
 
 On the encoder and decoder themselves, a 100-item payload, medians of 12 runs on
 **Go 1.25.11, linux/amd64** (`json/engine_bench_test.go`; raw output in

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -90,10 +90,14 @@ Beyond escaping, treat fallback output as untested rather than guaranteed
 identical. Sonic's compat layer does not implement `SortMapKeys` or
 `ValidateString`; those agree only because `encoding/json` sorts map keys and
 substitutes U+FFFD on its own. Error text and types come from `encoding/json`
-there, and nothing else is exercised — no build target can currently produce a
-fallback, since Sonic does not compile on 32-bit at all and Go 1.27 does not
-exist yet. That is why this is stated as a known-narrow result rather than a
-contract.
+there.
+
+The fallback is reachable today rather than hypothetical: `linux/ppc64le`,
+`s390x`, `riscv64`, `mips64` and `loong64` all build and take it. (32-bit is a
+different case — Sonic does not compile on `386` or `arm` at all, so those reach
+neither path.) Kruda's CI runs on amd64 and arm64 only, so nothing exercises the
+fallback. If you deploy to one of those architectures, benchmark and test there
+rather than relying on figures from this page.
 
 On the encoder and decoder themselves, a 100-item payload, medians of 12 runs on
 **Go 1.25.11, linux/amd64** (`json/engine_bench_test.go`; raw output in

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -62,15 +62,30 @@ Route registration order doesn't affect lookup performance.
 | Sonic | default | Assembly-accelerated; clearly ahead on amd64, mixed on arm64 (see below) |
 | encoding/json | `kruda_stdjson` build tag | Portable standard-library baseline |
 
-The engine is selected at build time by that tag alone. **Neither engine needs
-CGO** — Sonic is pure Go plus assembly, so `CGO_ENABLED=0` builds get Sonic too
-(since v1.7.0; earlier versions silently fell back to `encoding/json`). On
-platforms Sonic does not accelerate, its own build constraints route its API to
-`encoding/json`.
+Selection happens at build time, in this order:
+
+1. The `kruda_stdjson` tag always selects `encoding/json`.
+2. Otherwise Kruda selects Sonic — but Sonic then applies **its own** constraints,
+   which cover amd64 and arm64 on the Go versions it has validated. Outside those,
+   Sonic routes its API to `encoding/json` itself. For Sonic v1.15.0 that means
+   **Go 1.27 and newer fall back**, regardless of the tag or the platform.
+
+**Neither engine needs CGO.** Sonic is pure Go plus assembly, so `CGO_ENABLED=0`
+builds are not excluded (since v1.7.0; earlier versions silently fell back to
+`encoding/json`).
+
+::: warning The startup log reports intent, not the outcome
+`listening … json=sonic` says which of Kruda's two files compiled, not whether
+Sonic is actually doing the work. On a Go version or platform Sonic does not
+support it still prints `json=sonic` while `encoding/json` runs. Treat it as "this
+build did not set `kruda_stdjson`", and pin the Go toolchain if you depend on the
+figures below.
+:::
 
 On the encoder and decoder themselves, a 100-item payload, medians of 12 runs on
-linux/amd64 (`json/engine_bench_test.go`; raw output in
-`bench/reproducible/results/2026-07-29-coldstart/`):
+**Go 1.25.11, linux/amd64** (`json/engine_bench_test.go`; raw output in
+`bench/reproducible/results/2026-07-29-coldstart/`). Both collapse to 1× on any
+build where Sonic falls back, per the rule above:
 
 | | encoding/json | Sonic | |
 |---|---|---|---|

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -57,12 +57,35 @@ Route registration order doesn't affect lookup performance.
 
 ## JSON Performance
 
-| Engine | CGO Required | Performance |
+| Engine | Selected by | Performance |
 |--------|-------------|-------------|
-| Sonic | Yes in Kruda's default build | SIMD-accelerated; benchmark with your payloads |
-| encoding/json | No | Portable standard-library baseline |
+| Sonic | default | SIMD-accelerated on amd64/arm64; benchmark with your payloads |
+| encoding/json | `kruda_stdjson` build tag | Portable standard-library baseline |
 
-The engine is selected at build time: CGO-enabled builds use Sonic by default, while `CGO_ENABLED=0` or the `kruda_stdjson` tag selects `encoding/json`.
+The engine is selected at build time by that tag alone. **Neither engine needs
+CGO** — Sonic is pure Go plus assembly, so `CGO_ENABLED=0` builds get Sonic too
+(since v1.7.0; earlier versions silently fell back to `encoding/json`). On
+platforms Sonic does not accelerate, its own build constraints route its API to
+`encoding/json`.
+
+How much the engine is worth depends entirely on payload shape. Measured on an
+8-core linux/amd64 host, `wrk -t4 -c256`, Sonic against `encoding/json`:
+
+| route | payload | delta |
+|---|---|---|
+| encode ~30 B (the TFB `/json` shape) | small | no measurable change |
+| encode ~8 KB | array of 100 structs | +23% req/s |
+| decode ~8 KB request body | POST | +160% req/s |
+
+Small responses do not move because the kernel's per-request TCP cost dominates
+— at ~700k req/s a worker spends ~11 µs per request and encoding 30 bytes is a
+rounding error against that. Bodies of any size are where the engine shows up.
+Reproduce with `bench/reproducible/jsonthroughput/`.
+
+Cold start is the trade: Sonic's JIT warm-up costs about +3 ms and +7 MB RSS per
+process, a fixed cost that does not scale with route count. Set `kruda_stdjson`
+for workloads that spawn a process per request or scale to zero. See
+`bench/reproducible/coldstart/`.
 
 ## Zero-Allocation Hot Path
 

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -81,10 +81,19 @@ while the standard library does the work, so the **speed** is not. Kruda picks i
 JSON response path from the same signal, so a fallback build takes the path that
 suits the standard library.
 
-Only speed changes on fallback — not output. Sonic's fallback honours the
-configuration it was frozen with, so responses are byte-identical to an
-accelerated build. `kruda_stdjson` is the only build whose bytes differ (it
-escapes HTML; see the table above).
+The escaping difference above does **not** appear on a fallback build: Sonic's
+compat layer honours the `EscapeHTML` setting it was frozen with, so it emits the
+same unescaped output an accelerated build does. `kruda_stdjson` remains the only
+configuration whose bytes are known to differ.
+
+Beyond escaping, treat fallback output as untested rather than guaranteed
+identical. Sonic's compat layer does not implement `SortMapKeys` or
+`ValidateString`; those agree only because `encoding/json` sorts map keys and
+substitutes U+FFFD on its own. Error text and types come from `encoding/json`
+there, and nothing else is exercised — no build target can currently produce a
+fallback, since Sonic does not compile on 32-bit at all and Go 1.27 does not
+exist yet. That is why this is stated as a known-narrow result rather than a
+contract.
 
 On the encoder and decoder themselves, a 100-item payload, medians of 12 runs on
 **Go 1.25.11, linux/amd64** (`json/engine_bench_test.go`; raw output in

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -74,13 +74,11 @@ Selection happens at build time, in this order:
 builds are not excluded (since v1.7.0; earlier versions silently fell back to
 `encoding/json`).
 
-::: warning The startup log reports intent, not the outcome
-`listening … json=sonic` says which of Kruda's two files compiled, not whether
-Sonic is actually doing the work. On a Go version or platform Sonic does not
-support it still prints `json=sonic` while `encoding/json` runs. Treat it as "this
-build did not set `kruda_stdjson`", and pin the Go toolchain if you depend on the
-figures below.
-:::
+`listening … json=sonic` reports the engine actually doing the work, not the tag
+the build used: on a platform or Go version Sonic falls back on, the line reads
+`json=encoding/json`. Kruda picks its JSON response path from the same signal, so
+a fallback build gets the path that suits `encoding/json` rather than the one that
+suits Sonic.
 
 On the encoder and decoder themselves, a 100-item payload, medians of 12 runs on
 **Go 1.25.11, linux/amd64** (`json/engine_bench_test.go`; raw output in

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -74,11 +74,17 @@ Selection happens at build time, in this order:
 builds are not excluded (since v1.7.0; earlier versions silently fell back to
 `encoding/json`).
 
-`listening … json=sonic` reports the engine actually doing the work, not the tag
-the build used: on a platform or Go version Sonic falls back on, the line reads
-`json=encoding/json`. Kruda picks its JSON response path from the same signal, so
-a fallback build gets the path that suits `encoding/json` rather than the one that
-suits Sonic.
+`listening … json=` names what is actually encoding. A fallback build reads
+`json=sonic (fallback: encoding/json)` rather than either plain answer, because it
+is genuinely both: Sonic's API is still in front, so the **bytes** are Sonic's,
+while the standard library does the work, so the **speed** is not. Kruda picks its
+JSON response path from the same signal, so a fallback build takes the path that
+suits the standard library.
+
+Only speed changes on fallback — not output. Sonic's fallback honours the
+configuration it was frozen with, so responses are byte-identical to an
+accelerated build. `kruda_stdjson` is the only build whose bytes differ (it
+escapes HTML; see the table above).
 
 On the encoder and decoder themselves, a 100-item payload, medians of 12 runs on
 **Go 1.25.11, linux/amd64** (`json/engine_bench_test.go`; raw output in

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -68,12 +68,19 @@ CGO** — Sonic is pure Go plus assembly, so `CGO_ENABLED=0` builds get Sonic to
 platforms Sonic does not accelerate, its own build constraints route its API to
 `encoding/json`.
 
-How much the engine is worth depends on payload shape. On the encoder and
-decoder themselves, measured on linux/amd64 with `json/engine_bench_test.go`,
-Sonic is roughly 35% faster to encode a 100-item payload and about 6× faster to
-decode one. How much of that reaches request throughput is a separate question —
-a small response spends most of its budget in the kernel, not the encoder — so
-benchmark your own payload shapes rather than assuming either figure carries over.
+On the encoder and decoder themselves, a 100-item payload, medians of 12 runs on
+linux/amd64 (`json/engine_bench_test.go`; raw output in
+`bench/reproducible/results/2026-07-29-coldstart/`):
+
+| | encoding/json | Sonic | |
+|---|---|---|---|
+| encode | 10,625 ns | 2,475 ns | **4.3× faster** |
+| decode | 78,133 ns | 13,015 ns | **6.0× faster** |
+
+How much of that reaches request throughput is a separate question, and the
+answer is often "none": a small response spends most of its per-request budget in
+the kernel rather than in the encoder. Benchmark your own payload shapes rather
+than assuming either ratio carries over.
 
 Cold start is the trade: Sonic's JIT warm-up costs about +3 ms and +7 MB RSS per
 process, a fixed cost that does not scale with route count. Set `kruda_stdjson`

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -77,8 +77,11 @@ Kruda's JSON engine.
 
 ### Selecting the engine
 
-The engine is chosen at build time by the `kruda_stdjson` tag and nothing else.
-Kruda never switches engines at runtime.
+The `kruda_stdjson` tag always selects `encoding/json`. Without it Kruda selects
+Sonic, and Sonic applies its own constraints — amd64/arm64, on Go versions it has
+validated — falling back to `encoding/json` itself outside them. Sonic v1.15.0
+excludes **Go 1.27 and newer**, so a toolchain upgrade can change the engine
+without any change to your build flags. Kruda never switches engines at runtime.
 
 ```bash
 go build ./...                        # Sonic (default)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -66,39 +66,43 @@ Or use a different port:
 app.Listen(":3001")
 ```
 
-## CGO and Sonic JSON
+## Choosing the JSON engine
 
-### `cgo: C compiler not found`
+### Sonic does not need CGO
 
-Sonic JSON requires CGO for SIMD optimizations. If you don't have a C compiler:
+Earlier versions of this page said Sonic required a C compiler. That was wrong:
+Sonic is pure Go plus assembly. If you hit `cgo: C compiler not found`, something
+else in your build needs CGO — a database driver, `-race` on some platforms — not
+Kruda's JSON engine.
 
-Option 1 — Install a C compiler:
-```bash
-# macOS
-xcode-select --install
+### Selecting the engine
 
-# Ubuntu/Debian
-sudo apt install build-essential
-
-# Windows
-# Install MinGW or use WSL
-```
-
-Option 2 — Use stdlib JSON (no CGO):
-```bash
-go build -tags kruda_stdjson ./...
-```
-
-### Selecting the encoding/json fallback
-
-Kruda selects the JSON engine at build time. Disabling CGO selects `encoding/json` automatically; the `kruda_stdjson` tag selects it explicitly. Kruda does not switch engines at runtime after the binary has been built.
-
-Either of these builds uses stdlib JSON:
+The engine is chosen at build time by the `kruda_stdjson` tag and nothing else.
+Kruda never switches engines at runtime.
 
 ```bash
-CGO_ENABLED=0 go build ./...
-go build -tags kruda_stdjson ./...
+go build ./...                        # Sonic (default)
+go build -tags kruda_stdjson ./...    # encoding/json
 ```
+
+`CGO_ENABLED=0` is **not** a way to select `encoding/json`. It was, accidentally,
+before v1.7.0 — `json/sonic.go` carried a `cgo` build constraint, so every
+CGO-disabled build silently got the standard library while still reporting a
+default build. Since v1.7.0 a `CGO_ENABLED=0` build gets Sonic like any other.
+
+To confirm what a running binary actually got, read the `listening` startup line:
+
+```
+INFO listening addr=:3000 json=sonic
+```
+
+### Upgrading and finding your JSON got faster and your start-up slower
+
+Expected, if you build with `CGO_ENABLED=0`. That build used to get
+`encoding/json` and now gets Sonic: decoding request bodies gets several times
+cheaper, at a fixed cost of roughly +3 ms start-up and +7 MB RSS per process for
+Sonic's JIT warm-up. If you spawn a process per request or scale to zero, set
+`kruda_stdjson` to keep the faster start.
 
 ## Windows Compatibility
 

--- a/json/engine_golden_test.go
+++ b/json/engine_golden_test.go
@@ -65,7 +65,7 @@ func TestGoldenBytesMatchAcrossEngines(t *testing.T) {
 				t.Fatalf("Marshal failed: %v", err)
 			}
 			if string(got) != tc.want {
-				t.Errorf("engine %s: Marshal = %s, want %s", EncoderName, got, tc.want)
+				t.Errorf("engine %s: Marshal = %s, want %s", ActiveEngine(), got, tc.want)
 			}
 
 			buf := &bytes.Buffer{}
@@ -73,7 +73,7 @@ func TestGoldenBytesMatchAcrossEngines(t *testing.T) {
 				t.Fatalf("MarshalToBuffer failed: %v", err)
 			}
 			if buf.String() != tc.want {
-				t.Errorf("engine %s: MarshalToBuffer = %s, want %s", EncoderName, buf.String(), tc.want)
+				t.Errorf("engine %s: MarshalToBuffer = %s, want %s", ActiveEngine(), buf.String(), tc.want)
 			}
 		})
 	}
@@ -97,7 +97,7 @@ func TestMapMarshalIsDeterministic(t *testing.T) {
 		}
 		if !bytes.Equal(got, first) {
 			t.Fatalf("engine %s: marshal %d = %s, first = %s (map key order is not deterministic)",
-				EncoderName, i, got, first)
+				ActiveEngine(), i, got, first)
 		}
 
 		buf := &bytes.Buffer{}
@@ -106,7 +106,7 @@ func TestMapMarshalIsDeterministic(t *testing.T) {
 		}
 		if !bytes.Equal(buf.Bytes(), first) {
 			t.Fatalf("engine %s: MarshalToBuffer %d = %s, Marshal = %s",
-				EncoderName, i, buf.Bytes(), first)
+				ActiveEngine(), i, buf.Bytes(), first)
 		}
 	}
 }
@@ -142,8 +142,12 @@ func TestKnownCrossEngineDivergences(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			// EngineIsStdlib, not EncoderName: this table pins how the engine
+			// actually running escapes HTML. On a build where the tag names sonic
+			// but sonic has fallen back, encoding/json does the escaping, and
+			// expecting sonic's output would fail for the wrong reason.
 			want := tc.wantStd
-			if EncoderName == "sonic" {
+			if !EngineIsStdlib {
 				want = tc.wantSonic
 			}
 			got, err := Marshal(tc.val)
@@ -154,7 +158,7 @@ func TestKnownCrossEngineDivergences(t *testing.T) {
 				t.Errorf("engine %s: Marshal = %q, want %q\n"+
 					"If this engine's escaping behavior changed on purpose, update this "+
 					"table and the sonic.Config comment in json/sonic.go.",
-					EncoderName, got, want)
+					ActiveEngine(), got, want)
 			}
 		})
 	}

--- a/json/engine_golden_test.go
+++ b/json/engine_golden_test.go
@@ -142,14 +142,19 @@ func TestKnownCrossEngineDivergences(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			// EncoderName, deliberately, not EngineIsStdlib. This table is about
-			// bytes, and bytes follow the config, which follows the tag: when
-			// sonic falls back its compat layer still honours the Config it was
-			// frozen with — compat.go calls SetEscapeHTML(cfg.EscapeHTML) — so a
-			// fallback build emits sonic's unescaped output, not the standard
-			// library's escaped default. Only speed changes on fallback, not
-			// bytes. EngineIsStdlib answers "is the fast implementation present",
-			// which is a different question and the wrong one here.
+			// EncoderName, deliberately, not EngineIsStdlib. Every case here is
+			// HTML escaping, and escaping follows the frozen Config, which
+			// follows the tag: sonic's compat layer calls
+			// SetEscapeHTML(cfg.EscapeHTML), so a fallback build emits the same
+			// unescaped bytes as an accelerated one. EngineIsStdlib answers
+			// whether the fast implementation is present — a cost question, and
+			// the wrong one for a table of bytes.
+			//
+			// This reasoning covers escaping only. compat does not act on
+			// SortMapKeys or ValidateString at all; those happen to agree because
+			// encoding/json sorts and substitutes U+FFFD unconditionally. Do not
+			// extend this table with a case whose divergence is not config-driven
+			// without checking compat for it.
 			want := tc.wantStd
 			if EncoderName == "sonic" {
 				want = tc.wantSonic

--- a/json/engine_golden_test.go
+++ b/json/engine_golden_test.go
@@ -142,12 +142,16 @@ func TestKnownCrossEngineDivergences(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			// EngineIsStdlib, not EncoderName: this table pins how the engine
-			// actually running escapes HTML. On a build where the tag names sonic
-			// but sonic has fallen back, encoding/json does the escaping, and
-			// expecting sonic's output would fail for the wrong reason.
+			// EncoderName, deliberately, not EngineIsStdlib. This table is about
+			// bytes, and bytes follow the config, which follows the tag: when
+			// sonic falls back its compat layer still honours the Config it was
+			// frozen with — compat.go calls SetEscapeHTML(cfg.EscapeHTML) — so a
+			// fallback build emits sonic's unescaped output, not the standard
+			// library's escaped default. Only speed changes on fallback, not
+			// bytes. EngineIsStdlib answers "is the fast implementation present",
+			// which is a different question and the wrong one here.
 			want := tc.wantStd
-			if !EngineIsStdlib {
+			if EncoderName == "sonic" {
 				want = tc.wantSonic
 			}
 			got, err := Marshal(tc.val)

--- a/json/engine_parity_test.go
+++ b/json/engine_parity_test.go
@@ -56,10 +56,10 @@ func TestMarshalToBufferMatchesMarshal(t *testing.T) {
 				t.Fatalf("MarshalToBuffer(%v) failed: %v", tc.val, err)
 			}
 			if got := buf.Bytes(); !bytes.Equal(got, want) {
-				t.Errorf("engine %s: MarshalToBuffer = %q, Marshal = %q", EncoderName, got, want)
+				t.Errorf("engine %s: MarshalToBuffer = %q, Marshal = %q", ActiveEngine(), got, want)
 			}
 			if bytes.HasSuffix(buf.Bytes(), []byte("\n")) {
-				t.Errorf("engine %s: trailing newline not trimmed: %q", EncoderName, buf.Bytes())
+				t.Errorf("engine %s: trailing newline not trimmed: %q", ActiveEngine(), buf.Bytes())
 			}
 		})
 	}
@@ -90,15 +90,15 @@ func TestMarshalToBufferMultiKeyMapSemanticParity(t *testing.T) {
 	}
 
 	if len(fromBuffer) != len(in) {
-		t.Fatalf("engine %s: got %d keys, want %d", EncoderName, len(fromBuffer), len(in))
+		t.Fatalf("engine %s: got %d keys, want %d", ActiveEngine(), len(fromBuffer), len(in))
 	}
 	for k, v := range fromMarshal {
 		if fromBuffer[k] != v {
-			t.Errorf("engine %s: key %q = %d, want %d", EncoderName, k, fromBuffer[k], v)
+			t.Errorf("engine %s: key %q = %d, want %d", ActiveEngine(), k, fromBuffer[k], v)
 		}
 	}
 	if bytes.HasSuffix(buf.Bytes(), []byte("\n")) {
-		t.Errorf("engine %s: trailing newline not trimmed: %q", EncoderName, buf.Bytes())
+		t.Errorf("engine %s: trailing newline not trimmed: %q", ActiveEngine(), buf.Bytes())
 	}
 }
 
@@ -117,7 +117,7 @@ func TestMarshalToBufferAppendsToExistingContent(t *testing.T) {
 			t.Fatalf("Marshal failed: %v", err)
 		}
 		if got := buf.String(); got != prefix+string(want) {
-			t.Errorf("engine %s: prefix %q → got %q, want %q", EncoderName, prefix, got, prefix+string(want))
+			t.Errorf("engine %s: prefix %q → got %q, want %q", ActiveEngine(), prefix, got, prefix+string(want))
 		}
 	}
 }
@@ -142,7 +142,7 @@ func TestMarshalToBufferRoundTrips(t *testing.T) {
 		t.Fatalf("Unmarshal of buffered output failed: %v (bytes: %q)", err, buf.Bytes())
 	}
 	if out.Name != in.Name || out.Age != in.Age || out.Score != in.Score || strings.Join(out.Tags, ",") != strings.Join(in.Tags, ",") {
-		t.Errorf("engine %s: round trip mismatch: got %+v, want %+v", EncoderName, out, in)
+		t.Errorf("engine %s: round trip mismatch: got %+v, want %+v", ActiveEngine(), out, in)
 	}
 }
 
@@ -152,13 +152,13 @@ func TestMarshalToBufferRoundTrips(t *testing.T) {
 func TestMarshalToBufferErrorLeavesBufferUsable(t *testing.T) {
 	buf := &bytes.Buffer{}
 	if err := MarshalToBuffer(buf, make(chan int)); err == nil {
-		t.Fatalf("engine %s: expected error for unsupported type", EncoderName)
+		t.Fatalf("engine %s: expected error for unsupported type", ActiveEngine())
 	}
 	buf.Reset()
 	if err := MarshalToBuffer(buf, "ok"); err != nil {
 		t.Fatalf("MarshalToBuffer after error failed: %v", err)
 	}
 	if got := buf.String(); got != `"ok"` {
-		t.Errorf("engine %s: got %q, want %q", EncoderName, got, `"ok"`)
+		t.Errorf("engine %s: got %q, want %q", ActiveEngine(), got, `"ok"`)
 	}
 }

--- a/json/engine_signal_test.go
+++ b/json/engine_signal_test.go
@@ -40,11 +40,27 @@ func TestSonicConstraintMirrorIsCurrent(t *testing.T) {
 // depends on: ActiveEngine and EngineIsStdlib must agree with each other and with
 // what this build can actually do.
 func TestActiveEngineMatchesThisBuild(t *testing.T) {
-	if got := ActiveEngine(); got != "sonic" && got != "encoding/json" {
-		t.Fatalf("ActiveEngine() = %q, want sonic or encoding/json", got)
-	}
-	if (ActiveEngine() == "encoding/json") != EngineIsStdlib {
-		t.Errorf("ActiveEngine()=%q disagrees with EngineIsStdlib=%v", ActiveEngine(), EngineIsStdlib)
+	// Three states, not two: the fallback is distinguishable from both plain
+	// answers because its bytes are sonic's and its speed is the standard
+	// library's.
+	switch got := ActiveEngine(); got {
+	case "sonic":
+		if EngineIsStdlib {
+			t.Errorf("ActiveEngine()=%q but EngineIsStdlib=true", got)
+		}
+		if EncoderName != "sonic" {
+			t.Errorf("ActiveEngine()=%q under the %s tag", got, EncoderName)
+		}
+	case "encoding/json":
+		if EncoderName != "encoding/json" {
+			t.Errorf("ActiveEngine()=%q but EncoderName=%q — the plain stdlib answer belongs to the kruda_stdjson build only", got, EncoderName)
+		}
+	case "sonic (fallback: encoding/json)":
+		if !EngineIsStdlib || EncoderName != "sonic" {
+			t.Errorf("fallback name reported with EngineIsStdlib=%v EncoderName=%q", EngineIsStdlib, EncoderName)
+		}
+	default:
+		t.Fatalf("ActiveEngine() = %q, not one of the three known states", got)
 	}
 
 	// On an architecture sonic has no assembly for, the default build must report

--- a/json/engine_signal_test.go
+++ b/json/engine_signal_test.go
@@ -40,9 +40,9 @@ func TestSonicConstraintMirrorIsCurrent(t *testing.T) {
 // depends on: ActiveEngine and EngineIsStdlib must agree with each other and with
 // what this build can actually do.
 func TestActiveEngineMatchesThisBuild(t *testing.T) {
-	// Three states, not two: the fallback is distinguishable from both plain
-	// answers because its bytes are sonic's and its speed is the standard
-	// library's.
+	// Three states, not two: a fallback is distinguishable from both plain
+	// answers — its escaping follows sonic's frozen Config while its speed is the
+	// standard library's.
 	switch got := ActiveEngine(); got {
 	case "sonic":
 		if EngineIsStdlib {

--- a/json/engine_signal_test.go
+++ b/json/engine_signal_test.go
@@ -1,0 +1,69 @@
+package json
+
+import (
+	"os"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// sonicConstraintPin is the sonic release whose build constraint sonic_accel.go
+// mirrors. Bump it only after re-reading that constraint.
+const sonicConstraintPin = "v1.15.0"
+
+// TestSonicConstraintMirrorIsCurrent fails when the sonic dependency moves.
+//
+// sonic_accel.go copies sonic's own build constraint by hand, because sonic
+// exposes no way to ask whether its accelerated implementation compiled. A sonic
+// release that adds support for a newer Go version makes that copy wrong in the
+// direction that silently costs speed: Kruda would report and select
+// encoding/json's path while sonic was in fact accelerating. Pinning the version
+// forces a human to re-check the constraint on every bump.
+func TestSonicConstraintMirrorIsCurrent(t *testing.T) {
+	b, err := os.ReadFile("../go.mod")
+	if err != nil {
+		t.Fatalf("read go.mod: %v", err)
+	}
+	m := regexp.MustCompile(`github\.com/bytedance/sonic (v[0-9][^\s]*)`).FindStringSubmatch(string(b))
+	if m == nil {
+		t.Fatal("sonic not found in go.mod")
+	}
+	if m[1] != sonicConstraintPin {
+		t.Fatalf("sonic moved to %s but sonic_accel.go still mirrors the constraint from %s.\n"+
+			"Re-read that release's sonic.go build tag, update sonic_accel.go and sonic_noaccel.go to match, "+
+			"then bump sonicConstraintPin.", m[1], sonicConstraintPin)
+	}
+}
+
+// TestActiveEngineMatchesThisBuild pins the relationship the response path now
+// depends on: ActiveEngine and EngineIsStdlib must agree with each other and with
+// what this build can actually do.
+func TestActiveEngineMatchesThisBuild(t *testing.T) {
+	if got := ActiveEngine(); got != "sonic" && got != "encoding/json" {
+		t.Fatalf("ActiveEngine() = %q, want sonic or encoding/json", got)
+	}
+	if (ActiveEngine() == "encoding/json") != EngineIsStdlib {
+		t.Errorf("ActiveEngine()=%q disagrees with EngineIsStdlib=%v", ActiveEngine(), EngineIsStdlib)
+	}
+
+	// On an architecture sonic has no assembly for, the default build must report
+	// the fallback rather than the tag.
+	accelArch := runtime.GOARCH == "amd64" || runtime.GOARCH == "arm64"
+	if EncoderName == "sonic" && !accelArch && !EngineIsStdlib {
+		t.Errorf("GOARCH=%s cannot be accelerated by sonic, but EngineIsStdlib is false", runtime.GOARCH)
+	}
+}
+
+// TestEncoderNameIsDocumentedAsTheTag guards the distinction that caused the bug:
+// EncoderName names what the tag selected, ActiveEngine names what runs. Anything
+// choosing behaviour must use the latter.
+func TestEncoderNameIsDocumentedAsTheTag(t *testing.T) {
+	b, err := os.ReadFile("sonic.go")
+	if err != nil {
+		t.Skip("sonic.go not in this build")
+	}
+	if !strings.Contains(string(b), "not necessarily") {
+		t.Error("EncoderName's doc no longer warns that it is not necessarily the engine doing the work")
+	}
+}

--- a/json/sonic.go
+++ b/json/sonic.go
@@ -27,21 +27,27 @@ const EncoderName = "sonic"
 // work — true under the default tag exactly when sonic has routed its own API to
 // encoding/json. A const, so the choice stays free on the hot path.
 //
-// This answers a question about **speed**, not about output. Sonic's fallback
-// still honours the Config it was frozen with, so a fallback build emits the
-// same bytes as an accelerated one; only the cost changes. Anything asserting or
-// depending on byte-level behaviour must key on EncoderName, which follows the
-// build tag and therefore the config.
+// This answers a question about cost, not about output. Anything asserting or
+// depending on byte-level behaviour must key on EncoderName instead, which
+// follows the build tag and therefore the frozen Config.
+//
+// Sonic's fallback honours EscapeHTML, so the HTML-escaping difference between
+// the engines does not appear on one. It does not implement SortMapKeys or
+// ValidateString — those agree only because encoding/json sorts and substitutes
+// U+FFFD unconditionally — and its errors come from encoding/json. Output beyond
+// escaping is therefore untested rather than known identical, and cannot be
+// tested yet: sonic does not build on 32-bit at all, so no architecture reaches
+// the fallback, and the Go-version route needs a go1.27 that does not exist.
 const EngineIsStdlib = !sonicAccelerated
 
 // ActiveEngine names what is actually encoding, for logs and for labelling
 // benchmark output.
 //
-// A fallback build is neither of the two plain answers: sonic's API is still in
-// front, so the bytes are sonic's, while the standard library does the work, so
-// the speed is not. Calling it "encoding/json" would imply the kruda_stdjson
-// build, which emits different bytes; calling it "sonic" would imply the
-// accelerated speed. It gets its own name.
+// A fallback build gets its own name rather than either plain answer. Calling it
+// "encoding/json" would imply the kruda_stdjson build, whose HTML escaping
+// differs; calling it "sonic" would imply the accelerated speed. Naming it as a
+// fallback keeps a benchmark run from filing its numbers under an engine it did
+// not use.
 func ActiveEngine() string {
 	if EngineIsStdlib {
 		return "sonic (fallback: encoding/json)"

--- a/json/sonic.go
+++ b/json/sonic.go
@@ -19,8 +19,24 @@ import (
 	"github.com/bytedance/sonic"
 )
 
-// EncoderName identifies the active JSON encoder for diagnostics.
+// EncoderName names the engine this build's tag selected. It is not necessarily
+// the engine doing the work — see ActiveEngine.
 const EncoderName = "sonic"
+
+// EngineIsStdlib reports whether encoding/json ends up doing the work. Under the
+// default tag that is true exactly when sonic routes its own API to the standard
+// library, so callers choosing a code path by engine get the real answer rather
+// than the tag's. A const, so the choice stays free on the hot path.
+const EngineIsStdlib = !sonicAccelerated
+
+// ActiveEngine returns the engine actually in use: "sonic" when sonic's
+// accelerated implementation compiled, "encoding/json" when it fell back.
+func ActiveEngine() string {
+	if EngineIsStdlib {
+		return "encoding/json"
+	}
+	return "sonic"
+}
 
 // api is the Sonic configuration Kruda encodes and decodes with.
 //

--- a/json/sonic.go
+++ b/json/sonic.go
@@ -38,10 +38,14 @@ const EncoderName = "sonic"
 // beyond escaping as untested rather than known identical.
 //
 // The fallback is reachable today, not hypothetical: linux/ppc64le, s390x,
-// riscv64, mips64 and loong64 build and take it. (32-bit is a separate story —
-// sonic does not compile there at all, so 386 and arm reach neither path.) Kruda
-// does not run its tests on any of those, so the gap is a matter of coverage
-// rather than of impossibility.
+// riscv64, mips64 and loong64 build and take it. Kruda does not run its tests on
+// any of those, so the gap is coverage rather than impossibility.
+//
+// 32-bit selects this same fallback but cannot build it: sonic refuses to
+// compile there, from a deliberate guard in its own internals. On linux/arm the
+// kruda_stdjson tag works around that by dropping the sonic import. linux/386
+// cannot be built at all, for an unrelated reason — Wing's Linux engine uses
+// syscall.SYS_ACCEPT4, which Go does not define for 386 — so no JSON tag helps.
 const EngineIsStdlib = !sonicAccelerated
 
 // ActiveEngine names what is actually encoding, for logs and for labelling

--- a/json/sonic.go
+++ b/json/sonic.go
@@ -3,10 +3,14 @@
 // Package json provides a pluggable JSON engine for Kruda.
 // This file uses github.com/bytedance/sonic for SIMD-accelerated JSON processing.
 // It is compiled by default, and is selected regardless of whether CGO is
-// enabled: Sonic is pure Go plus assembly and has no cgo dependency. On
-// platforms or Go versions Sonic does not accelerate (anything other than
-// amd64/arm64), Sonic's own build constraints transparently route its API to
-// encoding/json, so this file stays correct everywhere.
+// enabled: Sonic is pure Go plus assembly and has no cgo dependency.
+//
+// Compiling this file is not the same as Sonic doing the work. Sonic carries its
+// own build constraints — amd64/arm64, and only Go versions it has validated
+// (v1.15.0 excludes go1.27 and newer) — and transparently routes its API to
+// encoding/json outside them. This file stays correct everywhere as a result, but
+// EncoderName below reports the tag's effect, not the outcome, so a build on an
+// unsupported toolchain logs json=sonic while encoding/json runs.
 package json
 
 import (

--- a/json/sonic.go
+++ b/json/sonic.go
@@ -34,10 +34,14 @@ const EncoderName = "sonic"
 // Sonic's fallback honours EscapeHTML, so the HTML-escaping difference between
 // the engines does not appear on one. It does not implement SortMapKeys or
 // ValidateString — those agree only because encoding/json sorts and substitutes
-// U+FFFD unconditionally — and its errors come from encoding/json. Output beyond
-// escaping is therefore untested rather than known identical, and cannot be
-// tested yet: sonic does not build on 32-bit at all, so no architecture reaches
-// the fallback, and the Go-version route needs a go1.27 that does not exist.
+// U+FFFD unconditionally — and its errors come from encoding/json. Treat output
+// beyond escaping as untested rather than known identical.
+//
+// The fallback is reachable today, not hypothetical: linux/ppc64le, s390x,
+// riscv64, mips64 and loong64 build and take it. (32-bit is a separate story —
+// sonic does not compile there at all, so 386 and arm reach neither path.) Kruda
+// does not run its tests on any of those, so the gap is a matter of coverage
+// rather than of impossibility.
 const EngineIsStdlib = !sonicAccelerated
 
 // ActiveEngine names what is actually encoding, for logs and for labelling

--- a/json/sonic.go
+++ b/json/sonic.go
@@ -23,17 +23,28 @@ import (
 // the engine doing the work — see ActiveEngine.
 const EncoderName = "sonic"
 
-// EngineIsStdlib reports whether encoding/json ends up doing the work. Under the
-// default tag that is true exactly when sonic routes its own API to the standard
-// library, so callers choosing a code path by engine get the real answer rather
-// than the tag's. A const, so the choice stays free on the hot path.
+// EngineIsStdlib reports whether the standard library is doing the encoding
+// work — true under the default tag exactly when sonic has routed its own API to
+// encoding/json. A const, so the choice stays free on the hot path.
+//
+// This answers a question about **speed**, not about output. Sonic's fallback
+// still honours the Config it was frozen with, so a fallback build emits the
+// same bytes as an accelerated one; only the cost changes. Anything asserting or
+// depending on byte-level behaviour must key on EncoderName, which follows the
+// build tag and therefore the config.
 const EngineIsStdlib = !sonicAccelerated
 
-// ActiveEngine returns the engine actually in use: "sonic" when sonic's
-// accelerated implementation compiled, "encoding/json" when it fell back.
+// ActiveEngine names what is actually encoding, for logs and for labelling
+// benchmark output.
+//
+// A fallback build is neither of the two plain answers: sonic's API is still in
+// front, so the bytes are sonic's, while the standard library does the work, so
+// the speed is not. Calling it "encoding/json" would imply the kruda_stdjson
+// build, which emits different bytes; calling it "sonic" would imply the
+// accelerated speed. It gets its own name.
 func ActiveEngine() string {
 	if EngineIsStdlib {
-		return "encoding/json"
+		return "sonic (fallback: encoding/json)"
 	}
 	return "sonic"
 }

--- a/json/sonic_accel.go
+++ b/json/sonic_accel.go
@@ -1,0 +1,15 @@
+//go:build !kruda_stdjson && ((amd64 && go1.17 && !go1.27) || (arm64 && go1.20 && !go1.27))
+
+package json
+
+// sonicAccelerated mirrors the build constraint sonic itself uses to decide
+// whether to compile its accelerated implementation or route its API to
+// encoding/json. Copied verbatim from sonic v1.15.0's sonic.go; its compat.go
+// carries the inverse.
+//
+// Kruda cannot ask sonic which one it got — there is no API for it — and Kruda's
+// own guard (`!kruda_stdjson`) says nothing about architecture or Go version. So
+// the constraint is mirrored here, and TestSonicConstraintMirrorIsCurrent fails
+// when the dependency moves, because a sonic release that supports a new Go
+// version makes this copy wrong in the direction that silently loses speed.
+const sonicAccelerated = true

--- a/json/sonic_noaccel.go
+++ b/json/sonic_noaccel.go
@@ -1,0 +1,8 @@
+//go:build !kruda_stdjson && !((amd64 && go1.17 && !go1.27) || (arm64 && go1.20 && !go1.27))
+
+package json
+
+// sonicAccelerated is false where sonic routes its own API to encoding/json:
+// architectures it has no assembly for, and Go versions it has not validated
+// (sonic v1.15.0 excludes go1.27 and newer). See sonic_accel.go.
+const sonicAccelerated = false

--- a/json/std.go
+++ b/json/std.go
@@ -12,6 +12,12 @@ import (
 	stdjson "encoding/json"
 )
 
+// EngineIsStdlib is always true here: this file exists to use encoding/json.
+const EngineIsStdlib = true
+
+// ActiveEngine returns the engine actually in use.
+func ActiveEngine() string { return "encoding/json" }
+
 // EncoderName identifies the active JSON encoder for diagnostics.
 const EncoderName = "encoding/json"
 

--- a/kruda.go
+++ b/kruda.go
@@ -306,7 +306,7 @@ func (app *App) Listen(addr string) error {
 	// Report the active JSON engine: it is chosen at build time by the
 	// kruda_stdjson tag, so this is the only way to confirm from a running
 	// binary which one a build actually got.
-	app.config.Logger.Info("listening", "addr", addr, "json", krudajson.EncoderName)
+	app.config.Logger.Info("listening", "addr", addr, "json", krudajson.ActiveEngine())
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)

--- a/wing_preset_internal_test.go
+++ b/wing_preset_internal_test.go
@@ -374,8 +374,12 @@ func TestWingSendStaticJSONUsesJSONResponder(t *testing.T) {
 }
 
 func TestPresetJSONSerializeUsesStreamResponderWithStdJSON(t *testing.T) {
-	if krudajson.EncoderName != "encoding/json" {
-		t.Skip("stream responder is used only when the active encoder avoids an intermediate marshal allocation")
+	// Gate on the same signal the production path uses. Keying on EncoderName
+	// would skip this on builds where the tag names sonic but sonic has fallen
+	// back to encoding/json — which is precisely where the stream responder is
+	// now selected.
+	if !krudajson.EngineIsStdlib {
+		t.Skip("stream responder is used only when encoding/json is the active engine")
 	}
 
 	app := New(Wing(), WithJSONStreamEncoder(func(buf *bytes.Buffer, v any) error {


### PR DESCRIPTION
Pre-release docs audit for the unreleased JSON-engine work. Three published pages
tie the engine to CGO. **One claim was never true; the rest stop being true when
the engine change ships.**

## Never true

`docs/troubleshooting.md` had a `cgo: C compiler not found` entry stating:

> Sonic JSON requires CGO for SIMD optimizations.

with instructions to install a C compiler. **Sonic is pure Go plus assembly and
cannot produce that error.** A reader who hit it from a database driver or from
`-race` was sent to fix the wrong thing, and a reader who believed the claim had
a reason to avoid the default engine that never existed.

## True by accident, wrong after the release

`docs/faq.md` and `docs/guide/performance.md` said CGO-enabled builds get Sonic
and `CGO_ENABLED=0` gets `encoding/json`. That *was* the behaviour — because
`json/sonic.go` carried a `cgo` build constraint — and that is precisely the bug
fixed in `[Unreleased]`. After it ships, both pages are wrong.

Both now say the `kruda_stdjson` tag is the only selector, and name the version
the behaviour changed in, so a reader on v1.6.2 is not misled either.

## performance.md's JSON section had no numbers

It said only "benchmark with your payloads". It now answers the question people
actually ask, with the measured deltas:

| payload | delta |
|---|---|
| encode ~30 B (the TFB `/json` shape) | no measurable change |
| encode ~8 KB | **+23% req/s** |
| decode ~8 KB request body | **+160% req/s** |

Plus why small responses don't move (at ~700k req/s a worker spends ~11 µs per
request; encoding 30 bytes is a rounding error against the kernel's TCP cost) and
the cold-start cost on the other side of the trade (+3 ms, +7 MB RSS per process).

## Also

`bench/reproducible/README.md` tied its default build tag to "CGO availability"
for the same reason — corrected, with a note on why the old framing existed.

## Checked and left alone

- **Validation opt-in** — already correct in `guide/handlers.md` and
  `api/handler.md`; `auto-crud.md`, `api/resource.md` and `getting-started.md`
  show no `validate:` tags, so there is nothing to gate there.
- **`contrib.md`** uses unpinned `go get`, so it stays correct across the
  `contrib/observability` bump.
- **`docs/superpowers/plans|specs`** carry old version numbers by design — they
  are dated design records, not live documentation. Not touched.

## Verification

`npm run build` in `docs/` succeeds; `scripts/check-docs.sh` passes.

## Noticed, not fixed here

`docs/faq.md` and `docs/troubleshooting.md` are **not in the sidebar nav** — two
pages of user-facing troubleshooting reachable only by direct URL or search. That
is a navigation question rather than a correctness one, so it is left for a
separate call.