### PR TITLE
Guard shipped docs against validation rules that do not exist

### DIFF
--- a/examples/typed-handlers/main.go
+++ b/examples/typed-handlers/main.go
@@ -105,7 +105,7 @@ func NewStore() *Store {
 //   - `param:"name"` → URL path parameter
 //   - `query:"name"` → query string parameter
 //   - `json:"name"`  → JSON request body field
-//   - `validate:"rules"` → validation rules
+//   - `validate:"required,min=2"` → validation rules, comma-separated
 // ---------------------------------------------------------------------------
 
 // GetProductInput binds the :id path parameter.

--- a/validation.go
+++ b/validation.go
@@ -104,6 +104,13 @@ type ruleEntry struct {
 	fn    ValidatorFunc // pre-looked-up function
 }
 
+// validationModifiers are the tag words that carry no ValidatorFunc and instead
+// change how the rules around them apply. They are handled structurally by
+// buildValidators, so they never appear in the rules map — this is the one place
+// that names them, so the parser, the unknown-rule warning and the documentation
+// guard cannot drift apart.
+var validationModifiers = [...]string{"omitempty", "dive"}
+
 // warnedUnknownRules keeps the warning to one line per rule per field, so a type
 // registered on many routes does not repeat it.
 var warnedUnknownRules sync.Map
@@ -122,7 +129,7 @@ func warnUnknownRule(v *Validator, rule, typeName, fieldName string) {
 	slog.Warn("kruda: unknown validation rule in a validate tag — that rule is ignored, the field's other rules still apply",
 		"rule", rule, "type", typeName, "field", fieldName,
 		"available", strings.Join(v.RuleNames(), ","),
-		"modifiers", "omitempty,dive")
+		"modifiers", strings.Join(validationModifiers[:], ","))
 }
 
 // RuleNames lists the validation rules this Validator recognises, sorted —
