### PR TITLE
fix(examples): refresh observability's go.sum after the grpc bump

### DIFF
--- a/examples/observability/go.mod
+++ b/examples/observability/go.mod
@@ -67,6 +67,6 @@ require (
 	golang.org/x/text v0.37.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )

--- a/examples/observability/go.sum
+++ b/examples/observability/go.sum
@@ -139,8 +139,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
`scripts/pre-release.sh` fails on `examples/observability`:

```
== examples build ==
 ✗ example failed to build: examples/observability/
```

It replaces `contrib/observability` with the local copy, so the grpc bump in #184
left its own `go.mod`/`go.sum` a version behind. Confirmed as a regression from
this release, not pre-existing: building it at `4154427^` succeeds.

Worth noting the gate caught what CI could not — `Tests` does not build examples,
so main was green on every check while the release script was red.

This is the second module #184 left stale (`bench/reproducible/kruda` was the
first, fixed in #183's follow-up). So rather than fix the one that failed, every
module with a local `replace` was checked:

| module | builds |
|---|---|
| `bench`, `bench/reproducible/{coldstart/app,kruda,soak}` | ✅ |
| `examples/{ratelimit,session,websocket}` | ✅ |
| `examples/observability` | ❌ → fixed here |
| `bench/transport-compare` | ❌ **pre-existing** — also red at `4154427^`, and `go mod tidy` does not resolve it. Outside the gate (it only walks `examples/*/`), so it is left for its own change rather than folded in here. |