### PR TITLE
Harden transport security and require Go 1.25.13

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -24,7 +24,7 @@ What actually happened. Include error messages or logs if applicable.
 
 ## Environment
 
-- **Go version**: (e.g. 1.25.11)
+- **Go version**: (e.g. 1.25.13)
 - **Kruda version**: (e.g. v1.0.0)
 - **OS**: (e.g. Linux amd64, macOS arm64, Windows amd64)
 - **Transport**: (e.g. Wing, fasthttp, net/http)

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install benchstat
         if: github.event_name == 'pull_request'
-        run: go install golang.org/x/perf/cmd/benchstat@latest
+        run: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260813145340-fd4a688df892
 
       - name: Run main benchmarks
         if: github.event_name == 'pull_request'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25.11'
+          go-version: '1.25.13'
 
       - name: Install benchstat
         if: github.event_name == 'pull_request'

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: '1.25.13'
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version: '1.25.13'
           
       - name: Run security scan (all modules)
         run: ./scripts/govulncheck-modules.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 # CI Test Pipeline — Kruda Framework
 # Runs tests, vet, lint, and coverage on every push/PR
-# Matrix: Go 1.25.11 + stable × {Linux, macOS, Windows}
+# Matrix: Go 1.25.13 + stable × {Linux, macOS, Windows}
 
 name: Tests
 
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ['1.25.11', 'stable']
+        go-version: ['1.25.13', 'stable']
         os: [ubuntu-latest, macos-latest, windows-2025]
 
     steps:
@@ -35,13 +35,13 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Install revive
-        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25.11'
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25.13'
         run: |
           go install github.com/mgechev/revive@v1.12.0
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Check documentation
-        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25.11'
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25.13'
         run: |
           scripts/check-docs.sh
           scripts/check-godoc.sh
@@ -50,7 +50,7 @@ jobs:
         run: go vet -tags kruda_stdjson ./...
 
       - name: Lint (golangci-lint)
-        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25.11'
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25.13'
         uses: golangci/golangci-lint-action@v9
         with:
           args: --build-tags kruda_stdjson
@@ -66,7 +66,7 @@ jobs:
           go test -v -race -tags kruda_stdjson $COVER_FLAG ./...
 
       - name: Run default JSON engine tests
-        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25.11'
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25.13'
         shell: bash
         run: CGO_ENABLED=1 go test -race ./...
 
@@ -76,7 +76,7 @@ jobs:
       # amd64 and arm64, so nothing else covers that path — this at least keeps it
       # compiling. Build-only: there is no runner for these.
       - name: Build the Sonic-fallback architectures
-        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25.11'
+        if: matrix.os == 'ubuntu-latest' && matrix.go-version == '1.25.13'
         shell: bash
         run: |
           for arch in ppc64le s390x riscv64; do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 Kruda is a high-performance Go web framework that combines speed with type-safety through Go generics.
 
 - **Module**: `github.com/go-kruda/kruda`
-- **Go version**: 1.25+
+- **Go version**: 1.25.13+ or 1.26.4+
 - **License**: MIT
 
 ## Architecture

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Thank you for your interest in contributing to Kruda!
 
 ## Requirements
 
-- **Go 1.25.11+ or Go 1.26.4+** required
+- **Go 1.25.13+ or Go 1.26.4+** required
 - All tests must pass: `go test ./...`
 - Code must be formatted: `gofmt -s -w .`
 - Code must pass vet: `go vet ./...`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Fast by default, type-safe by design.
 
