### PR TITLE
docs: warn that CGO_ENABLED=0 builds get different JSON bytes, and fix the stale package doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Upgrade note — `CGO_ENABLED=0` builds: JSON response bytes change
+
+If you build with `CGO_ENABLED=0`, this release changes which JSON engine you get
+and therefore what your responses look like on the wire. Nothing else in this
+release does that, and it is easy to miss because no build flag of yours changed.
+
+Before this release a `CGO_ENABLED=0` build silently got `encoding/json`, which
+escapes `<`, `>` and `&` in strings. It now gets Sonic, which is configured with
+`EscapeHTML` off. Measured on the same input:
+
+| string in a response | before | after |
+|---|---|---|
+| `if x < 10 && y > 3` | `"if x \u003c 10 \u0026\u0026 y \u003e 3"` | `"if x < 10 && y > 3"` |
+| `<p>Chapter 1</p>` | `"\u003cp\u003eChapter 1\u003c/p\u003e"` | `"<p>Chapter 1</p>"` |
+| `{"title": "A & B"}` | `{"title":"A \u0026 B"}` | `{"title":"A & B"}` |
+
+Enabling CGO does **not** avoid this — CGO no longer takes part in choosing the
+engine, which is the point of the fix below. `-tags kruda_stdjson` is the only way
+to keep the previous behaviour.
+
+What to check before upgrading:
+
+- **Anything that renders API strings as HTML.** Escaped output was masking `<`
+  and `&` for you. Text nodes in React, Vue and similar escape on their own and
+  are unaffected, but `innerHTML`, `dangerouslySetInnerHTML` and `v-html` fed from
+  a response are not. Responses are served as `application/json`, which no browser
+  executes, so this is about your rendering, not the transport.
+- **Anything keyed on response bytes** — `contrib/etag`, response caches, snapshot
+  tests — will miss once as bodies change.
+
+If you would rather keep the escaping and the speed, `kruda.WithJSONEncoder` can
+supply a Sonic config with `EscapeHTML` on, at roughly 41% on responses containing
+strings. Note that a custom encoder also disables the streaming response path.
+
 ### Security
 
 - `contrib/observability` now requires `google.golang.org/grpc` v1.82.1, clearing

--- a/json/sonic.go
+++ b/json/sonic.go
@@ -8,9 +8,13 @@
 // Compiling this file is not the same as Sonic doing the work. Sonic carries its
 // own build constraints — amd64/arm64, and only Go versions it has validated
 // (v1.15.0 excludes go1.27 and newer) — and transparently routes its API to
-// encoding/json outside them. This file stays correct everywhere as a result, but
-// EncoderName below reports the tag's effect, not the outcome, so a build on an
-// unsupported toolchain logs json=sonic while encoding/json runs.
+// encoding/json outside them, so this file stays correct everywhere.
+//
+// Two exported names follow from that split, and confusing them is what this
+// package's callers have to avoid. EncoderName is the engine the build tag
+// selected, which fixes the frozen configuration and therefore the bytes.
+// ActiveEngine and EngineIsStdlib describe what is actually encoding, which fixes
+// the cost. Assert output against the first; choose a code path by the second.
 package json
 
 import (


### PR DESCRIPTION
Found by the focused review of the new exported surface, done before a tag can
freeze it.

`json`'s **package doc** — the first thing pkg.go.dev renders — still said:

> EncoderName below reports the tag's effect, not the outcome, so a build on an
> unsupported toolchain logs `json=sonic` while `encoding/json` runs.

True before #185 moved the startup line to `ActiveEngine()`; false after it. The
symbol docs were updated in that PR and the package doc above them was not.

It now explains the distinction callers have to get right, since two exported
names for adjacent ideas is what produced the original defect in the first place:

- `EncoderName` — the engine the **build tag** selected, which fixes the frozen
  config and therefore the **bytes**. Assert output against this.
- `ActiveEngine` / `EngineIsStdlib` — what is **actually encoding**, which fixes
  the **cost**. Choose a code path by these.

## Verification

`scripts/check-godoc.sh` passes, `go test -race` passes under both engines,
`gofmt` clean.

## Note on the review that found it

The rest of the new surface came out clean, with one deliberate trade-off worth
recording rather than changing: `EngineIsStdlib` is an exported **const**, so the
answer is fixed at compile time and the response-path choice stays free on the hot
path. If Sonic ever exposes a runtime way to report acceleration, turning that
const into a function would be a breaking change. That is the intended trade —
the hot path is the reason the const exists — but it should be a known one before
v1.7.0 tags it.