@@ -199,6 +206,8 @@ func buildValidators[T any](v *Validator) []fieldValidator {
 			// omitempty makes an optional field behave as required; dropping
 			// dive runs an element rule against the container, which no slice
 			// can satisfy.
+			// The cases here are validationModifiers; a test pins the two lists
+			// together so a modifier cannot be dropped while docs still teach it.
 			switch ruleName {
 			case "omitempty":
 				fv.omitEmpty = true

--- a/validation_doc_test.go
+++ b/validation_doc_test.go
@@ -51,7 +51,13 @@ func TestDocumentedRulesExist(t *testing.T) {
 		// reports registered rules alongside the built-in ones — so a guard that
 		// only knew builtinRules would reject a valid page and blame the package
 		// for not implementing a rule the page itself supplies.
-		local := registeredRuleNames(body)
+		//
+		// The exception has to respect the ordering contract, though: validators
+		// are compiled at route registration, so a rule registered afterwards
+		// never takes effect (see buildTypedHandler). Accepting such a file
+		// would bless an example that silently does not validate — the same
+		// failure this guard exists to catch, arriving from the other side.
+		local := registeredRuleNames(body, strings.HasSuffix(f, ".go"))
 
 		for _, m := range docValidateTagRe.FindAllStringSubmatch(body, -1) {
 			for _, rule := range strings.Split(m[1], ",") {
@@ -79,13 +85,60 @@ func TestDocumentedRulesExist(t *testing.T) {
 // form (v.Register("adult", ...)) or through the app (app.Validator().Register).
 var registerCallRe = regexp.MustCompile(`\.Register\(\s*"([a-zA-Z_][a-zA-Z0-9_]*)"`)
 
+// routeRegistrationRe matches the calls that compile validators. A custom rule
+// added after one of these does not apply to it.
+var routeRegistrationRe = regexp.MustCompile(`kruda\.(Get|Post|Put|Patch|Delete|Resource)\[`)
+
 // registeredRuleNames returns the rule names a document registers for itself.
-func registeredRuleNames(body string) map[string]bool {
+//
+// ordered applies the "before route registration" half of the contract, and is
+// set only for Go files: there, text order is execution order, so a Register
+// call below the first route is provably too late. Markdown presents snippets
+// in teaching order rather than execution order — a guide may well show the
+// route first and the registration afterwards while the prose sequences them
+// correctly — so imposing source order there would fail correct pages.
+func registeredRuleNames(body string, ordered bool) map[string]bool {
+	limit := len(body)
+	if ordered {
+		if loc := routeRegistrationRe.FindStringIndex(body); loc != nil {
+			limit = loc[0]
+		}
+	}
 	out := map[string]bool{}
-	for _, m := range registerCallRe.FindAllStringSubmatch(body, -1) {
-		out[m[1]] = true
+	for _, m := range registerCallRe.FindAllStringSubmatchIndex(body, -1) {
+		if m[0] >= limit {
+			continue
+		}
+		out[body[m[2]:m[3]]] = true
 	}
 	return out
+}
+
+// TestRegisteredRuleNamesRespectsOrdering pins the half of the exception that is
+// easy to lose: a rule registered after route registration never applies, so
+// accepting it would let the guard bless an example that silently does not
+// validate.
+func TestRegisteredRuleNamesRespectsOrdering(t *testing.T) {
+	const route = "kruda.Post[In, Out](app, \"/x\", h)"
+	const reg = "v.Register(\"adult\", f)"
+
+	cases := []struct {
+		name    string
+		body    string
+		ordered bool
+		want    bool
+	}{
+		{"go, registered before the route", reg + "\n" + route, true, true},
+		{"go, registered after the route", route + "\n" + reg, true, false},
+		{"go, no route in the file", reg, true, true},
+		// Markdown sequences snippets for teaching, not execution.
+		{"markdown, order not meaningful", route + "\n" + reg, false, true},
+	}
+	for _, c := range cases {
+		if got := registeredRuleNames(c.body, c.ordered)["adult"]; got != c.want {
+			t.Errorf("%s: accepted=%v, want %v", c.name, got, c.want)
+		}
+	}
 }
 
 // TestValidationModifiersAreHandled pins validationModifiers to the parser. If a

--- a/validation_doc_test.go
+++ b/validation_doc_test.go
@@ -87,7 +87,15 @@ var registerCallRe = regexp.MustCompile(`\.Register\(\s*"([a-zA-Z_][a-zA-Z0-9_]*
 
 // routeRegistrationRe matches the calls that compile validators. A custom rule
 // added after one of these does not apply to it.
-var routeRegistrationRe = regexp.MustCompile(`kruda\.(Get|Post|Put|Patch|Delete|Resource)\[`)
+//
+// The alternation covers the Group* and *X variants because they reach the same
+// place — GetX delegates to Get, GroupResource to registerResource — and an
+// example written against a Group would otherwise slip the ordering check
+// entirely. The kruda. qualifier is optional because doc comments inside this
+// package call these unqualified, and an importer may alias the package.
+// TestRouteRegistrationMatcherCoversEveryEntryPoint derives the real list from
+// the source so this pattern cannot fall behind a newly added entry point.
+var routeRegistrationRe = regexp.MustCompile(`(?:kruda\.)?(?:Group)?(?:Get|Post|Put|Patch|Delete|Resource)X?\[`)
 
 // registeredRuleNames returns the rule names a document registers for itself.
 //
@@ -139,6 +147,40 @@ func TestRegisteredRuleNamesRespectsOrdering(t *testing.T) {
 			t.Errorf("%s: accepted=%v, want %v", c.name, got, c.want)
 		}
 	}
+}
+
+// TestRouteRegistrationMatcherCoversEveryEntryPoint derives the set of exported
+// generic route registrars from handler.go and resource.go and requires the
+// ordering matcher to recognise each one.
+//
+// Hand-written, the pattern had already fallen behind: it listed five names and
+// missed eleven, so an example built on a Group or on the *X shorthand escaped
+// the ordering check silently. Reading the list from source means adding an
+// entry point fails this test instead.
+func TestRouteRegistrationMatcherCoversEveryEntryPoint(t *testing.T) {
+	declRe := regexp.MustCompile(`(?m)^func ([A-Z][A-Za-z]*)\[`)
+	var names []string
+	for _, f := range []string{"handler.go", "resource.go"} {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		for _, m := range declRe.FindAllStringSubmatch(string(b), -1) {
+			names = append(names, m[1])
+		}
+	}
+	if len(names) < 10 {
+		t.Fatalf("found only %d generic route registrars; the discovery pattern is stale", len(names))
+	}
+	for _, n := range names {
+		for _, call := range []string{n + "[", "kruda." + n + "["} {
+			if !routeRegistrationRe.MatchString(call) {
+				t.Errorf("routeRegistrationRe does not match %q — an example registering a custom "+
+					"rule after this call would escape the ordering check", call)
+			}
+		}
+	}
+	t.Logf("covered %d route registrars", len(names))
 }
 
 // TestValidationModifiersAreHandled pins validationModifiers to the parser. If a

--- a/validation_doc_test.go
+++ b/validation_doc_test.go
@@ -44,17 +44,28 @@ func TestDocumentedRulesExist(t *testing.T) {
 		if err != nil {
 			t.Fatalf("read %s: %v", f, err)
 		}
-		for _, m := range docValidateTagRe.FindAllStringSubmatch(string(b), -1) {
+		body := string(b)
+
+		// A document that registers a custom rule may then use it, and that
+		// documentation is correct. Register is a supported feature — RuleNames
+		// reports registered rules alongside the built-in ones — so a guard that
+		// only knew builtinRules would reject a valid page and blame the package
+		// for not implementing a rule the page itself supplies.
+		local := registeredRuleNames(body)
+
+		for _, m := range docValidateTagRe.FindAllStringSubmatch(body, -1) {
 			for _, rule := range strings.Split(m[1], ",") {
 				name, _, _ := strings.Cut(strings.TrimSpace(rule), "=")
 				if name == "" {
 					continue
 				}
 				checked++
-				if !known[name] {
-					t.Errorf("%s documents validate rule %q, which this package does not implement — "+
-						"a reader copying that tag gets a field that is never checked", f, name)
+				if known[name] || local[name] {
+					continue
 				}
+				t.Errorf("%s documents validate rule %q, which this package does not implement and "+
+					"the file does not Register — a reader copying that tag gets a field that is "+
+					"never checked", f, name)
 			}
 		}
 	}
@@ -62,6 +73,19 @@ func TestDocumentedRulesExist(t *testing.T) {
 		t.Fatal("matched files but extracted no rule names; the tag pattern is stale")
 	}
 	t.Logf("verified %d documented rule use(s)", checked)
+}
+
+// registerCallRe matches a custom rule being registered, in either the direct
+// form (v.Register("adult", ...)) or through the app (app.Validator().Register).
+var registerCallRe = regexp.MustCompile(`\.Register\(\s*"([a-zA-Z_][a-zA-Z0-9_]*)"`)
+
+// registeredRuleNames returns the rule names a document registers for itself.
+func registeredRuleNames(body string) map[string]bool {
+	out := map[string]bool{}
+	for _, m := range registerCallRe.FindAllStringSubmatch(body, -1) {
+		out[m[1]] = true
+	}
+	return out
 }
 
 // TestValidationModifiersAreHandled pins validationModifiers to the parser. If a

--- a/validation_doc_test.go
+++ b/validation_doc_test.go
@@ -1,0 +1,81 @@
+package kruda
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+var docValidateTagRe = regexp.MustCompile(`validate:\\?"([^"\\]+)`)
+
+// TestDocumentedRulesExist checks every `validate` tag in shipped documentation
+// against the rules this package actually implements.
+//
+// cmd/kruda has the equivalent guard for the MCP server's embedded docs, and it
+// caught real defects. Nothing covered the site documentation, README or doc
+// comments, which is the larger surface: a reader copies a tag out of the guide,
+// the rule does not exist, and the field silently goes unenforced — the failure
+// mode validation-by-default was supposed to end.
+//
+// The check runs against the live rule set rather than a hardcoded list, so
+// adding or removing a rule cannot leave the guard asserting yesterday's truth.
+func TestDocumentedRulesExist(t *testing.T) {
+	known := make(map[string]bool, len(builtinRules()))
+	for name := range builtinRules() {
+		known[name] = true
+	}
+	// Modifiers are legal in a tag but carry no ValidatorFunc, so they are
+	// absent from the rules map by design. Without them here the guard would
+	// reject correct documentation.
+	for _, mod := range validationModifiers {
+		known[mod] = true
+	}
+
+	files := shippedFilesMentioning(t, `validate:"`)
+	if len(files) == 0 {
+		t.Fatal(`found no shipped file containing validate:" — the guard is scanning the wrong tree`)
+	}
+	t.Logf("checking %d shipped file(s)", len(files))
+
+	checked := 0
+	for _, f := range files {
+		b, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		for _, m := range docValidateTagRe.FindAllStringSubmatch(string(b), -1) {
+			for _, rule := range strings.Split(m[1], ",") {
+				name, _, _ := strings.Cut(strings.TrimSpace(rule), "=")
+				if name == "" {
+					continue
+				}
+				checked++
+				if !known[name] {
+					t.Errorf("%s documents validate rule %q, which this package does not implement — "+
+						"a reader copying that tag gets a field that is never checked", f, name)
+				}
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("matched files but extracted no rule names; the tag pattern is stale")
+	}
+	t.Logf("verified %d documented rule use(s)", checked)
+}
+
+// TestValidationModifiersAreHandled pins validationModifiers to the parser. If a
+// modifier is dropped from buildValidators, the doc guard above would go on
+// accepting it as a legal tag word and documentation would keep teaching a tag
+// that no longer does anything.
+func TestValidationModifiersAreHandled(t *testing.T) {
+	src, err := os.ReadFile("validation.go")
+	if err != nil {
+		t.Fatalf("read validation.go: %v", err)
+	}
+	for _, mod := range validationModifiers {
+		if !regexp.MustCompile(`(?m)^\s*case "` + mod + `":`).Match(src) {
+			t.Errorf("validation.go no longer handles the %q modifier; validationModifiers is stale", mod)
+		}
+	}
+}


### PR DESCRIPTION
`cmd/kruda` already checks the MCP server's embedded docs this way and it
caught real defects. Nothing covered the site guide, the API pages, the
README or doc comments — the larger surface, and the one a human reads. A
reader copies a tag out of the guide, the rule does not exist, the field
silently goes unenforced: exactly the failure validation-by-default was
meant to end.

The guard reads the rule set from `builtinRules()` rather than a list, so
adding or removing a rule cannot leave it asserting yesterday's truth, and
it reuses `shippedFilesMentioning` so it scans what git actually ships
instead of a hardcoded path list.

## Modifiers needed a single home

`omitempty` and `dive` are legal tag words but carry no `ValidatorFunc`, so
they are absent from the rules map by design and the guard would have
rejected correct documentation. They are now named once, in
`validationModifiers`, which the parser's switch, the unknown-rule warning
and this guard all read — the warning had been carrying its own hardcoded
copy since v1.7.1. A second test pins that list to the switch, so dropping
a modifier fails loudly instead of leaving the docs teaching a dead tag.

## What its first run found

`examples/typed-handlers` documented the tag legend as `validate:"rules"`
while every neighbouring entry used a realistic value — `param:"name"`,
`json:"name"`. Changed to `validate:"required,min=2"`, which removes the
false positive by making the example better rather than by weakening the
check.

## Verified

By reintroducing the defect: injecting `hexcolor` into the handlers guide
fails the guard with the file and the rule named. 14 shipped files and 104
documented rule uses checked. Core and cmd/kruda suites, `golangci-lint`
and gofmt all clean.