### PR TITLE
Prepare v1.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to Kruda are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [1.7.1] — 2026-08-03
 
 ### Breaking
 


### PR DESCRIPTION
Dates the `[Unreleased]` section as `1.7.1` so the tag has a CHANGELOG
entry to point at. No code changes.

`./scripts/pre-release.sh` passes 21/21, including the golangci-lint step
added in #191.

## What v1.7.1 contains

`validate` tags are enforced without configuration. An application
carrying them may start rejecting requests it previously accepted, with
422 and a per-field error body; `kruda.New(kruda.WithoutValidation())` is
the opt-out. Two prerequisites shipped with it: an unknown rule is skipped
with a startup warning instead of panicking at route registration, and the
`omitempty` and `dive` modifiers are implemented, without which tags
carried over from `go-playground/validator` would have made optional
fields behave as required and left one collection field rejecting every
input.

This is a patch release that changes behaviour. Version numbers here
signal how much attention a release needs rather than a semver guarantee
— see `docs/decisions/0002-breaking-changes-after-adoption.md`. The
CHANGELOG entry says so and lists what to grep for before upgrading.