-[![Go Version](https://img.shields.io/badge/Go-1.25.11+-00ADD8?logo=go)](https://go.dev)
+[![Go Version](https://img.shields.io/badge/Go-1.25.13+-00ADD8?logo=go)](https://go.dev)
 [![Go Reference](https://pkg.go.dev/badge/github.com/go-kruda/kruda.svg)](https://pkg.go.dev/github.com/go-kruda/kruda)
 [![CI](https://github.com/go-kruda/kruda/actions/workflows/test.yml/badge.svg)](https://github.com/go-kruda/kruda/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/go-kruda/kruda/graph/badge.svg?token=9HIGH8L2Q7)](https://codecov.io/gh/go-kruda/kruda)
@@ -276,7 +276,7 @@ Wing's runtime implementation lives in the core module (`wing_*.go` at the repo 
 
 Kruda core has minimal external dependencies (Sonic JSON, fasthttp). Use `kruda_stdjson` build tag to switch to stdlib JSON. Upgrade to the latest Go patch release for security fixes.
 
-**Minimum Go patch release for zero known standard-library vulnerabilities:** go1.25.11+ or go1.26.4+
+**Minimum Go patch release for zero known standard-library vulnerabilities:** go1.25.13+ or go1.26.4+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,9 @@ Wing's runtime implementation lives in the core module (`wing_*.go` at the repo 
 
 Kruda core has minimal external dependencies (Sonic JSON, fasthttp). Use `kruda_stdjson` build tag to switch to stdlib JSON. Upgrade to the latest Go patch release for security fixes.
 
-**Minimum Go patch release for zero known standard-library vulnerabilities:** go1.25.13+ or go1.26.4+
+**Tested security baseline (2026-08-29):** the repository's all-module scan has
+zero reachable `govulncheck` findings with go1.25.13+ or go1.26.4+. This does
+not mean the dependency graph contains no non-reachable advisories.
 
 ## Contributing
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -82,7 +82,7 @@ go1.25 test -bench=BenchmarkKruda -benchmem -count=10 -tags kruda_stdjson ./... 
 # Run with Go 1.26
 go1.26 test -bench=BenchmarkKruda -benchmem -count=10 -tags kruda_stdjson ./... > go126.txt
 
-# Compare (requires benchstat: go install golang.org/x/perf/cmd/benchstat@latest)
+# Compare (requires benchstat: go install golang.org/x/perf/cmd/benchstat@v0.0.0-20260813145340-fd4a688df892)
 benchstat go125.txt go126.txt
 ```
 

--- a/bench/go.mod
+++ b/bench/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda/bench
 
-go 1.25.10
+go 1.25.13
 
 replace github.com/go-kruda/kruda => ../
 

--- a/bench/reproducible/coldstart/app/go.mod
+++ b/bench/reproducible/coldstart/app/go.mod
@@ -1,6 +1,6 @@
 module coldstart-app
 
-go 1.25.11
+go 1.25.13
 
 replace github.com/go-kruda/kruda => ../../../..
 

--- a/bench/reproducible/coldstart/driver/go.mod
+++ b/bench/reproducible/coldstart/driver/go.mod
@@ -1,3 +1,3 @@
 module coldstart-driver
 
-go 1.25.11
+go 1.25.13

--- a/bench/reproducible/fiber/go.mod
+++ b/bench/reproducible/fiber/go.mod
@@ -1,6 +1,6 @@
 module fiber-bench
 
-go 1.25.10
+go 1.25.13
 
 require github.com/gofiber/fiber/v2 v2.52.13
 

--- a/bench/reproducible/jsonthroughput/app/go.mod
+++ b/bench/reproducible/jsonthroughput/app/go.mod
@@ -1,3 +1,3 @@
 module jsonthroughput-app
 
-go 1.25.11
+go 1.25.13

--- a/bench/reproducible/kruda/go.mod
+++ b/bench/reproducible/kruda/go.mod
@@ -1,6 +1,6 @@
 module bench-kruda
 
-go 1.25.11
+go 1.25.13
 
 require (
 	github.com/go-kruda/kruda v1.4.0

--- a/bench/reproducible/soak/go.mod
+++ b/bench/reproducible/soak/go.mod
@@ -1,6 +1,6 @@
 module kruda-soak
 
-go 1.25.11
+go 1.25.13
 
 require github.com/go-kruda/kruda v1.5.0
 

--- a/cmd/kruda/cmd_validate.go
+++ b/cmd/kruda/cmd_validate.go
@@ -19,7 +19,7 @@ var validateCmd = &cobra.Command{
 	Long: `Check Go version compatibility, required dependencies, and project setup.
 
 Validates:
-  • Go version is 1.25.11+ or 1.26.4+
+  • Go version is 1.25.13+ or 1.26.4+
   • go.mod exists and contains the kruda dependency
   • Project structure is correct
 
@@ -103,7 +103,7 @@ func checkGoVersion() validationResult {
 		return validationResult{
 			name:    "Go Version",
 			passed:  false,
-			message: fmt.Sprintf("Go %d.%d.%d found, but Kruda requires Go 1.25.11+ or 1.26.4+", major, minor, patch),
+			message: fmt.Sprintf("Go %d.%d.%d found, but Kruda requires Go 1.25.13+ or 1.26.4+", major, minor, patch),
 			suggest: "Upgrade Go: https://go.dev/dl/",
 		}
 	}
@@ -141,7 +141,7 @@ func meetsMinimumGoVersion(major, minor, patch int) bool {
 	}
 	switch minor {
 	case 25:
-		return patch >= 11
+		return patch >= 13
 	case 26:
 		return patch >= 4
 	default:

--- a/cmd/kruda/cmd_validate_test.go
+++ b/cmd/kruda/cmd_validate_test.go
@@ -42,8 +42,8 @@ func TestParseGoVersion(t *testing.T) {
 		},
 		{
 			name:      "current secure baseline",
-			input:     "go version go1.25.11 linux/amd64",
-			wantMajor: 1, wantMinor: 25, wantPatch: 11, wantOK: true,
+			input:     "go version go1.25.13 linux/amd64",
+			wantMajor: 1, wantMinor: 25, wantPatch: 13, wantOK: true,
 		},
 		{
 			name:      "invalid string",
@@ -88,8 +88,8 @@ func TestMeetsMinimumGoVersion(t *testing.T) {
 		want                bool
 	}{
 		{name: "below minor", major: 1, minor: 24, patch: 99, want: false},
-		{name: "below patch", major: 1, minor: 25, patch: 10, want: false},
-		{name: "minimum patch", major: 1, minor: 25, patch: 11, want: true},
+		{name: "below patch", major: 1, minor: 25, patch: 12, want: false},
+		{name: "minimum patch", major: 1, minor: 25, patch: 13, want: true},
 		{name: "newer minor below secure patch", major: 1, minor: 26, patch: 3, want: false},
 		{name: "newer minor secure patch", major: 1, minor: 26, patch: 4, want: true},
 		{name: "future minor", major: 1, minor: 27, patch: 0, want: true},

--- a/cmd/kruda/go.mod
+++ b/cmd/kruda/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda/cmd/kruda
 
-go 1.25.11
+go 1.25.13
 
 require github.com/spf13/cobra v1.8.1
 

--- a/cmd/kruda/templates/api/go.mod.tmpl
+++ b/cmd/kruda/templates/api/go.mod.tmpl
@@ -1,3 +1,3 @@
 module {{.ModuleName}}
 
-go 1.25.11
+go 1.25.13

--- a/cmd/kruda/templates/fullstack/go.mod.tmpl
+++ b/cmd/kruda/templates/fullstack/go.mod.tmpl
@@ -1,3 +1,3 @@
 module {{.ModuleName}}
 
-go 1.25.11
+go 1.25.13

--- a/cmd/kruda/templates/minimal/go.mod.tmpl
+++ b/cmd/kruda/templates/minimal/go.mod.tmpl
@@ -1,3 +1,3 @@
 module {{.ModuleName}}
 
-go 1.25.11
+go 1.25.13

--- a/config.go
+++ b/config.go
@@ -203,7 +203,9 @@ func WithLegacySecurityHeaders() Option {
 	}
 }
 
-// WithTransport sets a custom transport.
+// WithTransport sets a custom transport. When used with WithTLS, Listen
+// requires the transport to implement transport.TLSServer. Serve continues to
+// use the caller-supplied listener as-is.
 func WithTransport(t transport.Transport) Option {
 	return func(a *App) { a.config.Transport = t }
 }

--- a/contrib/cache/go.mod
+++ b/contrib/cache/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda/contrib/cache
 
-go 1.25.11
+go 1.25.13
 
 require github.com/go-kruda/kruda v1.2.0
 

--- a/contrib/compress/go.mod
+++ b/contrib/compress/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda/contrib/compress
 
-go 1.25.11
+go 1.25.13
 
 require github.com/go-kruda/kruda v1.2.0
 

--- a/contrib/etag/go.mod
+++ b/contrib/etag/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda/contrib/etag
 
-go 1.25.11
+go 1.25.13
 
 require github.com/go-kruda/kruda v1.2.0
 

--- a/contrib/jwt/go.mod
+++ b/contrib/jwt/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda/contrib/jwt
 
-go 1.25.11
+go 1.25.13
 
 require github.com/go-kruda/kruda v1.2.0
 

--- a/contrib/observability/README.md
+++ b/contrib/observability/README.md
@@ -41,7 +41,7 @@ importing application. Make sure your `go.mod` can satisfy:
 
 | Dependency | Minimum |
 |---|---|
-| Go | 1.25 |
+| Go | 1.25.13 |
 | `go.opentelemetry.io/otel` (+ `sdk`, `metric`, `trace`) | v1.43.0 (this module pins v1.44.0) |
 | `go.opentelemetry.io/contrib/*` (otelhttp, otelgrpc, autoexport, exporters) | matching contrib train (v0.69.x for the v1.44.0 core) |
 | `google.golang.org/grpc` | v1.79.1 |

--- a/contrib/observability/go.mod
+++ b/contrib/observability/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda/contrib/observability
 
-go 1.25.11
+go 1.25.13
 
 require (
 	github.com/go-kruda/kruda v1.4.0

--- a/contrib/otel/go.mod
+++ b/contrib/otel/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda/contrib/otel
 
-go 1.25.11
+go 1.25.13
 
 require (
 	github.com/go-kruda/kruda v1.2.0

--- a/contrib/prometheus/go.mod
+++ b/contrib/prometheus/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda/contrib/prometheus
 
-go 1.25.11
+go 1.25.13
 
 require (
 	github.com/go-kruda/kruda v1.2.0

--- a/contrib/ratelimit/go.mod
+++ b/contrib/ratelimit/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda/contrib/ratelimit
 
-go 1.25.11
+go 1.25.13
 
 require github.com/go-kruda/kruda v1.2.0
 

--- a/contrib/session/go.mod
+++ b/contrib/session/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda/contrib/session
 
-go 1.25.11
+go 1.25.13
 
 require github.com/go-kruda/kruda v1.2.0
 

--- a/contrib/swagger/go.mod
+++ b/contrib/swagger/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda/contrib/swagger
 
-go 1.25.11
+go 1.25.13
 
 require github.com/go-kruda/kruda v1.2.0
 

--- a/contrib/ws/go.mod
+++ b/contrib/ws/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda/contrib/ws
 
-go 1.25.11
+go 1.25.13
 
 require github.com/go-kruda/kruda v1.6.0
 

--- a/doc.go
+++ b/doc.go
@@ -38,8 +38,10 @@
 //   - macOS:   fasthttp
 //   - Windows: net/http
 //
-// Override with the [WithTransport], [NetHTTP], or [FastHTTP] options. TLS
-// (via [WithTLS]) auto-falls back to net/http on every platform.
+// Override with the [WithTransport], [NetHTTP], or [FastHTTP] options. Named
+// transports auto-fall back to net/http for TLS. An explicit custom transport
+// used with [App.Listen] must implement transport.TLSServer; [App.Serve]
+// continues to use a caller-supplied listener as-is.
 //
 // Wing is built into core since v1.2.0; import github.com/go-kruda/kruda
 // directly and use the kruda.Wing option. The legacy

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -104,7 +104,9 @@ Sets a custom structured logger.
 func WithTransport(t transport.Transport) Option
 ```
 
-Sets a custom transport implementation.
+Sets a custom transport implementation. With `WithTLS`, `App.Listen` requires
+the transport to implement `transport.TLSServer`; `App.Serve` continues to use
+the caller-supplied listener as-is.
 
 ### FastHTTP
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -107,7 +107,7 @@ The `listening` startup log line reports which engine a running binary got
 
 ## What Go version do I need?
 
-Go 1.25.11+ or Go 1.26.4+ is required for generic type aliases used by `C[T]` typed handlers and current stdlib security fixes. Go 1.26.4+ is recommended for the Green Tea GC and self-referential generics support.
+Go 1.25.13+ or Go 1.26.4+ is required for generic type aliases used by `C[T]` typed handlers and current stdlib security fixes. Go 1.26.4+ is recommended for the Green Tea GC and self-referential generics support.
 
 ## Is Kruda production-ready?
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-Requires Go 1.25.11+ or Go 1.26.4+.
+Requires Go 1.25.13+ or Go 1.26.4+.
 
 ```bash
 go get github.com/go-kruda/kruda

--- a/docs/guide/transport.md
+++ b/docs/guide/transport.md
@@ -43,6 +43,11 @@ KRUDA_TRANSPORT=fasthttp ./myapp   # force fasthttp
 - Wing on Windows → auto-falls back to net/http
 - Unsupported OS → defaults to fasthttp (macOS) or net/http (Windows)
 
+An explicit `WithTransport(custom)` is never replaced. With `WithTLS`,
+`App.Listen` requires that custom transport to implement
+`transport.TLSServer` and otherwise returns an error before binding. A caller
+that pre-wraps a listener with TLS can continue to pass it to `App.Serve`.
+
 ## Production TLS: terminate in front of Wing {#production-tls-terminate-in-front-of-wing}
 
 Wing does not implement TLS. When `WithTLS` is configured, Kruda automatically

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1993,9 +1993,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -2003,7 +2003,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -2038,9 +2037,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2056,9 +2055,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,13 +2,13 @@
 
 ## Common Build Errors
 
-### `go: requires go >= 1.25.11`
+### `go: requires go >= 1.25.13`
 
-Kruda requires Go 1.25.11+ on the Go 1.25 release line or Go 1.26.4+ on the Go 1.26 release line for generic type aliases and current standard-library security fixes. Upgrade your Go installation:
+Kruda requires Go 1.25.13+ on the Go 1.25 release line or Go 1.26.4+ on the Go 1.26 release line for generic type aliases and current standard-library security fixes. Upgrade your Go installation:
 
 ```bash
-go install golang.org/dl/go1.25.11@latest
-go1.25.11 download
+go install golang.org/dl/go1.25.13@latest
+go1.25.13 download
 ```
 
 Or download from [go.dev/dl](https://go.dev/dl/).

--- a/examples/observability/go.mod
+++ b/examples/observability/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda/examples/observability
 
-go 1.25.11
+go 1.25.13
 
 replace (
 	github.com/go-kruda/kruda => ../../

--- a/examples/ratelimit/go.mod
+++ b/examples/ratelimit/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda/examples/ratelimit
 
-go 1.25.11
+go 1.25.13
 
 replace (
 	github.com/go-kruda/kruda => ../../

--- a/examples/session/go.mod
+++ b/examples/session/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda/examples/session
 
-go 1.25.11
+go 1.25.13
 
 replace (
 	github.com/go-kruda/kruda => ../../

--- a/examples/websocket/go.mod
+++ b/examples/websocket/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda/examples/websocket
 
-go 1.25.11
+go 1.25.13
 
 replace (
 	github.com/go-kruda/kruda => ../../

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-kruda/kruda
 
-go 1.25.11
+go 1.25.13
 
 require (
 	github.com/bytedance/sonic v1.15.0

--- a/integration_transport_test.go
+++ b/integration_transport_test.go
@@ -382,6 +382,9 @@ func requireSecurityCookieGet(t *testing.T, url string) {
 		t.Fatalf("GET %s: %v", url, err)
 	}
 	defer resp.Body.Close()
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		t.Fatalf("GET %s body: %v", url, err)
+	}
 	if resp.StatusCode != 200 {
 		t.Fatalf("GET %s status=%d want=200", url, resp.StatusCode)
 	}

--- a/json/engine_golden_invalid_utf8_go127_test.go
+++ b/json/engine_golden_invalid_utf8_go127_test.go
@@ -1,0 +1,5 @@
+//go:build go1.27
+
+package json
+
+const invalidUTF8Golden = `"��"`

--- a/json/engine_golden_invalid_utf8_pre_go127_test.go
+++ b/json/engine_golden_invalid_utf8_pre_go127_test.go
@@ -1,0 +1,5 @@
+//go:build !go1.27
+
+package json
+
+const invalidUTF8Golden = `"\ufffd\ufffd"`

--- a/json/engine_golden_test.go
+++ b/json/engine_golden_test.go
@@ -6,13 +6,14 @@ import (
 )
 
 // The sonic and encoding/json engines are selected by build tag, so no single
-// test binary can run both. These tests instead pin exact bytes: each engine
-// build asserts against the same golden values, so an engine whose output
-// drifts from the other fails here rather than silently changing responses for
-// whichever build a user happens to compile.
+// test binary can run both. These tests instead pin exact bytes for each Go
+// version: each engine build asserts against the same version-selected golden
+// values, so an engine whose output drifts from the other fails here rather
+// than silently changing responses for whichever build a user happens to
+// compile.
 
-// goldenCases must encode identically on every engine. Multi-key maps belong
-// here only because both engines now sort map keys.
+// goldenCases must encode identically on every engine for a given Go version.
+// Multi-key maps belong here only because both engines now sort map keys.
 var goldenCases = []struct {
 	name string
 	val  any
@@ -38,7 +39,7 @@ var goldenCases = []struct {
 	{"slice", []int{1, 2, 3}, `[1,2,3]`},
 	{"unicode", "สวัสดี 🦅", `"สวัสดี 🦅"`},
 	{"escapes", "tab\there\nnewline\"quote\\slash", `"tab\there\nnewline\"quote\\slash"`},
-	{"invalidUTF8", string([]byte{0xff, 0xfe}), `"\ufffd\ufffd"`},
+	{"invalidUTF8", string([]byte{0xff, 0xfe}), invalidUTF8Golden},
 	{"singleKeyMap", map[string]int{"a": 1}, `{"a":1}`},
 	{"multiKeyMapSorted", map[string]int{"zebra": 1, "apple": 2, "mango": 3},
 		`{"apple":2,"mango":3,"zebra":1}`},
@@ -123,8 +124,8 @@ func TestMapMarshalIsDeterministic(t *testing.T) {
 // hand-embeds a response body into HTML can opt in with kruda.WithJSONEncoder.
 //
 // Invalid UTF-8 used to differ here too. The sonic engine now enables
-// ValidateString, so both engines substitute U+FFFD and that case has moved to
-// goldenCases.
+// ValidateString, so both engines substitute U+FFFD. Version-selected goldens
+// pin encoding/json's exact byte representation of those replacement runes.
 func TestKnownCrossEngineDivergences(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/json/sonic.go
+++ b/json/sonic.go
@@ -12,9 +12,10 @@
 //
 // Two exported names follow from that split, and confusing them is what this
 // package's callers have to avoid. EncoderName is the engine the build tag
-// selected, which fixes the frozen configuration and therefore the bytes.
-// ActiveEngine and EngineIsStdlib describe what is actually encoding, which fixes
-// the cost. Assert output against the first; choose a code path by the second.
+// selected, which fixes the frozen configuration. Exact bytes also depend on
+// the Go version used by encoding/json. ActiveEngine and EngineIsStdlib describe
+// what is actually encoding, which fixes the cost. Assert output against the
+// version-specific golden for the first; choose a code path by the second.
 package json
 
 import (
@@ -32,8 +33,8 @@ const EncoderName = "sonic"
 // encoding/json. A const, so the choice stays free on the hot path.
 //
 // This answers a question about cost, not about output. Anything asserting or
-// depending on byte-level behaviour must key on EncoderName instead, which
-// follows the build tag and therefore the frozen Config.
+// depending on byte-level behaviour must key on EncoderName's frozen Config and
+// the active Go version.
 //
 // Sonic's fallback honours EscapeHTML, so the HTML-escaping difference between
 // the engines does not appear on one. It does not implement SortMapKeys or

--- a/kruda.go
+++ b/kruda.go
@@ -288,6 +288,14 @@ func (app *App) Listen(addr string) error {
 	if err := app.compile(); err != nil {
 		return err
 	}
+	var tlsServer transport.TLSServer
+	if app.config.TLSCertFile != "" {
+		var ok bool
+		tlsServer, ok = app.transport.(transport.TLSServer)
+		if !ok {
+			return fmt.Errorf("kruda: transport does not support configured TLS with Listen")
+		}
+	}
 
 	// Use optimized listener (TCP_DEFER_ACCEPT + TCP_FASTOPEN on Linux,
 	// plain net.Listen on other platforms), then hand it to the transport.
@@ -304,11 +312,9 @@ func (app *App) Listen(addr string) error {
 	errCh := make(chan error, 1)
 	go func() {
 		defer ln.Close()
-		if app.config.TLSCertFile != "" && app.config.TLSKeyFile != "" {
-			if tlsServer, ok := app.transport.(transport.TLSServer); ok {
-				errCh <- tlsServer.ServeTLS(ln, app)
-				return
-			}
+		if tlsServer != nil {
+			errCh <- tlsServer.ServeTLS(ln, app)
+			return
 		}
 		errCh <- app.transport.Serve(ln, app)
 	}()

--- a/kruda.go
+++ b/kruda.go
@@ -311,7 +311,7 @@ func (app *App) Listen(addr string) error {
 
 	errCh := make(chan error, 1)
 	go func() {
-		defer ln.Close()
+		defer func() { _ = ln.Close() }()
 		if tlsServer != nil {
 			errCh <- tlsServer.ServeTLS(ln, app)
 			return

--- a/kruda.go
+++ b/kruda.go
@@ -104,6 +104,9 @@ func (app *App) Compile() {
 }
 
 func (app *App) compile() error {
+	if (app.config.TLSCertFile == "") != (app.config.TLSKeyFile == "") {
+		return fmt.Errorf("kruda: TLS certificate and key must both be configured")
+	}
 	if err := app.registerOpenAPI(); err != nil {
 		return err
 	}
@@ -300,6 +303,13 @@ func (app *App) Listen(addr string) error {
 
 	errCh := make(chan error, 1)
 	go func() {
+		defer ln.Close()
+		if app.config.TLSCertFile != "" && app.config.TLSKeyFile != "" {
+			if tlsServer, ok := app.transport.(transport.TLSServer); ok {
+				errCh <- tlsServer.ServeTLS(ln, app)
+				return
+			}
+		}
 		errCh <- app.transport.Serve(ln, app)
 	}()
 

--- a/listen_tls_test.go
+++ b/listen_tls_test.go
@@ -1,0 +1,110 @@
+package kruda
+
+import (
+	"context"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-kruda/kruda/transport"
+)
+
+var errTLSProbeDone = errors.New("TLS probe done")
+
+type tlsProbeTransport struct {
+	serveCalled    bool
+	serveTLSCalled bool
+}
+
+func (*tlsProbeTransport) ListenAndServe(string, transport.Handler) error {
+	return errors.New("ListenAndServe should not be called by App.Listen")
+}
+
+func (tr *tlsProbeTransport) Serve(ln net.Listener, _ transport.Handler) error {
+	tr.serveCalled = true
+	_ = ln.Close()
+	return errTLSProbeDone
+}
+
+func (tr *tlsProbeTransport) ServeTLS(ln net.Listener, _ transport.Handler) error {
+	tr.serveTLSCalled = true
+	_ = ln.Close()
+	return errTLSProbeDone
+}
+
+func (*tlsProbeTransport) Shutdown(context.Context) error { return nil }
+
+func TestListenUsesTLSServerForConfiguredTLS(t *testing.T) {
+	tr := &tlsProbeTransport{}
+	app := New(WithTransport(tr), WithTLS("cert.pem", "key.pem"))
+
+	err := app.Listen("127.0.0.1:0")
+	if !errors.Is(err, errTLSProbeDone) {
+		t.Fatalf("Listen error = %v, want %v", err, errTLSProbeDone)
+	}
+	if !tr.serveTLSCalled {
+		t.Fatal("transport ServeTLS was not called")
+	}
+	if tr.serveCalled {
+		t.Fatal("transport Serve was called with configured TLS")
+	}
+}
+
+func TestListenReleasesListenerWhenTLSSetupFails(t *testing.T) {
+	probe, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := probe.Addr().String()
+	probe.Close()
+
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "cert.pem")
+	keyFile := filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certFile, []byte("invalid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, []byte("invalid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New(NetHTTP(), WithTLS(certFile, keyFile))
+	if err := app.Listen(addr); err == nil {
+		t.Fatal("Listen succeeded with an invalid TLS key pair")
+	}
+
+	rebound, err := net.Listen("tcp", addr)
+	if err != nil {
+		t.Fatalf("listener remained bound after TLS setup failed: %v", err)
+	}
+	rebound.Close()
+}
+
+func TestListenRejectsIncompleteTLSConfiguration(t *testing.T) {
+	tests := []struct {
+		name string
+		cert string
+		key  string
+	}{
+		{name: "certificate only", cert: "cert.pem"},
+		{name: "key only", key: "key.pem"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := &tlsProbeTransport{}
+			app := New(WithTransport(tr), WithTLS(tt.cert, tt.key))
+
+			err := app.Listen("127.0.0.1:0")
+			if err == nil || !strings.Contains(err.Error(), "TLS certificate and key") {
+				t.Fatalf("Listen error = %v, want incomplete TLS configuration error", err)
+			}
+			if tr.serveCalled || tr.serveTLSCalled {
+				t.Fatal("transport started with incomplete TLS configuration")
+			}
+		})
+	}
+}

--- a/listen_tls_test.go
+++ b/listen_tls_test.go
@@ -53,6 +53,36 @@ func TestListenUsesTLSServerForConfiguredTLS(t *testing.T) {
 	}
 }
 
+func TestListenRejectsConfiguredTLSWithoutTLSServer(t *testing.T) {
+	tr := &startupProbeTransport{}
+	app := New(WithTransport(tr), WithTLS("cert.pem", "key.pem"))
+
+	err := app.Listen("127.0.0.1:0")
+	if err == nil || !strings.Contains(err.Error(), "does not support configured TLS") {
+		t.Fatalf("Listen error = %v, want TLS capability error", err)
+	}
+	if tr.serveCalled {
+		t.Fatal("transport Serve was called with configured TLS")
+	}
+}
+
+func TestServeAllowsTLSConfiguredTransportWithoutTLSServer(t *testing.T) {
+	tr := &startupProbeTransport{}
+	app := New(WithTransport(tr), WithTLS("cert.pem", "key.pem"))
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = app.Serve(ln)
+	if !errors.Is(err, errStartupTransportDone) {
+		t.Fatalf("Serve error = %v, want %v", err, errStartupTransportDone)
+	}
+	if !tr.serveCalled {
+		t.Fatal("transport Serve was not called for caller-owned listener")
+	}
+}
+
 func TestListenReleasesListenerWhenTLSSetupFails(t *testing.T) {
 	probe, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/static.go
+++ b/static.go
@@ -145,9 +145,17 @@ func (app *App) staticHandler(prefix string, fsys fs.FS, cfg staticConfig) *App 
 		// Try sendfile zero-copy path (Wing transport).
 		if fs, ok := c.writer.(transport.FileSender); ok {
 			if osFile, ok := f.(*os.File); ok {
-				fs.SetSendFile(int32(osFile.Fd()), stat.Size())
-				c.contentType = ct
-				return c.send()
+				canSendFile := true
+				if capability, ok := c.writer.(interface{ supportsStaticSendfile() bool }); ok {
+					canSendFile = capability.supportsStaticSendfile()
+				}
+				if canSendFile {
+					if fd, ok := duplicateStaticFile(osFile); ok {
+						fs.SetSendFile(fd, stat.Size())
+						c.contentType = ct
+						return c.send()
+					}
+				}
 			}
 		}
 

--- a/static_sendfile_stub.go
+++ b/static_sendfile_stub.go
@@ -1,0 +1,9 @@
+//go:build !linux && !darwin
+
+package kruda
+
+import "os"
+
+func duplicateStaticFile(*os.File) (int32, bool) {
+	return 0, false
+}

--- a/static_sendfile_unix.go
+++ b/static_sendfile_unix.go
@@ -8,18 +8,9 @@ import (
 )
 
 func duplicateStaticFile(file *os.File) (int32, bool) {
-	fd, err := syscall.Dup(int(file.Fd()))
-	if err != nil {
+	fd, _, errno := syscall.Syscall(syscall.SYS_FCNTL, file.Fd(), uintptr(syscall.F_DUPFD_CLOEXEC), 3)
+	if errno != 0 {
 		return 0, false
 	}
-	if fd == 0 {
-		next, dupErr := syscall.Dup(int(file.Fd()))
-		_ = syscall.Close(fd)
-		if dupErr != nil {
-			return 0, false
-		}
-		fd = next
-	}
-	syscall.CloseOnExec(fd)
 	return int32(fd), true
 }

--- a/static_sendfile_unix.go
+++ b/static_sendfile_unix.go
@@ -1,0 +1,25 @@
+//go:build linux || darwin
+
+package kruda
+
+import (
+	"os"
+	"syscall"
+)
+
+func duplicateStaticFile(file *os.File) (int32, bool) {
+	fd, err := syscall.Dup(int(file.Fd()))
+	if err != nil {
+		return 0, false
+	}
+	if fd == 0 {
+		next, dupErr := syscall.Dup(int(file.Fd()))
+		_ = syscall.Close(fd)
+		if dupErr != nil {
+			return 0, false
+		}
+		fd = next
+	}
+	syscall.CloseOnExec(fd)
+	return int32(fd), true
+}

--- a/static_wing_darwin_test.go
+++ b/static_wing_darwin_test.go
@@ -1,0 +1,51 @@
+//go:build darwin
+
+package kruda
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAppStaticWingDarwinRetainsFileThroughSendfile(t *testing.T) {
+	dir := t.TempDir()
+	want := bytes.Repeat([]byte("darwin-static\n"), 64*1024)
+	if err := os.WriteFile(filepath.Join(dir, "asset.bin"), want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	app := New(Wing())
+	app.Static("/assets", dir)
+	addr, stop := startWingApp(t, app)
+	defer stop()
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.WriteString(conn, "GET /assets/asset.bin HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("body length = %d, want %d", len(got), len(want))
+	}
+}

--- a/static_wing_linux_test.go
+++ b/static_wing_linux_test.go
@@ -157,6 +157,11 @@ func TestDuplicateStaticFileSurvivesSourceDescriptorReuse(t *testing.T) {
 		syscall.Close(int(ownedFD))
 		t.Fatal("duplicated static file descriptor is not close-on-exec")
 	}
+	if ownedFD < 3 {
+		source.Close()
+		syscall.Close(int(ownedFD))
+		t.Fatalf("duplicated static file descriptor = %d, want at least 3", ownedFD)
+	}
 	owned := os.NewFile(uintptr(ownedFD), "owned-static")
 	if err := source.Close(); err != nil {
 		owned.Close()

--- a/static_wing_linux_test.go
+++ b/static_wing_linux_test.go
@@ -1,0 +1,195 @@
+//go:build linux
+
+package kruda
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestAppStaticWingRetainsFileThroughSendfile(t *testing.T) {
+	dir := t.TempDir()
+	want := bytes.Repeat([]byte("static-file-body\n"), 128*1024)
+	if err := os.WriteFile(filepath.Join(dir, "asset.bin"), want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	decoyPath := filepath.Join(dir, "decoy.bin")
+	if err := os.WriteFile(decoyPath, bytes.Repeat([]byte("decoy\n"), 1024), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New(Wing())
+	app.Static("/assets", dir)
+	addr, stop := startWingApp(t, app)
+	defer stop()
+
+	stopChurn := make(chan struct{})
+	var churnWG sync.WaitGroup
+	churnWG.Add(1)
+	go func() {
+		defer churnWG.Done()
+		for {
+			select {
+			case <-stopChurn:
+				return
+			default:
+				f, err := os.Open(decoyPath)
+				if err == nil {
+					runtime.Gosched()
+					_ = f.Close()
+				}
+			}
+		}
+	}()
+	defer func() {
+		close(stopChurn)
+		churnWG.Wait()
+	}()
+
+	for i := 0; i < 8; i++ {
+		conn, err := net.Dial("tcp", addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+			conn.Close()
+			t.Fatal(err)
+		}
+		if _, err := io.WriteString(conn, "GET /assets/asset.bin HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n"); err != nil {
+			conn.Close()
+			t.Fatal(err)
+		}
+		resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+		if err != nil {
+			conn.Close()
+			t.Fatal(err)
+		}
+		got, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		conn.Close()
+		if err != nil {
+			t.Fatalf("request %d: read static body: %v", i, err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("request %d: body length = %d, want %d", i, len(got), len(want))
+		}
+	}
+}
+
+func TestAppStaticWingFallsBackOutsideInlineDispatch(t *testing.T) {
+	presets := []struct {
+		name   string
+		preset Preset
+	}{
+		{name: "Pool", preset: Arrow},
+		{name: "Spawn", preset: Preset{Dispatch: Spawn}},
+		{name: "Takeover", preset: DB},
+	}
+
+	for _, tt := range presets {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			want := []byte("buffered static response")
+			if err := os.WriteFile(filepath.Join(dir, "asset.txt"), want, 0o600); err != nil {
+				t.Fatal(err)
+			}
+			tr := NewWingTransport(WingConfig{Workers: 1, DefaultPreset: tt.preset})
+			app := New(WithTransport(tr))
+			app.Static("/assets", dir)
+			addr, stop := startWingApp(t, app)
+			defer stop()
+
+			resp, err := http.Get("http://" + addr + "/assets/asset.txt")
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(got, want) {
+				t.Fatalf("body = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestDuplicateStaticFileSurvivesSourceDescriptorReuse(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "source.txt")
+	decoyPath := filepath.Join(dir, "decoy.txt")
+	if err := os.WriteFile(sourcePath, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(decoyPath, []byte("decoy"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sourceFD := int(source.Fd())
+	ownedFD, ok := duplicateStaticFile(source)
+	if !ok {
+		source.Close()
+		t.Fatal("duplicateStaticFile failed")
+	}
+	flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(ownedFD), uintptr(syscall.F_GETFD), 0)
+	if errno != 0 {
+		source.Close()
+		syscall.Close(int(ownedFD))
+		t.Fatal(errno)
+	}
+	if flags&syscall.FD_CLOEXEC == 0 {
+		source.Close()
+		syscall.Close(int(ownedFD))
+		t.Fatal("duplicated static file descriptor is not close-on-exec")
+	}
+	owned := os.NewFile(uintptr(ownedFD), "owned-static")
+	if err := source.Close(); err != nil {
+		owned.Close()
+		t.Fatal(err)
+	}
+
+	decoy, err := os.Open(decoyPath)
+	if err != nil {
+		owned.Close()
+		t.Fatal(err)
+	}
+	defer decoy.Close()
+	if int(decoy.Fd()) != sourceFD {
+		if err := syscall.Dup3(int(decoy.Fd()), sourceFD, 0); err != nil {
+			owned.Close()
+			t.Fatal(err)
+		}
+		defer syscall.Close(sourceFD)
+	}
+
+	got, err := io.ReadAll(owned)
+	if err != nil {
+		owned.Close()
+		t.Fatal(err)
+	}
+	if err := owned.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "source" {
+		t.Fatalf("owned descriptor read %q after source fd reuse", got)
+	}
+	var one [1]byte
+	if _, err := syscall.Read(int(ownedFD), one[:]); err != syscall.EBADF {
+		t.Fatalf("read after owned close = %v, want EBADF", err)
+	}
+}

--- a/transport/nethttp.go
+++ b/transport/nethttp.go
@@ -84,6 +84,16 @@ func (t *NetHTTPTransport) Serve(ln net.Listener, handler Handler) error {
 	return srv.Serve(ln)
 }
 
+// ServeTLS starts the HTTP server with configured TLS on an existing listener.
+func (t *NetHTTPTransport) ServeTLS(ln net.Listener, handler Handler) error {
+	t.mu.Lock()
+	t.server = t.newServer("", handler)
+	srv := t.server
+	t.mu.Unlock()
+
+	return srv.ServeTLS(ln, t.config.TLSCertFile, t.config.TLSKeyFile)
+}
+
 // Shutdown gracefully shuts down the server.
 func (t *NetHTTPTransport) Shutdown(ctx context.Context) error {
 	t.mu.Lock()

--- a/transport/nethttp_tls_test.go
+++ b/transport/nethttp_tls_test.go
@@ -1,0 +1,147 @@
+package transport
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestNetHTTPTransportServeTLSUsesConfiguredTLS(t *testing.T) {
+	certFile, keyFile := writeTestTLSKeyPair(t)
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tr := NewNetHTTP(NetHTTPConfig{TLSCertFile: certFile, TLSKeyFile: keyFile})
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- tr.ServeTLS(ln, HandlerFunc(func(w ResponseWriter, _ Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("secure"))
+		}))
+	}()
+
+	conn, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{InsecureSkipVerify: true}) //nolint:gosec -- test certificate
+	if err != nil {
+		shutdownNetHTTPTestServer(t, tr, serveErr)
+		t.Fatalf("TLS handshake through ServeTLS failed: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := io.WriteString(conn, "GET / HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK || string(body) != "secure" {
+		t.Fatalf("response = (%d, %q), want (200, %q)", resp.StatusCode, body, "secure")
+	}
+
+	shutdownNetHTTPTestServer(t, tr, serveErr)
+}
+
+func TestNetHTTPTransportServePreservesWrappedListener(t *testing.T) {
+	certFile, keyFile := writeTestTLSKeyPair(t)
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tlsLn := tls.NewListener(ln, &tls.Config{Certificates: []tls.Certificate{cert}})
+
+	tr := NewNetHTTP(NetHTTPConfig{TLSCertFile: certFile, TLSKeyFile: keyFile})
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- tr.Serve(tlsLn, HandlerFunc(func(w ResponseWriter, _ Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("secure"))
+		}))
+	}()
+
+	conn, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{InsecureSkipVerify: true}) //nolint:gosec -- test certificate
+	if err != nil {
+		shutdownNetHTTPTestServer(t, tr, serveErr)
+		t.Fatalf("TLS handshake through wrapped listener failed: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := io.WriteString(conn, "GET / HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		shutdownNetHTTPTestServer(t, tr, serveErr)
+		t.Fatalf("read response through wrapped listener: %v", err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK || string(body) != "secure" {
+		t.Fatalf("response = (%d, %q), want (200, %q)", resp.StatusCode, body, "secure")
+	}
+
+	shutdownNetHTTPTestServer(t, tr, serveErr)
+}
+
+func writeTestTLSKeyPair(t *testing.T) (string, string) {
+	t.Helper()
+	tlsServer := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	cert := tlsServer.TLS.Certificates[0]
+	tlsServer.Close()
+
+	keyDER, err := x509.MarshalPKCS8PrivateKey(cert.PrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "cert.pem")
+	keyFile := filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return certFile, keyFile
+}
+
+func shutdownNetHTTPTestServer(t *testing.T, tr *NetHTTPTransport, serveErr <-chan error) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := tr.Shutdown(ctx); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-serveErr:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Fatalf("Serve returned %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Serve did not stop")
+	}
+}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -74,7 +74,8 @@ type StaticResponder interface {
 }
 
 // FileSender is an optional interface for ResponseWriters that support
-// sendfile(2) zero-copy file transfer (e.g., Wing transport).
+// sendfile(2) zero-copy file transfer (e.g., Wing transport). SetSendFile
+// transfers ownership of fd to the ResponseWriter, which must close it.
 type FileSender interface {
 	SetSendFile(fd int32, size int64)
 }

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -18,6 +18,11 @@ type Transport interface {
 	Shutdown(ctx context.Context) error
 }
 
+// TLSServer is implemented by transports that can apply configured TLS to a listener.
+type TLSServer interface {
+	ServeTLS(ln net.Listener, handler Handler) error
+}
+
 // Handler is the core request handler interface that transports call.
 type Handler interface {
 	ServeKruda(w ResponseWriter, r Request)

--- a/wing_async_fd_test.go
+++ b/wing_async_fd_test.go
@@ -1,0 +1,122 @@
+//go:build linux || darwin
+
+package kruda
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestWingAsyncPipelineClosesAfterItsResponse(t *testing.T) {
+	presets := []struct {
+		name   string
+		preset Preset
+	}{
+		{name: "Pool", preset: Arrow},
+		{name: "Spawn", preset: Preset{Dispatch: Spawn}},
+	}
+
+	for _, tt := range presets {
+		t.Run(tt.name, func(t *testing.T) {
+			started := make(chan struct{})
+			release := make(chan struct{})
+			defer func() {
+				select {
+				case <-release:
+				default:
+					close(release)
+				}
+			}()
+			app := New(Wing())
+			app.Get("/inline", func(c *Ctx) error { return c.Text("inline") }, Bolt)
+			app.Get("/async", func(c *Ctx) error {
+				close(started)
+				<-release
+				return c.Text("async")
+			}, tt.preset)
+
+			addr, stop := startWingApp(t, app)
+			defer stop()
+			conn, err := net.Dial("tcp", addr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer conn.Close()
+			if err := conn.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+				t.Fatal(err)
+			}
+			pipeline := "GET /inline HTTP/1.1\r\nHost: test\r\n\r\n" +
+				"GET /async HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n"
+			if _, err := io.WriteString(conn, pipeline); err != nil {
+				t.Fatal(err)
+			}
+			select {
+			case <-started:
+			case <-time.After(time.Second):
+				t.Fatal("async handler did not start")
+			}
+
+			reader := bufio.NewReader(conn)
+			assertWingPipelineResponse(t, reader, "inline")
+			close(release)
+			assertWingPipelineResponse(t, reader, "async")
+
+			if err := conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
+				t.Fatal(err)
+			}
+			var one [1]byte
+			if _, err := conn.Read(one[:]); err == nil {
+				t.Fatal("connection remained open after Connection: close response")
+			} else if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				t.Fatal("connection did not close after async response")
+			}
+		})
+	}
+}
+
+func assertWingPipelineResponse(t *testing.T, reader *bufio.Reader, wantBody string) {
+	t.Helper()
+	resp, err := http.ReadResponse(reader, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusOK || string(body) != wantBody {
+		t.Fatalf("response = (%d, %q), want (200, %q)", resp.StatusCode, body, wantBody)
+	}
+}
+
+func TestDirectSendRetainsConnectionWhileAsyncHandlerOwnsFD(t *testing.T) {
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer syscall.Close(fds[0])
+	if err := syscall.Close(fds[1]); err != nil {
+		t.Fatal(err)
+	}
+
+	w, eng := newTestWorker(0)
+	c := newTestConn(int32(fds[0]))
+	c.pending = 1
+	c.sendBuf = append(c.sendBuf, "prior response"...)
+	w.conns[c.fd] = c
+
+	w.directSend(c)
+
+	if len(eng.closedFds) != 0 {
+		t.Fatal("connection fd closed while async handler still owned it")
+	}
+	if w.conns[c.fd] == nil {
+		t.Fatal("connection bookkeeping removed before async completion")
+	}
+}

--- a/wing_async_sendfile_linux_test.go
+++ b/wing_async_sendfile_linux_test.go
@@ -52,6 +52,98 @@ func TestDirectSendRetainsConnectionOnSendfileErrorWhileAsyncHandlerOwnsFD(t *te
 	}
 }
 
+func TestDirectSendClosesOwnedSendfileDescriptorOnSuccess(t *testing.T) {
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer syscall.Close(fds[0])
+	defer syscall.Close(fds[1])
+	if err := syscall.SetNonblock(fds[0], true); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(t.TempDir(), "success.bin")
+	if err := os.WriteFile(path, []byte("sendfile success"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fileFD, err := syscall.Open(path, syscall.O_RDONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w, _ := newTestWorker(0)
+	c := newTestConn(int32(fds[0]))
+	c.keepAlive = true
+	c.sendFileFd = int32(fileFD)
+	c.sendFileSize = int64(len("sendfile success"))
+	w.conns[c.fd] = c
+
+	w.directSend(c)
+
+	if c.sendFileFd != 0 {
+		t.Fatalf("sendFileFd = %d, want released", c.sendFileFd)
+	}
+	assertDescriptorClosed(t, fileFD)
+}
+
+func TestFailSendClosesOwnedSendfileDescriptor(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "failure.bin")
+	if err := os.WriteFile(path, []byte("sendfile failure"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fileFD, err := syscall.Open(path, syscall.O_RDONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w, _ := newTestWorker(0)
+	c := newTestConn(123)
+	c.pending = 1
+	c.sendFileFd = int32(fileFD)
+	c.sendFileSize = int64(len("sendfile failure"))
+	w.conns[c.fd] = c
+
+	w.failSend(c)
+
+	if c.sendFileFd != 0 {
+		t.Fatalf("sendFileFd = %d, want released", c.sendFileFd)
+	}
+	assertDescriptorClosed(t, fileFD)
+}
+
+func TestConnectionCleanupClosesOwnedSendfileDescriptor(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "disconnect.bin")
+	if err := os.WriteFile(path, []byte("disconnect"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	fileFD, err := syscall.Open(path, syscall.O_RDONLY, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w, _ := newTestWorker(0)
+	c := newTestConn(123)
+	c.sendFileFd = int32(fileFD)
+	c.sendFileSize = int64(len("disconnect"))
+	w.conns[c.fd] = c
+
+	w.removeConnBookkeeping(c.fd)
+
+	if c.sendFileFd != 0 {
+		t.Fatalf("sendFileFd = %d, want released", c.sendFileFd)
+	}
+	assertDescriptorClosed(t, fileFD)
+}
+
+func assertDescriptorClosed(t *testing.T, fd int) {
+	t.Helper()
+	var one [1]byte
+	if _, err := syscall.Read(fd, one[:]); err != syscall.EBADF {
+		t.Fatalf("read fd %d after release = %v, want EBADF", fd, err)
+	}
+}
+
 func TestWingAsyncPipelinePreservesSendfileResponseOrder(t *testing.T) {
 	presets := []struct {
 		name   string

--- a/wing_async_sendfile_linux_test.go
+++ b/wing_async_sendfile_linux_test.go
@@ -151,6 +151,7 @@ func TestWingAsyncPipelinePreservesSendfileResponseOrder(t *testing.T) {
 	}{
 		{name: "Pool", preset: Arrow},
 		{name: "Spawn", preset: Preset{Dispatch: Spawn}},
+		{name: "Takeover", preset: DB},
 	}
 	fileBody := bytes.Repeat([]byte("f"), 8<<20)
 	filePath := filepath.Join(t.TempDir(), "response.bin")

--- a/wing_async_sendfile_linux_test.go
+++ b/wing_async_sendfile_linux_test.go
@@ -1,0 +1,119 @@
+//go:build linux
+
+package kruda
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/go-kruda/kruda/transport"
+)
+
+func TestDirectSendRetainsConnectionOnSendfileErrorWhileAsyncHandlerOwnsFD(t *testing.T) {
+	fds, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer syscall.Close(fds[0])
+	defer syscall.Close(fds[1])
+
+	file, err := os.CreateTemp(t.TempDir(), "sendfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fileFd := int32(file.Fd())
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	w, eng := newTestWorker(0)
+	c := newTestConn(int32(fds[0]))
+	c.pending = 1
+	c.sendFileFd = fileFd
+	c.sendFileSize = 1
+	w.conns[c.fd] = c
+
+	w.directSend(c)
+
+	if len(eng.closedFds) != 0 {
+		t.Fatal("connection fd closed while async handler still owned it")
+	}
+	if w.conns[c.fd] == nil {
+		t.Fatal("connection bookkeeping removed before async completion")
+	}
+}
+
+func TestWingAsyncPipelinePreservesSendfileResponseOrder(t *testing.T) {
+	presets := []struct {
+		name   string
+		preset Preset
+	}{
+		{name: "Pool", preset: Arrow},
+		{name: "Spawn", preset: Preset{Dispatch: Spawn}},
+	}
+	fileBody := bytes.Repeat([]byte("f"), 8<<20)
+	filePath := filepath.Join(t.TempDir(), "response.bin")
+	if err := os.WriteFile(filePath, fileBody, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tt := range presets {
+		t.Run(tt.name, func(t *testing.T) {
+			app := New(Wing())
+			app.Get("/file", func(c *Ctx) error {
+				fileSender, ok := c.ResponseWriter().(transport.FileSender)
+				if !ok {
+					return errors.New("Wing response does not support sendfile")
+				}
+				fd, err := syscall.Open(filePath, syscall.O_RDONLY, 0)
+				if err != nil {
+					return err
+				}
+				fileSender.SetSendFile(int32(fd), int64(len(fileBody)))
+				return nil
+			}, Bolt)
+			app.Get("/async", func(c *Ctx) error { return c.Text("async") }, tt.preset)
+
+			addr, stop := startWingApp(t, app)
+			defer stop()
+			conn, err := net.Dial("tcp", addr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer conn.Close()
+			if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+				t.Fatal(err)
+			}
+			pipeline := "GET /file HTTP/1.1\r\nHost: test\r\n\r\n" +
+				"GET /async HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n"
+			if _, err := io.WriteString(conn, pipeline); err != nil {
+				t.Fatal(err)
+			}
+			time.Sleep(100 * time.Millisecond)
+
+			reader := bufio.NewReader(conn)
+			resp, err := http.ReadResponse(reader, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			body, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err != nil {
+				t.Fatalf("read sendfile body (%d/%d bytes): %v", len(body), len(fileBody), err)
+			}
+			if !bytes.Equal(body, fileBody) {
+				t.Fatal("async response was written before the preceding sendfile body completed")
+			}
+			assertWingPipelineResponse(t, reader, "async")
+		})
+	}
+}

--- a/wing_engine_linux.go
+++ b/wing_engine_linux.go
@@ -22,10 +22,7 @@ const (
 	epollCtlDel = 2
 )
 
-type epollEvent struct {
-	events uint32
-	data   [8]byte // fd packed as int32 in first 4 bytes
-}
+type epollEvent = syscall.EpollEvent
 
 type epollEngine struct {
 	epfd     int
@@ -41,7 +38,7 @@ type epollEngine struct {
 func newEngine() engine {
 	return &epollEngine{
 		connPtrs: make(map[int32]unsafe.Pointer, 1024),
-		epevs:    make([]epollEvent, 128),
+		epevs:    make([]epollEvent, maxEventsPerWait),
 	}
 }
 
@@ -64,7 +61,9 @@ func (e *epollEngine) PostWake() {
 
 func (e *epollEngine) SubmitAccept(listenFd int) {
 	e.listenFd = listenFd
-	e.epollAdd(int32(listenFd), epollin|epollet)
+	// Keep the listener level-triggered so a full worker batch leaves it ready
+	// for the next wait until accept4 drains the queue to EAGAIN.
+	e.epollAdd(int32(listenFd), epollin)
 	// Register eventfd for wake signaling
 	e.epollAdd(int32(e.evfd), epollin|epollet)
 }
@@ -124,7 +123,11 @@ func (e *epollEngine) WaitNonBlock(events []event) (int, error) {
 }
 
 func (e *epollEngine) waitWithTimeout(events []event, msec int) (int, error) {
-	n, err := epollWait(e.epfd, e.epevs, msec, e.rawMode)
+	kernelEvents := e.epevs
+	if len(kernelEvents) > len(events) {
+		kernelEvents = kernelEvents[:len(events)]
+	}
+	n, err := epollWait(e.epfd, kernelEvents, msec, e.rawMode)
 	if err != nil {
 		if err == syscall.EINTR {
 			return 0, nil
@@ -132,21 +135,19 @@ func (e *epollEngine) waitWithTimeout(events []event, msec int) (int, error) {
 		return 0, err
 	}
 
-	// Elastic resize
-	if n == len(e.epevs) && len(e.epevs) < 1024 {
-		e.epevs = make([]epollEvent, len(e.epevs)*2)
-	} else if n < len(e.epevs)/4 && len(e.epevs) > 128 {
-		e.epevs = make([]epollEvent, len(e.epevs)/2)
-	}
-
 	count := 0
 	for i := 0; i < n && count < len(events); i++ {
 		ev := &e.epevs[i]
-		// All epoll_data stores fd as int32 in data[0:4].
-		fd := *(*int32)(unsafe.Pointer(&ev.data[0]))
+		fd := ev.Fd
 
 		if int(fd) == e.listenFd {
-			count += e.drainAccept(events[count:])
+			// One listener event can fan out into many accepts. Reserve one output
+			// slot for every kernel event still in this batch so their ET readiness
+			// is never consumed without reaching the worker.
+			acceptSlots := len(events) - count - (n - i - 1)
+			if acceptSlots > 0 {
+				count += e.drainAccept(events[count : count+acceptSlots])
+			}
 			continue
 		}
 
@@ -161,13 +162,13 @@ func (e *epollEngine) waitWithTimeout(events []event, msec int) (int, error) {
 		// Conn fd — look up pointer from connPtrs map.
 		ptr := e.connPtrs[fd]
 
-		if ev.events&epollout != 0 {
+		if ev.Events&epollout != 0 {
 			events[count] = event{Op: opSend, ConnPtr: ptr}
 			count++
 			continue
 		}
 
-		if ev.events&epollin != 0 {
+		if ev.Events&epollin != 0 {
 			events[count] = event{Op: opRecv, ConnPtr: ptr}
 			count++
 		}
@@ -176,7 +177,6 @@ func (e *epollEngine) waitWithTimeout(events []event, msec int) (int, error) {
 }
 
 func (e *epollEngine) drainAccept(events []event) int {
-	// Re-arm listen fd (ET, persistent — no need to re-add)
 	count := 0
 	for count < len(events) {
 		// Raw accept4 with a stack-allocated RawSockaddrAny so the peer address
@@ -240,15 +240,13 @@ func (e *epollEngine) Close() {
 // epoll helpers
 
 func (e *epollEngine) epollAdd(fd int32, events uint32) {
-	ev := epollEvent{events: events}
-	*(*int32)(unsafe.Pointer(&ev.data[0])) = fd
-	syscall.EpollCtl(e.epfd, epollCtlAdd, int(fd), (*syscall.EpollEvent)(unsafe.Pointer(&ev)))
+	ev := epollEvent{Events: events, Fd: fd}
+	syscall.EpollCtl(e.epfd, epollCtlAdd, int(fd), &ev)
 }
 
 func (e *epollEngine) epollMod(fd int32, events uint32) {
-	ev := epollEvent{events: events}
-	*(*int32)(unsafe.Pointer(&ev.data[0])) = fd
-	syscall.EpollCtl(e.epfd, epollCtlMod, int(fd), (*syscall.EpollEvent)(unsafe.Pointer(&ev)))
+	ev := epollEvent{Events: events, Fd: fd}
+	syscall.EpollCtl(e.epfd, epollCtlMod, int(fd), &ev)
 }
 
 func (e *epollEngine) epollModPtr(fd int32, events uint32) {

--- a/wing_engine_linux_overflow_test.go
+++ b/wing_engine_linux_overflow_test.go
@@ -1,0 +1,187 @@
+//go:build linux
+
+package kruda
+
+import (
+	"net"
+	"strconv"
+	"syscall"
+	"testing"
+	"unsafe"
+)
+
+func TestEpollWaitPreservesReadinessBeyondWorkerBatch(t *testing.T) {
+	epfd, err := syscall.EpollCreate1(syscall.EPOLL_CLOEXEC)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e := &epollEngine{
+		epfd:     epfd,
+		evfd:     -1,
+		listenFd: -1,
+		connPtrs: make(map[int32]unsafe.Pointer),
+		epevs:    make([]epollEvent, maxEventsPerWait*2),
+	}
+	defer e.Close()
+
+	type pipePair [2]int
+	pipes := make([]pipePair, maxEventsPerWait*2)
+	for i := range pipes {
+		if err := syscall.Pipe(pipes[i][:]); err != nil {
+			t.Fatal(err)
+		}
+		defer syscall.Close(pipes[i][0])
+		defer syscall.Close(pipes[i][1])
+		if err := syscall.SetNonblock(pipes[i][0], true); err != nil {
+			t.Fatal(err)
+		}
+		e.epollAdd(int32(pipes[i][0]), epollin|epollet)
+		if _, err := syscall.Write(pipes[i][1], []byte{1}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var events [maxEventsPerWait]event
+	total := 0
+	for range 4 {
+		n, err := e.WaitNonBlock(events[:])
+		if err != nil {
+			t.Fatal(err)
+		}
+		total += n
+	}
+	if total != len(pipes) {
+		t.Fatalf("delivered %d readiness events, want %d", total, len(pipes))
+	}
+}
+
+func TestEpollAcceptContinuesAfterWorkerBatchFills(t *testing.T) {
+	listenFd, err := createListenFd("127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeFd(listenFd)
+	sa, err := syscall.Getsockname(listenFd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := sa.(*syscall.SockaddrInet4).Port
+
+	eventFd, err := createEventfd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeFd(eventFd)
+
+	e := newEngine().(*epollEngine)
+	if err := e.Init(engineConfig{EventFd: eventFd}); err != nil {
+		t.Fatal(err)
+	}
+	defer e.Close()
+	e.SubmitAccept(listenFd)
+
+	clients := make([]net.Conn, 0, maxEventsPerWait*2)
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	for range maxEventsPerWait * 2 {
+		conn, err := net.Dial("tcp", addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		clients = append(clients, conn)
+	}
+	defer func() {
+		for _, conn := range clients {
+			conn.Close()
+		}
+	}()
+
+	var events [maxEventsPerWait]event
+	accepted := 0
+	for range 4 {
+		n, err := e.WaitNonBlock(events[:])
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, ev := range events[:n] {
+			if ev.Op != opAccept || ev.Res < 0 {
+				continue
+			}
+			accepted++
+			e.SubmitClose(ev.Res)
+		}
+	}
+	if accepted != len(clients) {
+		t.Fatalf("accepted %d connections, want %d", accepted, len(clients))
+	}
+}
+
+func TestEpollAcceptFanoutPreservesReturnedConnectionEvent(t *testing.T) {
+	listenFd, err := createListenFd("127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeFd(listenFd)
+	sa, err := syscall.Getsockname(listenFd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := sa.(*syscall.SockaddrInet4).Port
+
+	eventFd, err := createEventfd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closeFd(eventFd)
+	e := newEngine().(*epollEngine)
+	if err := e.Init(engineConfig{EventFd: eventFd}); err != nil {
+		t.Fatal(err)
+	}
+	defer e.Close()
+	e.SubmitAccept(listenFd)
+
+	clients := make([]net.Conn, 0, maxEventsPerWait*2)
+	addr := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	for range maxEventsPerWait * 2 {
+		conn, err := net.Dial("tcp", addr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		clients = append(clients, conn)
+	}
+	defer func() {
+		for _, conn := range clients {
+			conn.Close()
+		}
+	}()
+
+	var pipeFds [2]int
+	if err := syscall.Pipe(pipeFds[:]); err != nil {
+		t.Fatal(err)
+	}
+	defer syscall.Close(pipeFds[0])
+	defer syscall.Close(pipeFds[1])
+	marker := 1
+	e.connPtrs[int32(pipeFds[0])] = unsafe.Pointer(&marker)
+	if _, err := syscall.Write(pipeFds[1], []byte{1}); err != nil {
+		t.Fatal(err)
+	}
+	e.epollAdd(int32(pipeFds[0]), epollin|epollet)
+
+	var events [maxEventsPerWait]event
+	n, err := e.WaitNonBlock(events[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+	sawConnection := false
+	for _, ev := range events[:n] {
+		switch {
+		case ev.Op == opAccept && ev.Res >= 0:
+			e.SubmitClose(ev.Res)
+		case ev.Op == opRecv && ev.ConnPtr == unsafe.Pointer(&marker):
+			sawConnection = true
+		}
+	}
+	if !sawConnection {
+		t.Fatal("accept fanout discarded a connection event already returned by epoll")
+	}
+}

--- a/wing_engine_linux_overflow_test.go
+++ b/wing_engine_linux_overflow_test.go
@@ -4,11 +4,25 @@ package kruda
 
 import (
 	"net"
+	"runtime"
 	"strconv"
 	"syscall"
 	"testing"
 	"unsafe"
 )
+
+func TestEpollEventABIOnArm64(t *testing.T) {
+	if runtime.GOARCH != "arm64" {
+		t.Skip("arm64 ABI assertion")
+	}
+	var ev epollEvent
+	if got := unsafe.Sizeof(ev); got != 16 {
+		t.Fatalf("epoll event size = %d, want 16 on linux/arm64", got)
+	}
+	if got := unsafe.Offsetof(ev.Fd); got != 8 {
+		t.Fatalf("epoll fd offset = %d, want 8 on linux/arm64", got)
+	}
+}
 
 func TestEpollWaitPreservesReadinessBeyondWorkerBatch(t *testing.T) {
 	epfd, err := syscall.EpollCreate1(syscall.EPOLL_CLOEXEC)

--- a/wing_http.go
+++ b/wing_http.go
@@ -1169,6 +1169,7 @@ func acquireResponse() *wingResponse {
 	r.buf = r.buf[:0]
 	r.staticResp = nil
 	r.jsonFast = false
+	r.sendFileEnabled = false
 	r.fileFd = 0
 	r.fileSize = 0
 	r.responseMode = responseGeneric
@@ -1179,6 +1180,9 @@ func acquireResponse() *wingResponse {
 }
 
 func releaseResponse(r *wingResponse) {
+	if r.fileFd > 0 {
+		closeFd(int(r.fileFd))
+	}
 	r.status = 0
 	r.staticResp = nil
 	r.jsonFast = false
@@ -1186,6 +1190,7 @@ func releaseResponse(r *wingResponse) {
 	r.stringFast = false
 	r.stringBody = ""
 	r.stringContentType = ""
+	r.sendFileEnabled = false
 	r.fileFd = 0
 	r.fileSize = 0
 	r.headers.reset()
@@ -1220,6 +1225,7 @@ type wingResponse struct {
 	stringFast        bool
 	stringBody        string
 	stringContentType string
+	sendFileEnabled   bool
 	fileFd            int32 // sendfile fd (0 = not a file response)
 	fileSize          int64 // sendfile byte count
 }
@@ -1249,9 +1255,13 @@ func (r *wingResponse) SetStringBody(status int, contentType, body string) {
 
 // SetSendFile configures the response to use sendfile(2) for zero-copy file transfer.
 func (r *wingResponse) SetSendFile(fd int32, size int64) {
+	if r.fileFd > 0 && r.fileFd != fd {
+		closeFd(int(r.fileFd))
+	}
 	r.fileFd = fd
 	r.fileSize = size
 }
+func (r *wingResponse) supportsStaticSendfile() bool { return r.sendFileEnabled }
 func (r *wingResponse) SetJSON(status int, data []byte) {
 	r.status = status
 	r.body = data

--- a/wing_pending_read_linux_test.go
+++ b/wing_pending_read_linux_test.go
@@ -1,0 +1,71 @@
+//go:build linux
+
+package kruda
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestWingResumesReadinessSuppressedByPendingHandler(t *testing.T) {
+	handlerStarted := make(chan struct{})
+	releaseHandler := make(chan struct{})
+	suppressedRead := make(chan struct{}, 1)
+	testSuppressedRecvHook = func(int32) {
+		select {
+		case suppressedRead <- struct{}{}:
+		default:
+		}
+	}
+
+	app := New(Wing())
+	app.Get("/async", func(c *Ctx) error {
+		close(handlerStarted)
+		<-releaseHandler
+		return c.Text("async")
+	}, Arrow)
+	app.Get("/next", func(c *Ctx) error { return c.Text("next") }, Bolt)
+	addr, stop := startWingApp(t, app)
+	defer func() {
+		select {
+		case <-releaseHandler:
+		default:
+			close(releaseHandler)
+		}
+		stop()
+		testSuppressedRecvHook = nil
+	}()
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if _, err := io.WriteString(conn, "GET /async HTTP/1.1\r\nHost: test\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("async handler did not start")
+	}
+	if _, err := io.WriteString(conn, "GET /next HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-suppressedRead:
+	case <-time.After(time.Second):
+		t.Fatal("EPOLLIN was not observed while the handler was pending")
+	}
+	close(releaseHandler)
+
+	reader := bufio.NewReader(conn)
+	assertWingPipelineResponse(t, reader, "async")
+	if err := conn.SetReadDeadline(time.Now().Add(500 * time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+	assertWingPipelineResponse(t, reader, "next")
+}

--- a/wing_sendfile_darwin.go
+++ b/wing_sendfile_darwin.go
@@ -2,10 +2,27 @@
 
 package kruda
 
-import "syscall"
+import (
+	"io"
+	"syscall"
+)
 
 // sendfile wraps the Darwin sendfile(2) syscall.
 func sendfile(outFd, inFd int32, offset *int64, count int) (int, error) {
+	if offset == nil {
+		current, err := syscall.Seek(int(inFd), 0, io.SeekCurrent)
+		if err != nil {
+			return 0, err
+		}
+		n, sendErr := syscall.Sendfile(int(outFd), int(inFd), &current, count)
+		if n > 0 {
+			_, seekErr := syscall.Seek(int(inFd), current+int64(n), io.SeekStart)
+			if seekErr != nil {
+				return n, seekErr
+			}
+		}
+		return n, sendErr
+	}
 	n, err := syscall.Sendfile(int(outFd), int(inFd), offset, count)
 	return n, err
 }

--- a/wing_stream_integration_test.go
+++ b/wing_stream_integration_test.go
@@ -31,18 +31,45 @@ func startWingApp(t *testing.T, app *App) (string, func()) {
 		t.Fatalf("listen: %v", err)
 	}
 	addr := ln.Addr().String()
-	ln.Close() // let the transport bind so a successful dial means it is accepting
-	go func() { _ = app.transport.ListenAndServe(addr, app) }()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		c, derr := net.DialTimeout("tcp", addr, 100*time.Millisecond)
-		if derr == nil {
-			c.Close()
-			break
+	_ = ln.Close() // let the transport bind so a successful dial means it is accepting
+	serveErrCh := make(chan error, 1)
+	go func() { serveErrCh <- app.transport.ListenAndServe(addr, app) }()
+	stop := func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if err := app.transport.Shutdown(ctx); err != nil {
+			t.Errorf("startWingApp: shutdown: %v", err)
 		}
+	}
+
+	var lastDialErr error
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case serveErr := <-serveErrCh:
+			stop()
+			t.Fatalf("startWingApp: server stopped before readiness at %s: %v (last dial: %v)", addr, serveErr, lastDialErr)
+		default:
+		}
+
+		c, dialErr := net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if dialErr == nil {
+			_ = c.Close()
+			return addr, stop
+		}
+		lastDialErr = dialErr
 		time.Sleep(10 * time.Millisecond)
 	}
-	return addr, func() { _ = app.transport.Shutdown(context.Background()) }
+
+	serveEvidence := "still running at readiness deadline"
+	select {
+	case serveErr := <-serveErrCh:
+		serveEvidence = fmt.Sprintf("stopped: %v", serveErr)
+	default:
+	}
+	stop()
+	t.Fatalf("startWingApp: server did not become ready at %s: last dial: %v; serve: %s", addr, lastDialErr, serveEvidence)
+	return "", func() {}
 }
 
 // readSSEEvent reads from r until it has consumed one full SSE event

--- a/wing_takeover_pipeline_test.go
+++ b/wing_takeover_pipeline_test.go
@@ -1,0 +1,97 @@
+//go:build linux || darwin
+
+package kruda
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWingInlineThenTakeoverPreservesResponseOrder(t *testing.T) {
+	firstBody := strings.Repeat("first-response-", 4096)
+	app := New(Wing())
+	app.Get("/inline", func(c *Ctx) error { return c.Text(firstBody) }, Bolt)
+	app.Get("/takeover", func(c *Ctx) error { return c.Text("takeover-response") }, DB)
+	addr, stop := startWingApp(t, app)
+	defer stop()
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	pipeline := "GET /inline HTTP/1.1\r\nHost: test\r\n\r\n" +
+		"GET /takeover HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n"
+	if _, err := io.WriteString(conn, pipeline); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := bufio.NewReader(conn)
+	status, body, err := readHTTPResponse(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(status, "200") || body != firstBody {
+		t.Fatalf("first response = (%q, %d bytes), want 200 and %d-byte inline body", status, len(body), len(firstBody))
+	}
+	status, body, err = readHTTPResponse(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(status, "200") || body != "takeover-response" {
+		t.Fatalf("second response = (%q, %q), want 200 takeover response", status, body)
+	}
+}
+
+func TestWingInlinePartialWriteThenTakeoverPreservesResponseOrder(t *testing.T) {
+	firstBody := bytes.Repeat([]byte("x"), 8<<20)
+	app := New(Wing())
+	app.Get("/inline", func(c *Ctx) error { return c.SendBytes(firstBody) }, Bolt)
+	app.Get("/takeover", func(c *Ctx) error { return c.Text("takeover-response") }, DB)
+	addr, stop := startWingApp(t, app)
+	defer stop()
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		if err := tcpConn.SetReadBuffer(64 << 10); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := conn.SetDeadline(time.Now().Add(20 * time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	pipeline := "GET /inline HTTP/1.1\r\nHost: test\r\n\r\n" +
+		"GET /takeover HTTP/1.1\r\nHost: test\r\nConnection: close\r\n\r\n"
+	if _, err := io.WriteString(conn, pipeline); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, firstBody) {
+		t.Fatalf("first response body length = %d, want %d", len(got), len(firstBody))
+	}
+	assertWingPipelineResponse(t, reader, "takeover-response")
+}

--- a/wing_takeover_timeout_test.go
+++ b/wing_takeover_timeout_test.go
@@ -1,0 +1,174 @@
+//go:build linux || darwin
+
+package kruda
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"io"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-kruda/kruda/transport"
+)
+
+func TestWingTakeoverIdleTimeout(t *testing.T) {
+	presets := []struct {
+		name   string
+		preset Preset
+	}{
+		{name: "Spear", preset: Spear},
+		{name: "DB", preset: DB},
+		{name: "Render", preset: Render},
+	}
+
+	for _, tt := range presets {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := WingConfig{
+				Workers:       1,
+				DefaultPreset: tt.preset,
+				IdleTimeout:   100 * time.Millisecond,
+			}
+			addr, stop := startWingServerWithConfig(t, cfg, transport.HandlerFunc(func(w transport.ResponseWriter, _ transport.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("ok"))
+			}))
+			defer stop()
+
+			conn, err := net.Dial("tcp", addr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer conn.Close()
+			if _, err := io.WriteString(conn, "GET / HTTP/1.1\r\nHost: test\r\n\r\n"); err != nil {
+				t.Fatal(err)
+			}
+			resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := io.ReadAll(resp.Body); err != nil {
+				t.Fatal(err)
+			}
+			resp.Body.Close()
+
+			if err := conn.SetReadDeadline(time.Now().Add(750 * time.Millisecond)); err != nil {
+				t.Fatal(err)
+			}
+			var one [1]byte
+			if _, err := conn.Read(one[:]); err == nil {
+				t.Fatal("idle Takeover connection remained readable")
+			} else if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+				t.Fatal("idle Takeover connection was not closed by IdleTimeout")
+			}
+		})
+	}
+}
+
+func TestWingTakeoverReadTimeoutBoundsPartialNextRequest(t *testing.T) {
+	cfg := WingConfig{
+		Workers:       1,
+		DefaultPreset: DB,
+		ReadTimeout:   100 * time.Millisecond,
+		IdleTimeout:   2 * time.Second,
+	}
+	addr, stop := startWingServerWithConfig(t, cfg, transport.HandlerFunc(func(w transport.ResponseWriter, _ transport.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer stop()
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+	if _, err := io.WriteString(conn, "GET / HTTP/1.1\r\nHost: test\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.ReadResponse(reader, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	if _, err := io.WriteString(conn, "GET / HTTP/1.1\r\nHost: test"); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.SetReadDeadline(time.Now().Add(750 * time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+	var one [1]byte
+	if _, err := conn.Read(one[:]); err == nil {
+		t.Fatal("partial Takeover request unexpectedly produced data")
+	} else if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		t.Fatal("partial Takeover request was not closed by ReadTimeout")
+	}
+}
+
+func TestWingTakeoverWriteTimeoutReleasesBlockedResponse(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	ln.Close()
+
+	cfg := WingConfig{
+		Workers:       1,
+		DefaultPreset: DB,
+		WriteTimeout:  100 * time.Millisecond,
+		MaxConns:      1,
+	}
+	cfg.defaults()
+	tr := NewWingTransport(cfg)
+	handlerDone := make(chan struct{})
+	go tr.ListenAndServe(addr, transport.HandlerFunc(func(w transport.ResponseWriter, _ transport.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(bytes.Repeat([]byte("x"), 8<<20))
+		close(handlerDone)
+	}))
+	defer tr.Shutdown(context.Background())
+
+	var conn net.Conn
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err = net.DialTimeout("tcp", addr, 100*time.Millisecond)
+		if err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if tcpConn, ok := conn.(*net.TCPConn); ok {
+		if err := tcpConn.SetReadBuffer(1024); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := io.WriteString(conn, "GET / HTTP/1.1\r\nHost: test\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-handlerDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Takeover handler did not finish")
+	}
+
+	deadline = time.Now().Add(750 * time.Millisecond)
+	for tr.connCount() != 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := tr.connCount(); got != 0 {
+		t.Fatalf("admitted connections = %d, want 0 after WriteTimeout", got)
+	}
+}

--- a/wing_takeover_timeout_test.go
+++ b/wing_takeover_timeout_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -110,6 +111,69 @@ func TestWingTakeoverReadTimeoutBoundsPartialNextRequest(t *testing.T) {
 		t.Fatal("partial Takeover request unexpectedly produced data")
 	} else if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
 		t.Fatal("partial Takeover request was not closed by ReadTimeout")
+	}
+}
+
+func TestWingTakeoverReadTimeoutIsAbsoluteAcrossBodyTrickle(t *testing.T) {
+	const readTimeout = 250 * time.Millisecond
+	var calls atomic.Int32
+	cfg := WingConfig{
+		Workers:       1,
+		DefaultPreset: DB,
+		ReadTimeout:   readTimeout,
+		IdleTimeout:   2 * time.Second,
+	}
+	addr, stop := startWingServerWithConfig(t, cfg, transport.HandlerFunc(func(w transport.ResponseWriter, _ transport.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer stop()
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	reader := bufio.NewReader(conn)
+	if _, err := io.WriteString(conn, "GET / HTTP/1.1\r\nHost: test\r\n\r\n"); err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.ReadResponse(reader, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.ReadAll(resp.Body); err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	started := time.Now()
+	if _, err := io.WriteString(conn, "POST / HTTP/1.1\r\nHost: test\r\nContent-Length: 4\r\n\r\na"); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if _, err := io.WriteString(conn, "b"); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if _, err := io.WriteString(conn, "c"); err != nil {
+		t.Fatal(err)
+	}
+	if err := conn.SetReadDeadline(started.Add(600 * time.Millisecond)); err != nil {
+		t.Fatal(err)
+	}
+	var one [1]byte
+	if _, err := conn.Read(one[:]); err == nil {
+		t.Fatal("incomplete trickled request unexpectedly produced a response")
+	} else if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		t.Fatal("trickled body extended the Takeover read deadline")
+	}
+	if elapsed := time.Since(started); elapsed >= 400*time.Millisecond {
+		t.Fatalf("connection closed after %v, want absolute %v deadline", elapsed, readTimeout)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("handler calls = %d, want only the complete initial request", got)
 	}
 }
 

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -247,6 +247,7 @@ type conn struct {
 	admitted     bool   // true once accepted; cleared once by removeConnBookkeeping (idempotency guard)
 	pending      int    // in-flight handler goroutines
 	takenOver    bool   // fd detached to a Takeover goroutine and owned by its *os.File
+	closePending bool   // close after async ownership returns; prevents fd reuse
 	remoteAddr   string // lazy peer address cache, filled only if Request.RemoteAddr is used
 	lastActive   int64  // unix nano — updated on accept + each recv
 	readDeadline int64  // unix nano — set when first byte arrives, cleared on full request
@@ -343,6 +344,7 @@ type handlerJob struct {
 	fd           int32
 	keepAlive    bool
 	responseMode responseMode
+	directWrite  bool
 }
 
 type wingRouteHandler interface {
@@ -401,6 +403,11 @@ func (p *workerPool) loop(h transport.Handler) {
 		releaseResponse(resp)
 		releaseRequest(job.req)
 
+		if !job.directWrite {
+			p.done <- doneMsg{fd: job.fd, data: data, keepAlive: job.keepAlive}
+			p.wake()
+			continue
+		}
 		// Direct write from pool goroutine — skip doneCh data copy + SubmitSend round-trip.
 		if len(data) == 0 {
 			p.done <- doneMsg{fd: job.fd, keepAlive: job.keepAlive}
@@ -904,7 +911,8 @@ func (w *worker) tryParse(c *conn) {
 					c.sendFileSize = resp.fileSize
 					releaseResponse(resp)
 					releaseRequest(req)
-					break
+					w.directSend(c)
+					return
 				}
 				if resp.stringFast {
 					c.keepAlive = req.keepAlive
@@ -931,7 +939,13 @@ func (w *worker) tryParse(c *conn) {
 			// Dispatch to goroutine pool.
 			c.keepAlive = req.keepAlive
 			c.pending++
-			job := handlerJob{req: req, fd: c.fd, keepAlive: req.keepAlive, responseMode: f.ResponseMode}
+			job := handlerJob{
+				req:          req,
+				fd:           c.fd,
+				keepAlive:    req.keepAlive,
+				responseMode: f.ResponseMode,
+				directWrite:  c.sendN >= len(c.sendBuf) && c.sendFileFd == 0,
+			}
 			select {
 			case w.pool.jobs <- job:
 			default:
@@ -962,8 +976,9 @@ func (w *worker) tryParse(c *conn) {
 			// New goroutine per request.
 			c.keepAlive = req.keepAlive
 			c.pending++
+			directWrite := c.sendN >= len(c.sendBuf) && c.sendFileFd == 0
 			w.dispatchWG.Add(1)
-			go func(req *wingRequest, fd int32, ka bool, f Preset) {
+			go func(req *wingRequest, fd int32, ka, directWrite bool, f Preset) {
 				defer w.dispatchWG.Done()
 				resp := acquireResponse()
 				resp.responseMode = f.ResponseMode
@@ -979,6 +994,11 @@ func (w *worker) tryParse(c *conn) {
 				data := resp.buildZeroCopy()
 				releaseResponse(resp)
 				releaseRequest(req)
+				if !directWrite {
+					w.doneCh <- doneMsg{fd: fd, data: data, keepAlive: ka}
+					w.wake()
+					return
+				}
 				// Direct write from spawn goroutine.
 				if len(data) == 0 {
 					w.doneCh <- doneMsg{fd: fd, keepAlive: ka}
@@ -996,7 +1016,10 @@ func (w *worker) tryParse(c *conn) {
 					w.doneCh <- doneMsg{fd: fd, data: data[written:], keepAlive: ka}
 				}
 				w.wake()
-			}(req, c.fd, req.keepAlive, f)
+			}(req, c.fd, req.keepAlive, directWrite, f)
+			if c.sendN < len(c.sendBuf) {
+				w.eng.SubmitSend(c.fd, nil)
+			}
 			return
 
 		case Takeover:
@@ -1023,7 +1046,13 @@ func (w *worker) tryParse(c *conn) {
 			// Persist or unknown — treat as Pool for now.
 			c.keepAlive = req.keepAlive
 			c.pending++
-			job := handlerJob{req: req, fd: c.fd, keepAlive: req.keepAlive, responseMode: f.ResponseMode}
+			job := handlerJob{
+				req:          req,
+				fd:           c.fd,
+				keepAlive:    req.keepAlive,
+				responseMode: f.ResponseMode,
+				directWrite:  c.sendN >= len(c.sendBuf) && c.sendFileFd == 0,
+			}
 			if w.pool != nil {
 				select {
 				case w.pool.jobs <- job:
@@ -1277,6 +1306,12 @@ func (w *worker) handleDone(msg doneMsg) {
 		return
 	}
 	c.pending--
+	if c.closePending {
+		if c.pending == 0 {
+			w.closeConn(c.fd)
+		}
+		return
+	}
 	c.keepAlive = msg.keepAlive
 	if len(msg.data) == 0 {
 		// Pool goroutine already wrote the response directly.
@@ -1306,7 +1341,7 @@ func (w *worker) directSend(c *conn) {
 				w.eng.SubmitSend(c.fd, nil)
 				return
 			}
-			w.closeConn(c.fd)
+			w.failSend(c)
 			return
 		}
 		c.sendN += int(r)
@@ -1317,24 +1352,33 @@ func (w *worker) directSend(c *conn) {
 	if c.sendFileFd > 0 {
 		for c.sendFileSize > 0 {
 			n, err := sendfile(c.fd, c.sendFileFd, nil, int(c.sendFileSize))
+			if n > 0 {
+				c.sendFileSize -= int64(n)
+			}
 			if err != nil {
 				if err == syscall.EAGAIN || err == syscall.EWOULDBLOCK {
 					// Socket buffer full — wait for writable notification.
 					w.eng.SubmitSend(c.fd, nil)
 					return
 				}
-				syscall.Close(int(c.sendFileFd))
-				c.sendFileFd = 0
-				w.closeConn(c.fd)
+				w.failSend(c)
 				return
 			}
-			c.sendFileSize -= int64(n)
+			if n == 0 {
+				w.failSend(c)
+				return
+			}
 		}
 		syscall.Close(int(c.sendFileFd))
 		c.sendFileFd = 0
 	}
 	if c.bodyNeed > 0 {
 		// Body accumulation owns receive arming; do not apply final-response handling.
+		return
+	}
+	if c.pending > 0 {
+		// An async handler still owns this physical connection. Keep the fd open
+		// until its completion is processed so the kernel cannot recycle its number.
 		return
 	}
 	if !c.keepAlive {
@@ -1357,6 +1401,21 @@ func (w *worker) directSend(c *conn) {
 	submitIdleRecv(w.eng, c.fd, nil, 0)
 }
 
+func (w *worker) failSend(c *conn) {
+	c.sendBuf = c.sendBuf[:0]
+	c.sendN = 0
+	if c.sendFileFd > 0 {
+		syscall.Close(int(c.sendFileFd))
+		c.sendFileFd = 0
+		c.sendFileSize = 0
+	}
+	if c.pending > 0 {
+		c.closePending = true
+		return
+	}
+	w.closeConn(c.fd)
+}
+
 // takeoverSpinReads bounds the non-blocking read attempts a Takeover keep-alive
 // loop makes before parking on the runtime netpoller. A small spin can catch an
 // already-buffered next request without a netpoller wake hop; the fallback park
@@ -1365,6 +1424,21 @@ const takeoverSpinReads = 8
 
 // takeoverBufPool provides read buffers for Takeover goroutines.
 var takeoverBufPool = sync.Pool{New: func() any { b := make([]byte, 8192); return &b }}
+
+func (w *worker) writeTakeover(f *os.File, data []byte) error {
+	if w.writeTimeout > 0 {
+		if err := f.SetWriteDeadline(time.Now().Add(time.Duration(w.writeTimeout))); err != nil {
+			return err
+		}
+	}
+	_, err := f.Write(data)
+	if w.writeTimeout > 0 {
+		if clearErr := f.SetWriteDeadline(time.Time{}); err == nil {
+			err = clearErr
+		}
+	}
+	return err
+}
 
 // takeoverLoop owns a connection fd: loops read→handle→write through an
 // *os.File so a blocked read parks the goroutine on the runtime netpoller
@@ -1427,6 +1501,7 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte, mod
 	connCtx := first.ctx // conn-level context — propagated to all pipelined requests.
 	req := first
 	keepAlive := req.keepAlive
+	requestStarted := false
 
 	for {
 		// Handle request.
@@ -1446,7 +1521,7 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte, mod
 
 		// Write full response — os.File loops over partial writes and parks
 		// on EAGAIN via the runtime poller.
-		if _, werr := f.Write(data); werr != nil {
+		if werr := w.writeTakeover(f, data); werr != nil {
 			keepAlive = false
 			goto done
 		}
@@ -1454,9 +1529,26 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte, mod
 		if !keepAlive {
 			goto done
 		}
+		if readN == 0 && w.idleTimeout > 0 {
+			if err := f.SetReadDeadline(time.Now().Add(time.Duration(w.idleTimeout))); err != nil {
+				keepAlive = false
+				goto done
+			}
+		}
 
 		// Read next request — parks the goroutine until data arrives.
 		for {
+			if readN > 0 && !requestStarted {
+				requestStarted = true
+				deadline := time.Time{}
+				if w.readTimeout > 0 {
+					deadline = time.Now().Add(time.Duration(w.readTimeout))
+				}
+				if err := f.SetReadDeadline(deadline); err != nil {
+					keepAlive = false
+					goto done
+				}
+			}
 			if readN > 0 {
 				r, consumed, ok := parseHTTPRequest(buf[:readN], w.limits)
 				if ok {
@@ -1471,6 +1563,11 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte, mod
 					r.trustProxy = w.trustProxy
 					req = r
 					keepAlive = req.keepAlive
+					requestStarted = false
+					if err := f.SetReadDeadline(time.Time{}); err != nil {
+						keepAlive = false
+						goto done
+					}
 					goto next
 				}
 				// Classify the incomplete/rejected request.
@@ -1480,20 +1577,20 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte, mod
 					// Need more header bytes — keep reading.
 					if readN >= len(buf) {
 						// Buffer full but headers still incomplete: 431.
-						f.Write(wingStatusClose(431))
+						_ = w.writeTakeover(f, wingStatusClose(431))
 						keepAlive = false
 						goto done
 					}
 				case parseBadRequest:
-					f.Write(wingStatusClose(400))
+					_ = w.writeTakeover(f, wingStatusClose(400))
 					keepAlive = false
 					goto done
 				case parseChunked:
-					f.Write(wingStatusClose(501))
+					_ = w.writeTakeover(f, wingStatusClose(501))
 					keepAlive = false
 					goto done
 				case parseBodyTooLarge:
-					f.Write(wingStatusClose(413))
+					_ = w.writeTakeover(f, wingStatusClose(413))
 					keepAlive = false
 					goto done
 				case parseNeedBody:
@@ -1512,13 +1609,13 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte, mod
 					if w.maxInflightBody > 0 {
 						if atomic.AddInt64(&w.inflightBody, int64(need)) > int64(w.maxInflightBody) {
 							atomic.AddInt64(&w.inflightBody, -int64(need))
-							f.Write(wingStatusClose(503))
+							_ = w.writeTakeover(f, wingStatusClose(503))
 							keepAlive = false
 							goto done
 						}
 					}
 					if expectContinue {
-						if _, werr := f.Write(wing100Continue); werr != nil {
+						if werr := w.writeTakeover(f, wing100Continue); werr != nil {
 							if w.maxInflightBody > 0 {
 								atomic.AddInt64(&w.inflightBody, -int64(need))
 							}
@@ -1535,11 +1632,8 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte, mod
 					}
 					readN = 0
 					// Read remaining body bytes, reusing buf as a temp chunk buffer.
-					// One absolute deadline bounds the whole body read so a slow
-					// client cannot extend it indefinitely by trickling bytes.
-					if w.readTimeout > 0 {
-						f.SetReadDeadline(time.Now().Add(time.Duration(w.readTimeout)))
-					}
+					// The request deadline was set when its first bytes arrived and is
+					// not refreshed here, so trickling cannot extend it indefinitely.
 					for len(bodyBuf) < need {
 						n, rerr := f.Read(buf)
 						if n > 0 {
@@ -1559,6 +1653,7 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte, mod
 					if w.readTimeout > 0 {
 						f.SetReadDeadline(time.Time{})
 					}
+					requestStarted = false
 					// Body fully accumulated — release the budget reservation
 					// (mirrors finishBodyAccum). Any later exit on this iteration is
 					// post-accumulation, so it must not refund again.
@@ -1587,7 +1682,7 @@ func (w *worker) takeoverLoop(first *wingRequest, fd int32, leftover []byte, mod
 					keepAlive = req.keepAlive
 					goto next
 				case parseHeaderTooLarge:
-					f.Write(wingStatusClose(431))
+					_ = w.writeTakeover(f, wingStatusClose(431))
 					keepAlive = false
 					goto done
 				default:

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -237,24 +237,25 @@ type parserLimits struct {
 }
 
 type conn struct {
-	fd           int32
-	peerIP       netip.Addr // peer IP captured at accept (zero value if unknown)
-	readBuf      []byte
-	readN        int
-	sendBuf      []byte
-	sendN        int
-	keepAlive    bool
-	admitted     bool   // true once accepted; cleared once by removeConnBookkeeping (idempotency guard)
-	pending      int    // in-flight handler goroutines
-	takenOver    bool   // fd detached to a Takeover goroutine and owned by its *os.File
-	closePending bool   // close after async ownership returns; prevents fd reuse
-	remoteAddr   string // lazy peer address cache, filled only if Request.RemoteAddr is used
-	lastActive   int64  // unix nano — updated on accept + each recv
-	readDeadline int64  // unix nano — set when first byte arrives, cleared on full request
-	ctx          context.Context
-	cancel       context.CancelFunc
-	sendFileFd   int32 // sendfile: source fd (0 = none)
-	sendFileSize int64 // sendfile: remaining bytes
+	fd             int32
+	peerIP         netip.Addr // peer IP captured at accept (zero value if unknown)
+	readBuf        []byte
+	readN          int
+	sendBuf        []byte
+	sendN          int
+	keepAlive      bool
+	admitted       bool   // true once accepted; cleared once by removeConnBookkeeping (idempotency guard)
+	pending        int    // in-flight handler goroutines
+	takenOver      bool   // fd detached to a Takeover goroutine and owned by its *os.File
+	closePending   bool   // close after async ownership returns; prevents fd reuse
+	remoteAddr     string // lazy peer address cache, filled only if Request.RemoteAddr is used
+	lastActive     int64  // unix nano — updated on accept + each recv
+	readDeadline   int64  // unix nano — set when first byte arrives, cleared on full request
+	readSuppressed bool   // readiness arrived while pending; drain once ownership returns
+	ctx            context.Context
+	cancel         context.CancelFunc
+	sendFileFd     int32 // sendfile: source fd (0 = none)
+	sendFileSize   int64 // sendfile: remaining bytes
 	// Slow-path body accumulation (populated when a request body spans multiple recvs).
 	bodyNeed       int    // total Content-Length expected (0 = not accumulating)
 	headerSnapshot []byte // copy of header block for re-parse after body complete
@@ -265,6 +266,10 @@ type conn struct {
 // accepted connection. Tests set it to pin assertions to the accept path rather
 // than the lazy getpeername used by RemoteAddr/IP. Always nil in production.
 var testAcceptPeerHook func(ip netip.Addr, ok bool)
+
+// testSuppressedRecvHook lets Linux integration tests prove that an EPOLLIN
+// event reached the worker while an async handler still owned the connection.
+var testSuppressedRecvHook func(fd int32)
 
 var resp503 = []byte("HTTP/1.1 503 Service Unavailable\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
 
@@ -767,9 +772,17 @@ func (w *worker) handleRecv(ev event) {
 	} else {
 		c = w.conns[ev.Fd]
 	}
-	if c == nil || c.pending > 0 {
+	if c == nil {
 		return
 	}
+	if c.pending > 0 {
+		c.readSuppressed = true
+		if testSuppressedRecvHook != nil {
+			testSuppressedRecvHook(c.fd)
+		}
+		return
+	}
+	c.readSuppressed = false
 	nr, _, e := syscall.RawSyscall(syscall.SYS_READ, uintptr(c.fd), uintptr(unsafe.Pointer(&c.readBuf[c.readN])), uintptr(len(c.readBuf)-c.readN))
 	if e != 0 || nr <= 0 {
 		w.closeConn(c.fd)
@@ -1327,6 +1340,8 @@ func (w *worker) handleDone(msg doneMsg) {
 		if c.keepAlive {
 			if c.readN > 0 {
 				w.tryParse(c)
+			} else if c.readSuppressed {
+				w.handleRecv(event{Fd: c.fd, ConnPtr: unsafe.Pointer(c)})
 			} else {
 				submitIdleRecv(w.eng, c.fd, nil, 0)
 			}
@@ -1398,6 +1413,7 @@ func (w *worker) directSend(c *conn) {
 		w.tryParse(c)
 		return
 	}
+	c.readSuppressed = false
 	r, _, e := syscall.RawSyscall(syscall.SYS_READ, uintptr(c.fd), uintptr(unsafe.Pointer(&c.readBuf[0])), uintptr(len(c.readBuf)))
 	if e == 0 && r > 0 {
 		c.readN = int(r)

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -881,6 +881,13 @@ func (w *worker) tryParse(c *conn) {
 			// Don't consume — leave data in readBuf for re-parse after handleDone.
 			break
 		}
+		if f.Dispatch == Takeover && (c.sendN < len(c.sendBuf) || c.sendFileFd > 0) {
+			// Keep the takeover request in readBuf until every earlier response is
+			// complete; detaching now would abandon the event loop's send state.
+			releaseRequest(req)
+			w.directSend(c)
+			return
+		}
 
 		// Consume parsed bytes.
 		remaining := c.readN - consumed

--- a/wing_transport.go
+++ b/wing_transport.go
@@ -899,6 +899,7 @@ func (w *worker) tryParse(c *conn) {
 			} else {
 				resp := acquireResponse()
 				resp.responseMode = f.ResponseMode
+				resp.sendFileEnabled = true
 				start := time.Now().UnixNano()
 				w.serveRoute(resp, req, f)
 				w.observeAdvisor(f, req.method, req.path, time.Now().UnixNano()-start)
@@ -909,6 +910,7 @@ func (w *worker) tryParse(c *conn) {
 					c.sendBuf = append(c.sendBuf, hdr...)
 					c.sendFileFd = resp.fileFd
 					c.sendFileSize = resp.fileSize
+					resp.fileFd = 0
 					releaseResponse(resp)
 					releaseRequest(req)
 					w.directSend(c)


### PR DESCRIPTION
## Summary

- fail closed for unsupported TLS transports and preserve listener lifecycle semantics
- harden Wing epoll, Takeover, async response ordering, and file-descriptor ownership
- require Go 1.25.13 across released modules, tooling, CI, examples, and documentation

## Validation

- GOTOOLCHAIN=go1.25.13 ./scripts/pre-release.sh
- both root race suites passed with standard and default JSON engines
- standalone modules, cross-platform builds, six fuzz suites, docs, godoc, and examples passed
- independent security diff review at b95d291 found 0 reportable findings; d921e17 only resolves the deferred Close lint result

## Remaining release gates

- exact-SHA pull request checks must pass before merge
- docs npm audit currently retains 3 high and 2 moderate third-party tooling advisories and requires remediation or explicit risk acceptance before release