### PR TITLE
Prepare v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.7.0] — 2026-07-30
+
 ### Upgrade note — `CGO_ENABLED=0` builds: JSON response bytes change
 
 If you build with `CGO_ENABLED=0`, this release changes which JSON engine you get


### PR DESCRIPTION
Changelog only: `[Unreleased]` becomes `[1.7.0] — 2026-07-30`.

Per `docs/release-process.md` the tag must sit on a `main` commit with successful
`Tests` and `Benchmark` runs, so the release-prep commit goes through a PR like
anything else.

## Gate status

`scripts/pre-release.sh` passes on `3e220d5` — the run before it failed on
`examples/observability`, fixed in #188.

Pre-release checklist:

- No `replace` directives in `cmd/kruda` or any `contrib/*`
- Nested modules changed this release are already tagged and unchanged since:
  `contrib/observability/v1.0.1` (grpc / GO-2026-6061) and `cmd/kruda/v1.0.0`,
  both 0 commits behind
- Public API diff is additions only — `json.EngineIsStdlib`, `json.ActiveEngine`
- 20 changelog entries, all with in-repo evidence

## Why a minor

Response bytes change for `CGO_ENABLED=0` builds, which now get Sonic instead of
`encoding/json` — the changelog opens with an upgrade note carrying the measured
before/after, since escaping differs and nothing in the user's build changed.
`SortMapKeys` and `ValidateString` also alter output for some inputs.